### PR TITLE
docs: document BLE peripheral mode implementation split

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ bs58 = "0.5"
 quinn = "0.11"
 rcgen = "0.13"
 btleplug = "0.11"
+bluer = { version = "0.17", features = ["full"] }
 
 # ffi
 uniffi = "0.28"

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -48,7 +48,7 @@ implementing one trait. It doesn't touch anything else.
 |---|---|
 | `pathweave-core` | Transport trait, PathweaveNode, Router, Session layer, Bundle layer |
 | `pathweave-transport-quic` | QUIC implementation of Transport |
-| `pathweave-transport-ble` | BLE implementation of Transport |
+| `pathweave-transport-ble` | BLE implementation of Transport. btleplug for central mode (scanning, GATT); bluer for peripheral mode (advertising) on Linux; native platform APIs on mobile. |
 | `pathweave-uniffi` | FFI bindings layer. Exposes PathweaveNode to Swift and Kotlin. |
 | `pw-chat` (example) | Terminal chat demo. The v0.1.0 launch artifact. |
 
@@ -342,6 +342,44 @@ static public key revealed, full PeerId derived, communication begins.
 These UUIDs are permanent. They are part of the protocol. Changing them after any
 deployment breaks every integration silently.
 
+**Implementation split: central and peripheral mode**
+
+BLE has two roles: central (scanning, initiating GATT connections) and peripheral
+(advertising, accepting GATT connections). No single Rust crate covers both roles
+well across all platforms, so we split them.
+
+Central mode: `btleplug` v0.11, all platforms. Handles scanning and GATT connections.
+
+Peripheral mode: platform-specific.
+
+- Linux: `bluer`, a well-maintained async Rust crate that wraps the full BlueZ API
+  including advertising.
+- Android and iOS: the platform's native BLE APIs called through the UniFFI layer.
+  CoreBluetooth on iOS, BluetoothManager on Android. The `pathweave-transport-ble`
+  Rust crate is not used for peripheral mode on mobile; the native layer handles it.
+- macOS: deferred to v0.2.0. CoreBluetooth is available on macOS (same framework as
+  iOS); the native binding work is not prioritized for v0.1.0 given the primary
+  deployment targets are phones.
+- Windows: deferred to v0.2.0.
+
+**macOS and Windows peripheral mode**
+
+macOS has CoreBluetooth, the same framework used for iOS peripheral mode. The path
+exists. But the native binding work for macOS desktop is separate from the iOS UniFFI
+path, and the primary deployment targets for v0.1.0 are phones. macOS peripheral mode
+is deferred to v0.2.0.
+
+Windows has OS-level BLE GATT Server support (WinRT, since Windows 10 Creators
+Update) but no maintained Rust crate wraps it reliably. Implementing it requires
+writing a WinRT wrapper using the `windows` crate, which involves COM apartment
+threading rules that interact with async Rust runtimes in ways that produce subtle,
+hardware-dependent bugs. The risk and timeline cost are not justified for v0.1.0
+given that the primary deployment targets are phones.
+
+BLE peripheral development for v0.1.0 requires a Linux machine or a phone via the
+native bindings path. A macOS or Windows machine cannot act as the advertising peer
+in v0.1.0.
+
 ---
 
 ## Delivery guarantees (v0.1.0)
@@ -387,6 +425,10 @@ discovery is a v0.2.0 addition.
 When neither transport can reach the peer: "message failed: no transport available."
 No queuing, no silent retry. Known v0.1.0 limitation, documented as one.
 
+BLE in pw-chat works when at least one peer can advertise. Supported configurations
+for the BLE fallback demo: two Linux machines, or a Linux machine and a phone running
+the native SDK. macOS and Windows machines cannot act as the advertising peer in v0.1.0.
+
 ---
 
 ## What v0.1.0 doesn't do
@@ -399,6 +441,7 @@ Being clear about this matters as much as being clear about what it does.
 - No automatic QUIC peer discovery (mDNS)
 - No multi-hop BLE routing (single-hop only)
 - No contact or key registry (Noise_XK upgrade deferred to v0.2.0)
+- No BLE peripheral mode (advertising) on macOS or Windows (deferred to v0.2.0)
 - No security audit completed
 
 v1.0.0 means the API is stable and the library is ready for production use. We're

--- a/notes/decisions/006-ble-peripheral-mode-split.md
+++ b/notes/decisions/006-ble-peripheral-mode-split.md
@@ -1,0 +1,75 @@
+# ADR 006: Split BLE central and peripheral mode across crates
+
+**Status:** Accepted
+
+## Context
+
+BLE has two distinct roles: central (scanning for peers, initiating GATT connections)
+and peripheral (advertising presence, accepting GATT connections). A working BLE
+fallback in pw-chat requires both roles simultaneously -- one peer must advertise
+while the other scans and connects.
+
+No single Rust crate provides reliable support for both roles across all platforms.
+The options were: pick one crate and accept its gaps, or split the implementation
+by role and by platform.
+
+The two most-evaluated central-mode crates:
+
+- `btleplug` v0.11: cross-platform (Linux, macOS, Windows, Android, iOS), actively
+  maintained, good async support. Central mode only. Peripheral mode exists in
+  theory but is not implemented on any platform.
+- `bluer` v0.17: Linux only. Wraps the full BlueZ D-Bus API including advertising
+  (peripheral mode). Async-native, well-maintained by the bluez-dbus-io team.
+
+One alternative for peripheral mode was evaluated: `ble-peripheral`. Active at the
+time of evaluation but minimal adoption and no established security track record.
+Not appropriate for a library with Pathweave's threat model. Ruled out.
+
+## Decision
+
+Split by role and platform:
+
+- Central mode (scanning, GATT connections): `btleplug` v0.11 on all platforms.
+- Peripheral mode (advertising):
+  - Linux: `bluer` v0.17, wrapping BlueZ.
+  - Android and iOS: native platform APIs (CoreBluetooth, BluetoothManager) called
+    through the UniFFI layer. The Rust crate does not handle peripheral mode on
+    mobile; the native layer does.
+  - macOS: deferred to v0.2.0. CoreBluetooth is available on macOS (same framework
+    as iOS); the native binding work is not prioritized for v0.1.0 given that the
+    primary deployment targets are phones.
+  - Windows: deferred to v0.2.0 (see below).
+
+## Why macOS and Windows peripheral mode are deferred
+
+macOS has CoreBluetooth, the same framework used for iOS peripheral mode. The path
+exists. But implementing the native binding layer for macOS desktop is separate work
+from the iOS UniFFI path, and the primary deployment targets for v0.1.0 are phones.
+A macOS machine running v0.1.0 can scan and connect as central but cannot advertise
+as peripheral.
+
+Windows has WinRT BLE GATT Server APIs (available since Windows 10 Creators Update)
+but no maintained Rust crate wraps them reliably. A correct wrapper requires the
+`windows` crate and careful COM apartment threading, which interacts with async Rust
+runtimes in ways that produce subtle, hardware-dependent bugs. The risk and timeline
+cost are not justified for v0.1.0 given that the primary deployment targets are phones.
+
+A Windows machine running v0.1.0 can scan and connect as central but cannot advertise
+as peripheral. It can still participate in the pw-chat demo as long as the other peer
+is a Linux machine or a phone.
+
+## Consequences
+
+`pathweave-transport-ble` uses `btleplug` for all central operations and `bluer` on
+Linux for peripheral operations, with a `cfg(target_os = "linux")` conditional at the
+crate level.
+
+BLE peripheral development for v0.1.0 requires a Linux machine or a phone via the
+native bindings path.
+
+The `bluer` dependency is Linux-only. On macOS and Windows it is excluded at compile
+time. CI must include a Linux runner for BLE peripheral tests.
+
+The v0.2.0 macOS work uses CoreBluetooth native bindings, following the same approach
+used for iOS via the UniFFI layer. The v0.2.0 Windows work starts with the `windows`
+crate WinRT wrapper for GATT Server.


### PR DESCRIPTION
## Summary

- Documents the btleplug (central) / bluer (Linux peripheral) / native UniFFI (mobile peripheral) split in ARCHITECTURE.md and ADR 006
- Explicitly defers macOS and Windows peripheral mode to v0.2.0, with reasoning for each
- Adds `bluer` to workspace dependencies
- Corrects an earlier gap where macOS was listed as "approach TBD" and then not addressed in consequences

## Test plan

- [ ] Review ARCHITECTURE.md BLE section for internal consistency
- [ ] Review ADR 006 for accurate crate descriptions and complete platform coverage
- [ ] Confirm `cargo check` passes with bluer in workspace deps

Closes #4