### PR TITLE
feat(core): implement NodeIdentity and PeerId derivation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,6 +473,7 @@ dependencies = [
  "fiat-crypto",
  "rustc_version",
  "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -1135,6 +1136,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "x25519-dalek",
 ]
 
 [[package]]
@@ -1376,7 +1378,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1386,8 +1388,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.5",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 
 [[package]]
 name = "rand_core"
@@ -1404,7 +1412,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
 dependencies = [
- "rand_core",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -2649,6 +2657,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core 0.6.4",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
 name = "xml"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2688,6 +2708,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 snow = "0.10"
 blake3 = "1"
 bs58 = "0.5"
+x25519-dalek = { version = "2", features = ["static_secrets"] }
 
 # transports
 quinn = "0.11"

--- a/crates/pathweave-core/Cargo.toml
+++ b/crates/pathweave-core/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 snow = { workspace = true }
 blake3 = { workspace = true }
 bs58 = { workspace = true }
+x25519-dalek = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -22,6 +22,12 @@ pub enum PathweaveError {
 
 // -- identity ------------------------------------------------------------
 
+const NOISE_PARAMS: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
+
+fn peer_id_from_public_key(public_key: &[u8]) -> PeerId {
+    PeerId(*blake3::hash(public_key).as_bytes())
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PeerId([u8; 32]);
 
@@ -45,7 +51,6 @@ impl std::fmt::Display for PeerId {
     }
 }
 
-#[allow(dead_code)]
 pub struct NodeIdentity {
     pub(crate) private_key: Vec<u8>,
     pub(crate) public_key: Vec<u8>,
@@ -53,14 +58,36 @@ pub struct NodeIdentity {
 }
 
 impl NodeIdentity {
+    /// Generates a fresh Noise_XX_25519_ChaChaPoly_BLAKE2s static keypair.
+    /// Panics if the system entropy source is unavailable (unrecoverable).
     pub fn generate() -> Self {
-        todo!(
-            "generate Noise_XX_25519_ChaChaPoly_BLAKE2s keypair via snow, derive PeerId via blake3"
-        )
+        let params: snow::params::NoiseParams = NOISE_PARAMS
+            .parse()
+            .expect("hardcoded noise params are valid");
+        let keypair = snow::Builder::new(params)
+            .generate_keypair()
+            .expect("keypair generation failed: system entropy unavailable");
+        let peer_id = peer_id_from_public_key(&keypair.public);
+        Self {
+            private_key: keypair.private,
+            public_key: keypair.public,
+            peer_id,
+        }
     }
 
-    pub fn from_bytes(_private_key: &[u8]) -> Result<Self> {
-        todo!("restore NodeIdentity from persisted private key bytes")
+    /// Restores a NodeIdentity from a previously persisted 32-byte private key.
+    pub fn from_bytes(private_key: &[u8]) -> Result<Self> {
+        let key_array: [u8; 32] = private_key
+            .try_into()
+            .map_err(|_| PathweaveError::InvalidKey)?;
+        let secret = x25519_dalek::StaticSecret::from(key_array);
+        let public_key = x25519_dalek::PublicKey::from(&secret).as_bytes().to_vec();
+        let peer_id = peer_id_from_public_key(&public_key);
+        Ok(Self {
+            private_key: private_key.to_vec(),
+            public_key,
+            peer_id,
+        })
     }
 
     pub fn peer_id(&self) -> &PeerId {
@@ -69,6 +96,63 @@ impl NodeIdentity {
 
     pub fn public_key(&self) -> &[u8] {
         &self.public_key
+    }
+
+    /// Returns the raw private key bytes. The caller is responsible for persisting these.
+    pub fn private_key_bytes(&self) -> &[u8] {
+        &self.private_key
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn generate_produces_valid_peer_id() {
+        let identity = NodeIdentity::generate();
+        let peer_id_str = identity.peer_id().to_string();
+        // blake3 produces 32 bytes; base58 of 32 bytes is 43-44 characters
+        assert!(
+            peer_id_str.len() == 43 || peer_id_str.len() == 44,
+            "unexpected peer id length: {}",
+            peer_id_str.len()
+        );
+    }
+
+    #[test]
+    fn from_bytes_roundtrips() {
+        let original = NodeIdentity::generate();
+        let restored = NodeIdentity::from_bytes(original.private_key_bytes()).unwrap();
+        assert_eq!(original.peer_id(), restored.peer_id());
+        assert_eq!(original.public_key(), restored.public_key());
+    }
+
+    #[test]
+    fn peer_id_is_deterministic() {
+        let identity = NodeIdentity::generate();
+        let a = NodeIdentity::from_bytes(identity.private_key_bytes()).unwrap();
+        let b = NodeIdentity::from_bytes(identity.private_key_bytes()).unwrap();
+        assert_eq!(a.peer_id(), b.peer_id());
+    }
+
+    #[test]
+    fn from_bytes_rejects_wrong_length() {
+        assert!(matches!(
+            NodeIdentity::from_bytes(&[0u8; 31]),
+            Err(PathweaveError::InvalidKey)
+        ));
+        assert!(matches!(
+            NodeIdentity::from_bytes(&[0u8; 33]),
+            Err(PathweaveError::InvalidKey)
+        ));
+    }
+
+    #[test]
+    fn distinct_identities_have_distinct_peer_ids() {
+        let a = NodeIdentity::generate();
+        let b = NodeIdentity::generate();
+        assert_ne!(a.peer_id(), b.peer_id());
     }
 }
 


### PR DESCRIPTION
## Summary

- `NodeIdentity::generate()` produces a fresh Noise_XX_25519_ChaChaPoly_BLAKE2s keypair via snow
- `NodeIdentity::from_bytes()` restores an identity from 32-byte private key using x25519-dalek to derive the public key
- `PeerId` is `blake3(static_public_key)` stored as `[u8; 32]`, displayed as base58 (~44 chars)
- `private_key_bytes()` exposes raw bytes so callers can persist to their platform's storage (ADR 005)
- Added `x25519-dalek = { version = "2", features = ["static_secrets"] }` to workspace deps

## Test plan

- [x] `cargo test -p pathweave-core` -- 5 tests pass
- [x] `cargo clippy -p pathweave-core -- -D warnings` -- clean
- [x] `cargo fmt --all --check` -- clean
- [x] `cargo check --workspace` -- all crates build

Closes #6