### PR TITLE
feat(core): implement PathweaveNode public API

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -5,6 +5,9 @@ use futures::stream::BoxStream;
 pub mod bundle;
 pub use bundle::BundleLayer;
 
+pub mod node;
+pub use node::PathweaveNode;
+
 pub mod router;
 pub use router::Router;
 
@@ -235,24 +238,4 @@ pub trait Connection: Send + Sync {
 #[derive(Default)]
 pub struct NodeConfig {
     pub listen_port: Option<u16>,
-}
-
-pub struct PathweaveNode;
-
-impl PathweaveNode {
-    pub async fn new(_config: NodeConfig, _identity: NodeIdentity) -> Result<Self> {
-        todo!("initialize router, session layer, and transport registry")
-    }
-
-    pub async fn send(&self, _peer_id: PeerId, _payload: Vec<u8>) -> Result<()> {
-        todo!("route payload through best available transport via session layer")
-    }
-
-    pub fn on_message(&self, _handler: Box<dyn MessageHandler>) {
-        todo!("register message handler for incoming bundles")
-    }
-
-    pub fn events(&self) -> BoxStream<'_, TransportEvent> {
-        todo!("subscribe to transport events from the router")
-    }
 }

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -1,0 +1,301 @@
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use futures::stream::BoxStream;
+
+use crate::{
+    MessageHandler, NodeConfig, NodeIdentity, PathweaveError, PeerAnnouncement, PeerId, Result,
+    Router, Transport, TransportEvent,
+};
+
+/// The top-level entry point for the Pathweave library.
+///
+/// PathweaveNode wires together the Router, Session layer, and registered transports.
+/// Callers create a node, register transports, inject any known peer addresses, and
+/// then use the four documented API surfaces (send, on_message, events, new).
+///
+/// The peer table maps PeerId -> PeerAnnouncement. send() looks up the announcement
+/// here; if the peer is not present, NoTransportAvailable is returned immediately.
+/// Use add_peer() to inject a known address (e.g. a QUIC address from the command
+/// line) or wait for a future connect() implementation that dials and learns the
+/// remote PeerId via the Noise_XX handshake.
+pub struct PathweaveNode {
+    router: Router,
+    identity: NodeIdentity,
+    peers: HashMap<PeerId, PeerAnnouncement>,
+    handler: Mutex<Option<Box<dyn MessageHandler>>>,
+}
+
+impl PathweaveNode {
+    /// Creates a new node. `config` is accepted but unused until transport
+    /// implementations are complete; callers should pass `NodeConfig::default()` for now.
+    pub async fn new(_config: NodeConfig, identity: NodeIdentity) -> Result<Self> {
+        Ok(Self {
+            router: Router::new(),
+            identity,
+            peers: HashMap::new(),
+            handler: Mutex::new(None),
+        })
+    }
+
+    /// Registers a transport and starts its background availability monitor.
+    ///
+    /// Not part of the UniFFI boundary; Rust callers use this during setup.
+    /// Must be called before any send() calls that depend on this transport.
+    pub fn register_transport(&mut self, transport: Box<dyn Transport>) {
+        self.router.register_transport(transport);
+    }
+
+    /// Records a known PeerId -> PeerAnnouncement mapping in the peer table.
+    ///
+    /// Not part of the UniFFI boundary. Used by pw-chat to inject a QUIC peer
+    /// address resolved from the command line, and by tests to set up known peers.
+    pub fn add_peer(&mut self, peer_id: PeerId, announcement: PeerAnnouncement) {
+        self.peers.insert(peer_id, announcement);
+    }
+
+    /// Sends `payload` to the peer identified by `peer_id`.
+    ///
+    /// Looks up the peer's transport address in the peer table, then delegates
+    /// to the Router, which selects the lowest-cost available transport and
+    /// opens a Session-encrypted connection for each message.
+    ///
+    /// Returns NoTransportAvailable if the peer is not in the peer table or if
+    /// no registered transport can reach the peer.
+    pub async fn send(&self, peer_id: PeerId, payload: Vec<u8>) -> Result<()> {
+        let announcement = self
+            .peers
+            .get(&peer_id)
+            .ok_or(PathweaveError::NoTransportAvailable)?;
+        self.router
+            .send(announcement, &self.identity, payload)
+            .await
+    }
+
+    /// Registers a handler that will be called for each incoming message.
+    ///
+    /// The accept loop that delivers messages to this handler is scaffolded
+    /// here but not yet wired: transport crates are stubs in v0.1.0. The
+    /// handler is stored and will be used once accept loops are implemented.
+    pub fn on_message(&self, handler: Box<dyn MessageHandler>) {
+        *self.handler.lock().unwrap() = Some(handler);
+    }
+
+    /// Returns a stream of transport lifecycle events from the Router.
+    pub fn events(&self) -> BoxStream<'_, TransportEvent> {
+        self.router.events()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Connection, NodeIdentity, PathweaveError, PeerAddress, Session, TransportCost,
+        TransportKind,
+    };
+    use async_trait::async_trait;
+    use bytes::Bytes;
+    use futures::stream::{self, BoxStream};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+    use crate::BundleLayer;
+
+    // --- in-memory connection -------------------------------------------------
+
+    struct TestConn {
+        tx: UnboundedSender<Bytes>,
+        rx: UnboundedReceiver<Bytes>,
+    }
+
+    fn conn_pair() -> (TestConn, TestConn) {
+        let (tx1, rx1) = unbounded_channel();
+        let (tx2, rx2) = unbounded_channel();
+        (TestConn { tx: tx1, rx: rx2 }, TestConn { tx: tx2, rx: rx1 })
+    }
+
+    #[async_trait]
+    impl Connection for TestConn {
+        async fn send_bytes(&mut self, bytes: &[u8]) -> crate::Result<()> {
+            self.tx
+                .send(Bytes::copy_from_slice(bytes))
+                .map_err(|_| PathweaveError::Transport("closed".into()))
+        }
+
+        async fn recv_bytes(&mut self) -> crate::Result<Bytes> {
+            self.rx
+                .recv()
+                .await
+                .ok_or_else(|| PathweaveError::Transport("closed".into()))
+        }
+
+        async fn close(&mut self) -> crate::Result<()> {
+            Ok(())
+        }
+
+        fn mtu(&self) -> usize {
+            65535
+        }
+    }
+
+    // --- mock transport -------------------------------------------------------
+
+    struct MockTransport {
+        cost: TransportCost,
+        kind: TransportKind,
+        responder_tx: UnboundedSender<TestConn>,
+        connect_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl crate::Transport for MockTransport {
+        async fn start(&self) -> Result<()> {
+            Ok(())
+        }
+
+        async fn stop(&self) -> Result<()> {
+            Ok(())
+        }
+
+        fn discover(&self) -> BoxStream<'_, PeerAnnouncement> {
+            Box::pin(stream::empty())
+        }
+
+        async fn connect(&self, _peer: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
+            self.connect_count.fetch_add(1, Ordering::Relaxed);
+            let (a, b) = conn_pair();
+            self.responder_tx.send(b).ok();
+            Ok(Box::new(a))
+        }
+
+        async fn accept(&self) -> Result<Box<dyn Connection>> {
+            Err(PathweaveError::Transport("not used in tests".into()))
+        }
+
+        fn mtu_hint(&self) -> usize {
+            65535
+        }
+
+        fn cost(&self) -> TransportCost {
+            self.cost
+        }
+
+        fn kind(&self) -> TransportKind {
+            self.kind
+        }
+
+        fn name(&self) -> &'static str {
+            "mock"
+        }
+    }
+
+    fn make_transport(
+        cost: TransportCost,
+        kind: TransportKind,
+    ) -> (MockTransport, UnboundedReceiver<TestConn>, Arc<AtomicUsize>) {
+        let (tx, rx) = unbounded_channel();
+        let count = Arc::new(AtomicUsize::new(0));
+        (
+            MockTransport {
+                cost,
+                kind,
+                responder_tx: tx,
+                connect_count: Arc::clone(&count),
+            },
+            rx,
+            count,
+        )
+    }
+
+    fn dummy_peer() -> PeerAnnouncement {
+        PeerAnnouncement {
+            address: PeerAddress::Ble("aa:bb:cc:dd:ee:ff".into()),
+            short_id: None,
+        }
+    }
+
+    async fn run_responder(conn: TestConn, identity: NodeIdentity) {
+        let bundled = Box::new(BundleLayer::new(Box::new(conn)));
+        let mut session = Session::respond(&identity, bundled).await.unwrap();
+        let _ = session.recv().await;
+    }
+
+    // -------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn send_to_unknown_peer_returns_no_transport_available() {
+        let node = PathweaveNode::new(NodeConfig::default(), NodeIdentity::generate())
+            .await
+            .unwrap();
+        let unknown_peer = NodeIdentity::generate().peer_id().clone();
+        let result = node.send(unknown_peer, b"hello".to_vec()).await;
+        assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
+    }
+
+    #[tokio::test]
+    async fn send_to_known_peer_routes_through_transport() {
+        let (mock, mut mock_rx, connect_count) =
+            make_transport(TransportCost::Free, TransportKind::Ble);
+
+        let sender_id = NodeIdentity::generate();
+        let responder_id = NodeIdentity::generate();
+        let peer_id = responder_id.peer_id().clone();
+
+        let mut node = PathweaveNode::new(NodeConfig::default(), sender_id)
+            .await
+            .unwrap();
+        node.register_transport(Box::new(mock));
+        node.add_peer(peer_id.clone(), dummy_peer());
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        tokio::spawn(async move {
+            let conn = mock_rx.recv().await.unwrap();
+            run_responder(conn, responder_id).await;
+        });
+
+        node.send(peer_id, b"hello node".to_vec()).await.unwrap();
+        assert_eq!(connect_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn on_message_stores_handler() {
+        struct RecordingHandler {
+            called: Arc<std::sync::atomic::AtomicBool>,
+        }
+        impl MessageHandler for RecordingHandler {
+            fn on_message(&self, _peer_id: PeerId, _payload: Vec<u8>) {
+                self.called.store(true, Ordering::Relaxed);
+            }
+        }
+
+        let called = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let node = PathweaveNode::new(NodeConfig::default(), NodeIdentity::generate())
+            .await
+            .unwrap();
+        node.on_message(Box::new(RecordingHandler {
+            called: Arc::clone(&called),
+        }));
+
+        // Handler is stored; call it directly to verify it's wired.
+        node.handler
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .on_message(NodeIdentity::generate().peer_id().clone(), vec![]);
+        assert!(called.load(Ordering::Relaxed));
+    }
+
+    #[tokio::test]
+    async fn events_returns_router_stream() {
+        let node = PathweaveNode::new(NodeConfig::default(), NodeIdentity::generate())
+            .await
+            .unwrap();
+        // events() must not panic and must return a stream.
+        let _stream = node.events();
+    }
+}

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -59,7 +59,10 @@ the previous.
 
 ## The public API
 
-Four surfaces. Nothing else is public.
+The public API has six surfaces: four exposed through UniFFI to Swift and Kotlin,
+two Rust-only setup methods that are not part of the FFI boundary.
+
+**UniFFI-facing (four):**
 
 ```rust
 // 1. create a node
@@ -74,6 +77,22 @@ node.on_message(handler); // handler implements MessageHandler (see below)
 // 4. subscribe to transport events
 let mut events = node.events(); // Stream<Item = TransportEvent>
 ```
+
+**Rust-only setup (two, not in the UDL):**
+
+```rust
+// register a transport before first use
+node.register_transport(Box::new(quic));
+
+// inject a known peer address (e.g. QUIC --peer <address> from the command line)
+// the PeerId -> PeerAnnouncement mapping is populated here so send() can route to it
+node.add_peer(peer_id, announcement);
+```
+
+`connect(announcement: PeerAnnouncement) -> Result<PeerId>` is the intended v0.2.0
+method for dialing a peer, completing the Noise_XX handshake, learning their PeerId,
+and storing it in the peer table. It requires working transport implementations and is
+deferred until QUIC and BLE transports are complete.
 
 **MessageHandler** is a callback interface, not a closure. This is a UniFFI requirement --
 closures don't cross FFI boundaries cleanly. In Rust, you implement the trait. In Swift,

--- a/notes/decisions/007-bpv7-bundle-layer.md
+++ b/notes/decisions/007-bpv7-bundle-layer.md
@@ -1,0 +1,68 @@
+# ADR 007: Use BPv7 for bundle framing, fragmentation, and reassembly
+
+**Status:** Accepted
+
+## Context
+
+The library needs a message framing layer that sits between the Session (crypto) layer
+and the raw transport connection. This layer has three jobs:
+
+1. Frame messages so the receiver knows where each one starts and ends.
+2. Fragment messages that exceed the transport's MTU (BLE is ~512 bytes).
+3. Reassemble fragments on the receiving end before handing bytes to the Session layer.
+
+Options considered:
+
+**Custom length-prefix framing** -- a 4-byte big-endian length header followed by the
+payload. Simple, zero dependencies, no overhead beyond the header. Does not give you
+anything else for free.
+
+**CBOR-only** -- encode messages as CBOR byte strings. Self-delimiting, widely
+implemented. Still needs a fragmentation scheme on top for small MTUs.
+
+**BPv7 (Bundle Protocol version 7, RFC 9171)** -- a full delay-tolerant networking
+bundle format encoded as CBOR. Carries a primary block with a creation timestamp,
+sequence number, and optional fragmentation fields (fragmentation_offset,
+total_data_length). The `bp7` crate (v0.10) implements the spec.
+
+## Decision
+
+Use BPv7 via the `bp7` crate.
+
+## Rationale
+
+The bundle ID (creation timestamp + sequence number) is the groundwork for
+at-least-once delivery in v0.2.0. A custom framing format would not carry this
+information, so adding at-least-once delivery later would require a protocol change.
+BPv7 gives us the infrastructure now at the cost of a slightly larger header.
+
+BPv7's fragmentation model (BUNDLE_IS_FRAGMENT flag, fragmentation_offset,
+total_data_length in the primary block) maps cleanly onto the problem. Fragments of
+the same bundle share a creation timestamp, so reassembly only needs to accumulate
+by sequence number and offset without a separate bundle-ID field.
+
+BPv7 is the IETF standard for delay-tolerant networking. The library is aimed at
+exactly the conditions DTN was designed for: unreliable links, high latency, small
+MTUs. Using the standard format means Pathweave bundles are at least structurally
+compatible with other DTN implementations, even if full interop is not a v0.1.0 goal.
+
+## Implementation notes
+
+CRC is set to CRC_NO on all bundles. CRC in BPv7 is optional and redundant here:
+the Noise_XX session layer provides authenticated encryption (ChaCha20-Poly1305 with
+a 16-byte authentication tag) which already detects any bit corruption or tampering.
+Computing a CRC on top would add overhead with no security or reliability benefit.
+
+The `bp7` crate lists `cdylib` in its crate-type, which forces full symbol resolution
+during `cargo test`. On Windows MSVC, this surfaced an unresolved symbol
+(SystemFunction036 from advapi32.dll) in nanorand 0.7.0, a transitive dependency.
+The fix is in `.cargo/config.toml`: a workspace-level linker flag that adds advapi32
+as a default library for the MSVC target. This is documented in that file.
+
+## Alternatives not chosen
+
+**Custom length-prefix framing**: Ruled out because it provides no path to at-least-once
+delivery without a protocol version bump. The simplicity is not worth the dead end.
+
+**CBOR-only**: Same problem as custom framing -- no bundle ID, fragmentation would
+be ad-hoc.

--- a/notes/decisions/008-rustcrypto-not-ring.md
+++ b/notes/decisions/008-rustcrypto-not-ring.md
@@ -1,0 +1,118 @@
+# ADR 008: Use RustCrypto as the active Noise resolver; ring is present in the binary but does not handle Noise crypto
+
+**Status:** Accepted
+
+## Context
+
+The `snow` crate (v0.10) supports two cryptographic backends: RustCrypto and ring.
+The backend is selected at build time via Cargo features. Snow's default features
+activate the RustCrypto backend.
+
+Ring IS present in the compiled binary. This comes from two sources:
+
+- **quinn** (the QUIC transport crate) depends on `rustls`, which depends on `ring`
+  for its TLS 1.3 implementation. This is unavoidable while QUIC is a transport.
+- **snow's `std` feature** includes `"ring/std"` in its feature list. In Cargo,
+  activating `dep/feature` for an optional dependency activates that dependency.
+  Since `snow = "0.10"` in the workspace uses default features (which include `std`),
+  ring is pulled in from snow as well, even though ring is not snow's active resolver.
+
+This can be verified directly:
+
+```
+grep -A 20 'name = "snow"' Cargo.lock
+```
+
+Ring appears in snow's `[[package]]` dependencies list. It also appears under snow
+in the full dependency tree:
+
+```
+cargo tree -p pathweave-core | grep -A 25 "snow v0"
+```
+
+A security auditor or new contributor looking at Cargo.lock will see ring in the
+dependency graph and may reasonably ask: is this the library doing the Noise crypto?
+The answer is no, and this document records why.
+
+## Decision
+
+Use RustCrypto as the active cryptographic backend for the Noise_XX session layer.
+Snow's `ring-resolver` feature is not enabled. Ring's presence in the binary is
+collateral from two sources (QUIC/TLS and snow's `std` feature) and does not affect
+which code handles Noise operations.
+
+## Rationale
+
+**ARM performance**: ChaCha20-Poly1305 was designed for software implementation on
+processors without hardware AES acceleration. Mobile ARM chips (the primary deployment
+target) fall into this category. WireGuard made the same call for the same reason.
+ChaChaPoly in RustCrypto runs fast on ARM; AES-GCM in software does not.
+
+**BLAKE2s for 32-bit targets**: BLAKE2s is optimized for 32-bit word sizes. Cheap
+Android phones running 32-bit or constrained 64-bit processors benefit meaningfully.
+BLAKE2b is faster on 64-bit desktops but slower on the devices this library targets.
+
+**Ring maintenance concerns**: Ring uses hand-optimized assembly that is hard to
+audit and has had periods of slow maintenance and breaking API changes. RustCrypto
+primitives are pure Rust (easier to audit), actively maintained, and independently
+verified. Using them reduces audit surface at the cost of being slightly slower on
+x86-64 desktop, which is not a target we optimize for.
+
+**Separation of concerns**: Keeping the Noise crypto entirely within RustCrypto means
+that ring security advisories are only relevant to the QUIC transport (via rustls),
+not to the session layer.
+
+## What ring is actually used for in this codebase
+
+Ring's code runs in two places:
+
+1. Via `quinn -> rustls -> ring`: TLS 1.3 for the QUIC transport. This satisfies the
+   QUIC protocol requirement (RFC 9000). As documented in ADR 004, all real security
+   comes from the Noise_XX handshake; the TLS layer is just the protocol requirement.
+
+2. Via snow's `std` feature activating `ring/std`: ring is compiled as a dependency
+   of snow even though it is not snow's active resolver. This is collateral from
+   snow's feature structure. Snow declares ring as `optional = true` but its `std`
+   feature (which we activate via default features) includes `"ring/std"`, which in
+   Cargo's feature resolution activates the optional ring dependency.
+
+In both cases, ring does not handle any Noise handshake messages, key derivation,
+or message encryption. All of that goes through snow's default-resolver-crypto path:
+chacha20poly1305, blake2, curve25519-dalek, and sha2.
+
+## Can ring be removed from the binary?
+
+Not entirely. Quinn (the QUIC transport) requires ring via rustls. Even if snow were
+changed to `default-features = false, features = ["default-resolver-crypto"]` to
+avoid snow's `std` activating ring, ring would still be present from quinn. Removing
+ring entirely would require replacing quinn with a QUIC implementation that does not
+depend on ring, which is a significant undertaking and deferred to v0.2.0 or later.
+
+The `default-features = false` change on snow has not been made because: (a) it would
+not remove ring from the binary, so the security picture is unchanged; and (b) it
+risks breaking std entropy and other std-dependent features in snow's crypto
+primitives without clear benefit. It is not ruled out, but is not the current priority.
+
+## How to verify the active resolver
+
+Snow's active resolver is determined by which backend feature is enabled. In the
+workspace Cargo.toml, snow is listed without the `ring-resolver` feature:
+
+```toml
+snow = "0.10"
+```
+
+Default features include `default-resolver` and `default-resolver-crypto`, not
+`ring-resolver`. `Builder::new(params).build_initiator()` in session.rs uses snow's
+default resolver, which dispatches to RustCrypto primitives.
+
+To confirm what is compiled under snow:
+
+```
+cargo tree -p pathweave-core | grep -A 25 "snow v0"
+```
+
+You will see `chacha20poly1305`, `blake2`, `curve25519-dalek`, and `sha2` in snow's
+subtree (the RustCrypto path), alongside `ring` (the collateral dep). Ring appears
+as a top-level dep of snow, not as part of the resolver dispatch chain for Noise
+operations.


### PR DESCRIPTION
## What this does

Implements `PathweaveNode` in `pathweave-core/src/node.rs` — the top-level entry point that wires the Router, Session layer, and registered transports into a coherent public API.

Also adds ADR 007 (BPv7 bundle layer choice) and ADR 008 (RustCrypto vs ring), both of which document decisions made in earlier PRs that were not captured at the time.

## PathweaveNode

Six public surfaces: four UniFFI-facing, two Rust-only setup methods.

**UniFFI-facing:**
- `new(config, identity)` — constructs the node; `NodeConfig` is accepted but unused until transport crates are implemented
- `send(peer_id, payload)` — looks up the peer's `PeerAnnouncement` in the peer table, delegates to `Router::send()`
- `on_message(handler)` — stores the handler for incoming messages; accept loop is scaffolded but not wired until transport crates exist
- `events()` — delegates to `Router::events()`

**Rust-only setup:**
- `register_transport(transport)` — delegates to `Router::register_transport()`
- `add_peer(peer_id, announcement)` — inserts a known `PeerId -> PeerAnnouncement` mapping; used by pw-chat for the QUIC `--peer <address>` case

`connect(announcement) -> Result<PeerId>` — the method that dials a peer, completes Noise_XX, reads `session.peer_id()`, and stores the mapping — is deferred. It requires working transport implementations.

ARCHITECTURE.md is updated: the API section now opens with "The public API has six surfaces: four exposed through UniFFI to Swift and Kotlin, two Rust-only setup methods" so the count is clear upfront.

## ADR 007: BPv7 bundle layer

Documents the choice to use BPv7 over custom framing. The key rationale: BPv7 bundle IDs (creation timestamp + sequence number) are the groundwork for at-least-once delivery in v0.2.0. Custom framing would require a protocol version bump to add that later. Also documents the CRC_NO decision: ChaCha20-Poly1305 AEAD already provides authentication, so a CRC is redundant overhead.

## ADR 008: RustCrypto vs ring

Documents the ring situation accurately after investigation. Ring IS present in the binary from two sources:

1. `quinn -> rustls -> ring` for QUIC TLS (unavoidable while QUIC is a transport)
2. Snow's `std` feature includes `"ring/std"`, which via Cargo's `dep/feature` resolution activates the optional ring dep

Ring does not handle any Noise handshake or message encryption. All Noise crypto goes through snow's default-resolver-crypto path: chacha20poly1305, blake2, curve25519-dalek, sha2. Feature names verified against snow v0.10.0's actual Cargo.toml in the registry cache.

The ADR addresses the "can ring be removed?" question directly: no, because quinn requires ring regardless. Even removing snow's `std` dependency wouldn't remove ring from the binary.

## Tests

Four tests in `node::tests`:

| Test | What it verifies |
|---|---|
| `send_to_unknown_peer_returns_no_transport_available` | Peers not in the table return `NoTransportAvailable` |
| `send_to_known_peer_routes_through_transport` | Known peers route through the registered transport |
| `on_message_stores_handler` | Handler is stored and callable |
| `events_returns_router_stream` | `events()` returns without panicking |

All 20 tests in `pathweave-core` pass. `cargo clippy --workspace --all-targets -- -D warnings` clean.

## Security considerations

No new cryptographic code. `send()` delegates to `Router::send()` which uses the existing `Session::initiate` path for every outgoing message. The peer table (`HashMap<PeerId, PeerAnnouncement>`) is owned by `PathweaveNode` and not exposed externally. `on_message` handler storage uses `std::sync::Mutex` — straightforward, no async locking needed since `on_message` itself is synchronous.

Ring's presence in the binary is documented in ADR 008. It does not affect the Noise session layer.

Closes #15