### PR TITLE
feat(core): add PathweaveNode::connect()

### DIFF
--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -51,6 +51,19 @@ impl PathweaveNode {
         self.router.register_transport(arc);
     }
 
+    /// Dials `announcement`, completes the Noise_XX handshake as the initiator, stores
+    /// the resulting PeerId -> announcement mapping in the peer table, and returns the PeerId.
+    ///
+    /// Tries transports in cost order (Free first). The handshake session is closed
+    /// immediately after the PeerId is learned; subsequent send() calls re-dial.
+    ///
+    /// Returns NoTransportAvailable if no registered transport is available or all fail.
+    pub async fn connect(&mut self, announcement: PeerAnnouncement) -> Result<PeerId> {
+        let peer_id = self.router.connect(&announcement, &self.identity).await?;
+        self.peers.insert(peer_id.clone(), announcement);
+        Ok(peer_id)
+    }
+
     /// Records a known PeerId -> PeerAnnouncement mapping in the peer table.
     ///
     /// Not part of the UniFFI boundary. Used by pw-chat to inject a QUIC peer
@@ -459,5 +472,46 @@ mod tests {
             .unwrap();
 
         assert_eq!(payload, b"hello from peer");
+    }
+
+    #[tokio::test]
+    async fn connect_learns_and_stores_peer_id() {
+        let (mock, mut mock_rx, _) = make_transport(TransportCost::Free, TransportKind::Ble);
+
+        let initiator_id = NodeIdentity::generate();
+        let responder_id = NodeIdentity::generate();
+        let expected_peer_id = responder_id.peer_id().clone();
+
+        let mut node = PathweaveNode::new(NodeConfig::default(), initiator_id)
+            .await
+            .unwrap();
+        node.register_transport(Box::new(mock));
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        tokio::spawn(async move {
+            let conn = mock_rx.recv().await.unwrap();
+            run_responder(conn, responder_id).await;
+        });
+
+        let peer_id = node.connect(dummy_peer()).await.unwrap();
+        assert_eq!(peer_id, expected_peer_id);
+        // Verify the mapping was stored so send() can now route to this peer.
+        assert!(node.peers.contains_key(&peer_id));
+    }
+
+    #[tokio::test]
+    async fn connect_no_transport_returns_error() {
+        let mut node = PathweaveNode::new(NodeConfig::default(), NodeIdentity::generate())
+            .await
+            .unwrap();
+        let result = node
+            .connect(PeerAnnouncement {
+                address: PeerAddress::Quic("127.0.0.1:1234".parse().unwrap()),
+                short_id: None,
+            })
+            .await;
+        assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }
 }

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -6,8 +6,8 @@ use tokio::sync::broadcast;
 use tokio::task::JoinHandle;
 
 use crate::{
-    BundleLayer, NodeIdentity, PathweaveError, PeerAnnouncement, Result, Session, Transport,
-    TransportCost, TransportEvent,
+    BundleLayer, NodeIdentity, PathweaveError, PeerAnnouncement, PeerId, Result, Session,
+    Transport, TransportCost, TransportEvent,
 };
 
 struct TransportEntry {
@@ -85,6 +85,35 @@ impl Router {
         Err(PathweaveError::NoTransportAvailable)
     }
 
+    /// Dials `peer`, completes the Noise_XX handshake as the initiator, and returns
+    /// the remote PeerId. Tries transports in cost order (Free first). The session is
+    /// closed after the handshake; the caller is responsible for storing the mapping.
+    pub async fn connect(
+        &self,
+        peer: &PeerAnnouncement,
+        identity: &NodeIdentity,
+    ) -> Result<PeerId> {
+        let mut candidates: Vec<&TransportEntry> = self
+            .transports
+            .iter()
+            .filter(|t| t.available.load(Ordering::Acquire))
+            .collect();
+
+        candidates.sort_by_key(|t| match t.transport.cost() {
+            TransportCost::Free => 0u8,
+            TransportCost::Metered => 1,
+            TransportCost::Unknown => 2,
+        });
+
+        for entry in candidates {
+            if let Ok(peer_id) = try_connect(entry.transport.as_ref(), peer, identity).await {
+                return Ok(peer_id);
+            }
+        }
+
+        Err(PathweaveError::NoTransportAvailable)
+    }
+
     /// Returns a stream of transport lifecycle events.
     pub fn events(&self) -> BoxStream<'_, TransportEvent> {
         let rx = self.event_tx.subscribe();
@@ -123,6 +152,19 @@ async fn monitor(transport: Arc<dyn Transport>, available: Arc<AtomicBool>) {
         // replace this with QUIC keepalive loops or BLE scan loops.
         std::future::pending::<()>().await;
     }
+}
+
+/// Dials the transport, completes the Noise_XX handshake, and returns the remote PeerId.
+/// The session is dropped after the handshake, closing the connection.
+async fn try_connect(
+    transport: &dyn Transport,
+    peer: &PeerAnnouncement,
+    identity: &NodeIdentity,
+) -> Result<PeerId> {
+    let raw = transport.connect(peer).await?;
+    let bundled = Box::new(BundleLayer::new(raw));
+    let session = Session::initiate(identity, bundled).await?;
+    Ok(session.peer_id().clone())
 }
 
 /// Opens a connection through the given transport, wraps it in BundleLayer and
@@ -389,6 +431,37 @@ mod tests {
         let result = router
             .send(&dummy_peer(), &sender_id, b"ignored".to_vec())
             .await;
+        assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
+    }
+
+    #[tokio::test]
+    async fn connect_returns_peer_id_on_success() {
+        let (transport, mut rx, _) = make_transport(TransportCost::Free, TransportKind::Ble, false);
+
+        let mut router = Router::new();
+        router.register_transport(transport);
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let initiator_id = NodeIdentity::generate();
+        let responder_id = NodeIdentity::generate();
+        let expected_peer_id = responder_id.peer_id().clone();
+
+        tokio::spawn(async move {
+            let conn = rx.recv().await.unwrap();
+            run_responder(conn, responder_id).await;
+        });
+
+        let peer_id = router.connect(&dummy_peer(), &initiator_id).await.unwrap();
+        assert_eq!(peer_id, expected_peer_id);
+    }
+
+    #[tokio::test]
+    async fn connect_returns_no_transport_when_none_registered() {
+        let router = Router::new();
+        let identity = NodeIdentity::generate();
+        let result = router.connect(&dummy_peer(), &identity).await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }
 }

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -89,10 +89,10 @@ node.register_transport(Box::new(quic));
 node.add_peer(peer_id, announcement);
 ```
 
-`connect(announcement: PeerAnnouncement) -> Result<PeerId>` is the intended v0.2.0
-method for dialing a peer, completing the Noise_XX handshake, learning their PeerId,
-and storing it in the peer table. It requires working transport implementations and is
-deferred until QUIC and BLE transports are complete.
+`connect(announcement: PeerAnnouncement) -> Result<PeerId>` dials the peer, completes
+the Noise_XX handshake as the initiator, stores `(PeerId, PeerAnnouncement)` in the
+peer table, and returns the PeerId. The session is closed immediately after the handshake;
+`send()` re-dials on each call (lazy connections). Tries transports in cost order.
 
 **MessageHandler** is a callback interface, not a closure. This is a UniFFI requirement --
 closures don't cross FFI boundaries cleanly. In Rust, you implement the trait. In Swift,


### PR DESCRIPTION
## Summary

- `PathweaveNode::connect(announcement) -> Result<PeerId>` dials the peer, runs the Noise_XX handshake as the initiator, stores `(PeerId, PeerAnnouncement)` in the peer table, and returns the PeerId
- `Router::connect()` and `try_connect()` mirror the existing `send()`/`try_send()` pattern; `try_connect()` stops after `Session::initiate()` returns without sending any payload
- The session is closed immediately after the handshake; `send()` re-dials on each call (lazy connections, as designed)
- ARCHITECTURE.md updated: removed the v0.2.0 deferral note on `connect()`

## Test plan

- [ ] `connect_learns_and_stores_peer_id`: calls `connect()` with a mock transport, verifies the correct PeerId is returned and stored so `send()` can route to the peer
- [ ] `connect_no_transport_returns_error`: no transports registered returns `NoTransportAvailable`
- [ ] `connect_returns_peer_id_on_success` (router): same verification at the Router layer
- [ ] `connect_returns_no_transport_when_none_registered` (router)
- [ ] All 25 existing `pathweave-core` tests continue to pass
- [ ] CI green

## Security considerations

`connect()` runs the full Noise_XX handshake. The remote peer's static key is authenticated during the handshake before the PeerId is derived. There is no way for a peer to claim a PeerId it does not own: the PeerId is `blake3(noise_static_public_key)` and the Noise_XX pattern cryptographically binds the key to the session. The session is closed after the handshake, so no application data is exchanged in this call.

Closes #24