### PR TITLE
feat(pw-chat): implement terminal chat demo

### DIFF
--- a/examples/pw-chat/Cargo.toml
+++ b/examples/pw-chat/Cargo.toml
@@ -11,7 +11,7 @@ rust-version.workspace = true
 pathweave-core = { path = "../../crates/pathweave-core" }
 pathweave-transport-quic = { path = "../../crates/pathweave-transport-quic" }
 pathweave-transport-ble = { path = "../../crates/pathweave-transport-ble" }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["io-std"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -1,15 +1,104 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+
 use clap::Parser;
+use pathweave_core::{
+    MessageHandler, NodeConfig, NodeIdentity, PeerAddress, PeerAnnouncement, PeerId,
+};
+use pathweave_transport_ble::BleTransport;
+use pathweave_transport_quic::QuicTransport;
+use tokio::io::AsyncBufReadExt;
+
+const DEFAULT_LISTEN_PORT: u16 = 9001;
 
 #[derive(Parser)]
 #[command(name = "pw-chat", about = "Pathweave terminal chat demo")]
 struct Args {
-    #[arg(long, help = "QUIC peer address (host:port). Omit to listen.")]
-    peer: Option<std::net::SocketAddr>,
+    /// QUIC peer address (host:port). Omit to run in listener mode.
+    #[arg(long)]
+    peer: Option<SocketAddr>,
+
+    /// Local QUIC listen port (listener mode only).
+    #[arg(long, default_value_t = DEFAULT_LISTEN_PORT)]
+    port: u16,
+}
+
+struct PrintHandler {
+    label: Arc<str>,
+}
+
+impl PrintHandler {
+    fn new(label: &str) -> Self {
+        Self {
+            label: Arc::from(label),
+        }
+    }
+}
+
+impl MessageHandler for PrintHandler {
+    fn on_message(&self, _peer_id: PeerId, payload: Vec<u8>) {
+        let text = String::from_utf8_lossy(&payload);
+        println!("{}: {}", self.label, text);
+    }
 }
 
 #[tokio::main]
 async fn main() {
     tracing_subscriber::fmt::init();
-    let _args = Args::parse();
-    todo!("wire up PathweaveNode with QUIC and BLE transports")
+    let args = Args::parse();
+
+    let identity = NodeIdentity::generate();
+    println!("my peer id: {}", identity.peer_id());
+
+    let mut node = pathweave_core::PathweaveNode::new(NodeConfig::default(), identity)
+        .await
+        .expect("failed to create node");
+
+    if let Some(peer_addr) = args.peer {
+        // Initiator mode: bind to an OS-assigned port, dial the peer.
+        let quic = QuicTransport::new("0.0.0.0:0".parse().unwrap());
+        node.register_transport(Box::new(quic));
+        node.register_transport(Box::new(BleTransport::new()));
+
+        // Yield so the monitor tasks run start() and mark transports available.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let announcement = PeerAnnouncement {
+            address: PeerAddress::Quic(peer_addr),
+            short_id: None,
+        };
+
+        print!("connecting to {}...", peer_addr);
+        let peer_id = node.connect(announcement).await.expect("failed to connect");
+        let short_id = &peer_id.to_base58()[..8];
+        println!(" connected. peer: {}", short_id);
+
+        node.on_message(Box::new(PrintHandler::new(short_id)));
+
+        let stdin = tokio::io::BufReader::new(tokio::io::stdin());
+        let mut lines = stdin.lines();
+        while let Some(line) = lines.next_line().await.expect("stdin error") {
+            if line.is_empty() {
+                continue;
+            }
+            if let Err(e) = node.send(peer_id.clone(), line.into_bytes()).await {
+                eprintln!("message failed: {}", e);
+            }
+        }
+    } else {
+        // Listener mode: bind to the specified port and wait for connections.
+        let listen_addr: SocketAddr = format!("0.0.0.0:{}", args.port)
+            .parse()
+            .expect("invalid listen address");
+        let quic = QuicTransport::new(listen_addr);
+        node.register_transport(Box::new(quic));
+        node.register_transport(Box::new(BleTransport::new()));
+
+        println!("listening on {}", listen_addr);
+        node.on_message(Box::new(PrintHandler::new("peer")));
+
+        // Block forever; the accept loop delivers messages to the handler.
+        std::future::pending::<()>().await;
+    }
 }


### PR DESCRIPTION
## Summary

- Initiator mode (`--peer <host:port>`): registers QUIC + BLE transports, calls `node.connect()` to learn the peer's PeerId, reads stdin line by line and calls `node.send()`, prints received messages via `on_message`
- Listener mode (no `--peer`): registers QUIC + BLE transports, registers `on_message` handler, blocks; the accept loop wired in `register_transport` handles all incoming connections
- `--port` flag (default 9001) for the listener's QUIC bind address
- Added `tokio` feature `io-std` to pw-chat Cargo.toml for `tokio::io::stdin()`

## Usage

```
# Terminal A — listener
pw-chat

# Terminal B — initiator  
pw-chat --peer 192.168.1.42:9001
```

Output on initiator:
```
my peer id: <base58 id>
connecting to 192.168.1.42:9001... connected. peer: <first 8 chars>
> hello
```

Output on listener:
```
my peer id: <base58 id>
listening on 0.0.0.0:9001
peer: hello
```

## BLE note

BLE registers in both modes. Central-mode scanning is active. Peripheral mode (advertising + GATT server) is tracked in issue #20 and requires Linux with `bluer`. The accept loop handles the BLE error from `accept()` gracefully (backs off 5 s, no busy loop). QUIC is the working demo path for v0.1.0.

## Test plan

- [ ] `cargo build -p pw-chat` passes on all three CI platforms
- [ ] `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` pass
- [ ] Manual end-to-end: initiator connects to listener, typed messages appear on listener terminal

## Security considerations

All messages are encrypted via Noise_XX before leaving the process. `connect()` authenticates the peer's static key during the handshake; the PeerId printed in the output is cryptographically bound to that key. No plaintext is sent over the network at any point.

Depends on #25 (`PathweaveNode::connect()`).
Closes #26