### PR TITLE
feat(pw-chat): enable bidirectional chat

### DIFF
--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -12,13 +12,21 @@ use tokio::io::AsyncBufReadExt;
 const DEFAULT_LISTEN_PORT: u16 = 9001;
 
 #[derive(Parser)]
-#[command(name = "pw-chat", about = "Pathweave terminal chat demo")]
+#[command(
+    name = "pw-chat",
+    about = "Pathweave terminal chat demo",
+    long_about = "Bidirectional encrypted chat over QUIC with automatic BLE fallback.\n\n\
+        Run with --peer on both sides for full bidirectional chat:\n\
+        \n  Machine A:  pw-chat --peer 192.168.1.2:9001\
+        \n  Machine B:  pw-chat --peer 192.168.1.1:9001\n\n\
+        Omit --peer to listen and receive only."
+)]
 struct Args {
-    /// QUIC peer address (host:port). Omit to run in listener mode.
+    /// QUIC peer address (host:port). Specify on both sides for bidirectional chat.
     #[arg(long)]
     peer: Option<SocketAddr>,
 
-    /// Local QUIC listen port (listener mode only).
+    /// Local QUIC listen port. Must match what the other side connects to.
     #[arg(long, default_value_t = DEFAULT_LISTEN_PORT)]
     port: u16,
 }
@@ -55,8 +63,9 @@ async fn main() {
         .expect("failed to create node");
 
     if let Some(peer_addr) = args.peer {
-        // Initiator mode: bind to an OS-assigned port, dial the peer.
-        let quic = QuicTransport::new("0.0.0.0:0".parse().unwrap());
+        // Bidirectional mode: bind to a known port so the peer can connect back.
+        let listen_addr: SocketAddr = format!("0.0.0.0:{}", args.port).parse().unwrap();
+        let quic = QuicTransport::new(listen_addr);
         node.register_transport(Box::new(quic));
         node.register_transport(Box::new(BleTransport::new()));
 


### PR DESCRIPTION
## Summary

When `--peer` is given, pw-chat now binds the local QUIC transport to `0.0.0.0:<port>` (default 9001) instead of an ephemeral port 0. This gives each node a known address so both sides can connect back to each other.

**Before:** initiator could send, listener could only receive.

**After:** run with `--peer` on both sides for full bidirectional chat:

```
# Machine A (IP: 192.168.1.1)
pw-chat --peer 192.168.1.2:9001

# Machine B (IP: 192.168.1.2)
pw-chat --peer 192.168.1.1:9001
```

Each side listens (accept loop delivers incoming messages to `on_message`), connects to the peer (`node.connect()` learns their PeerId), and reads stdin to send. One-line root cause fix.

The listen-only mode (no `--peer`) is unchanged.

## Test plan

- [ ] `cargo build -p pw-chat` passes on all three CI platforms
- [ ] `cargo fmt --all --check` and clippy pass
- [ ] Manual: both sides can send and receive when both use `--peer`

## Security considerations

No change to the security model. Every connection still goes through the full Noise_XX handshake. The only change is the local bind port for the QUIC endpoint in initiator mode.

Closes #29