### PR TITLE
fix(pw-chat): reliable startup timing and graceful connect error

### DIFF
--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -69,9 +69,9 @@ async fn main() {
         node.register_transport(Box::new(quic));
         node.register_transport(Box::new(BleTransport::new()));
 
-        // Yield so the monitor tasks run start() and mark transports available.
-        tokio::task::yield_now().await;
-        tokio::task::yield_now().await;
+        // Give monitor tasks time to call start() and bind real sockets.
+        // yield_now() is sufficient for in-memory mocks but not for OS socket binding.
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
         let announcement = PeerAnnouncement {
             address: PeerAddress::Quic(peer_addr),
@@ -79,7 +79,14 @@ async fn main() {
         };
 
         print!("connecting to {}...", peer_addr);
-        let peer_id = node.connect(announcement).await.expect("failed to connect");
+        let peer_id = match node.connect(announcement).await {
+            Ok(id) => id,
+            Err(e) => {
+                eprintln!("error: could not connect to {}: {}", peer_addr, e);
+                eprintln!("hint: check that the other side is running and port {} is not blocked by a firewall", args.port);
+                std::process::exit(1);
+            }
+        };
         let short_id = &peer_id.to_base58()[..8];
         println!(" connected. peer: {}", short_id);
 


### PR DESCRIPTION
## Summary

Two fixes to make pw-chat survivable in real-world conditions before the first two-laptop test.

**Fix 1: startup timing.** `yield_now()` works for in-memory mocks but not for QUIC, which binds a real OS socket in `start()`. If `connect()` fires before the monitor task finishes `start()`, the transport is not marked available and `connect()` returns `NoTransportAvailable`. Replaced the two `yield_now()` calls with `sleep(200ms)` to give the monitor task reliable time to complete socket binding.

**Fix 2: graceful connect error.** `.expect("failed to connect")` prints a Rust backtrace, which is not useful to someone running a demo. Replaced with a match that prints a human-readable error, a firewall hint, and exits with code 1.

Before:
```
thread 'main' panicked at 'failed to connect: NoTransportAvailable', examples/pw-chat/src/main.rs:82
```

After:
```
error: could not connect to 192.168.1.2:9001: no transport available
hint: check that the other side is running and port 9001 is not blocked by a firewall
```

## Test plan

- [ ] `cargo build -p pw-chat` passes on all three CI platforms
- [ ] `cargo fmt --all --check` and clippy pass

## Security considerations

No change to the security model.

Closes #31