### PR TITLE
fix(quic): finish send stream on drop to prevent RESET_STREAM

### DIFF
--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -230,6 +230,15 @@ pub struct QuicConnection {
     recv: RecvStream,
 }
 
+// Quinn resets a SendStream on drop instead of sending FIN, so the receiver
+// gets a stream-reset error before it can read buffered data. Finish here to
+// ensure every code path sends FIN and the peer can drain the stream cleanly.
+impl Drop for QuicConnection {
+    fn drop(&mut self) {
+        let _ = self.send.finish();
+    }
+}
+
 // QUIC is a byte stream, not a message stream. We prefix every frame with a
 // 4-byte big-endian length so recv_bytes can reassemble complete messages.
 #[async_trait]


### PR DESCRIPTION
## What

Adds a `Drop` impl to `QuicConnection` that calls `self.send.finish()`.

## Why

When `try_send` in the router finishes sending a message, the session is dropped without explicitly calling `close()`. Quinn treats a dropped `SendStream` as a reset (`RESET_STREAM` frame) rather than a clean close (`FIN`). The listener's receiver gets a stream-reset error and cannot read data that was already written and in-flight, so messages were silently lost.

`finish()` is synchronous in Quinn: it marks the stream as finished and the FIN goes out on the next runtime poll. The `Drop` impl covers every code path unconditionally.

## Where it was caught

First two-laptop QUIC test: the other laptop printed `connected. peer: DrXinxMR` but no messages ever appeared on the listener side.

## Security considerations

No change to the Noise_XX session layer or the crypto path. This only affects how the underlying QUIC stream is torn down after a message is delivered.

## Test plan

- [ ] `cargo test -p pathweave-transport-quic` passes (all 3 tests green)
- [ ] Two-laptop test: messages appear on the listener after this fix is applied