### PR TITLE
fix(quic): wait for receiver ACK before dropping QUIC session

### DIFF
--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -144,10 +144,20 @@ async fn handle_incoming(
         }
     };
     let peer_id = session.peer_id().clone();
-    while let Ok(payload) = session.recv().await {
-        let guard = handler.lock().unwrap();
-        if let Some(h) = guard.as_ref() {
-            h.on_message(peer_id.clone(), payload.to_vec());
+    loop {
+        match session.recv().await {
+            Ok(payload) => {
+                {
+                    let guard = handler.lock().unwrap();
+                    if let Some(h) = guard.as_ref() {
+                        h.on_message(peer_id.clone(), payload.to_vec());
+                    }
+                }
+                // ACK so the sender knows the data was delivered before it tears
+                // down the QUIC connection (see try_send in router.rs).
+                let _ = session.send(b"").await;
+            }
+            Err(_) => break,
         }
     }
 }
@@ -339,6 +349,7 @@ mod tests {
         let bundled = Box::new(BundleLayer::new(Box::new(conn)));
         let mut session = Session::respond(&identity, bundled).await.unwrap();
         let _ = session.recv().await;
+        let _ = session.send(b"").await;
     }
 
     // -------------------------------------------------------------------------

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -144,21 +144,16 @@ async fn handle_incoming(
         }
     };
     let peer_id = session.peer_id().clone();
-    loop {
-        match session.recv().await {
-            Ok(payload) => {
-                {
-                    let guard = handler.lock().unwrap();
-                    if let Some(h) = guard.as_ref() {
-                        h.on_message(peer_id.clone(), payload.to_vec());
-                    }
-                }
-                // ACK so the sender knows the data was delivered before it tears
-                // down the QUIC connection (see try_send in router.rs).
-                let _ = session.send(b"").await;
+    while let Ok(payload) = session.recv().await {
+        {
+            let guard = handler.lock().unwrap();
+            if let Some(h) = guard.as_ref() {
+                h.on_message(peer_id.clone(), payload.to_vec());
             }
-            Err(_) => break,
         }
+        // ACK so the sender knows the data was delivered before it tears
+        // down the QUIC connection (see try_send in router.rs).
+        let _ = session.send(b"").await;
     }
 }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -168,7 +168,7 @@ async fn try_connect(
 }
 
 /// Opens a connection through the given transport, wraps it in BundleLayer and
-/// Session, sends the payload, then closes the connection.
+/// Session, sends the payload, waits for the receiver's delivery ACK, then closes.
 async fn try_send(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
@@ -178,7 +178,12 @@ async fn try_send(
     let raw = transport.connect(peer).await?;
     let bundled = Box::new(BundleLayer::new(raw));
     let mut session = Session::initiate(identity, bundled).await?;
-    session.send(payload).await
+    session.send(payload).await?;
+    // Quinn's write_all() buffers internally; CONNECTION_CLOSE fires when the last
+    // connection handle drops, which happens before the buffer is flushed. Waiting
+    // for the receiver's ACK keeps the connection alive until the data is delivered.
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(5), session.recv()).await;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -318,12 +323,13 @@ mod tests {
         }
     }
 
-    /// Runs a responder: completes the Noise_XX handshake and receives one message.
-    /// Wraps the connection in BundleLayer to match what try_send does on the initiator side.
+    /// Runs a responder: completes the Noise_XX handshake, receives one message, and
+    /// sends an empty ACK so try_send() can return before dropping the connection.
     async fn run_responder(conn: TestConn, identity: NodeIdentity) {
         let bundled = Box::new(BundleLayer::new(Box::new(conn)));
         let mut session = Session::respond(&identity, bundled).await.unwrap();
         let _ = session.recv().await;
+        let _ = session.send(b"").await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What changed

`try_send()` in `router.rs` now waits up to 5 seconds for an empty ACK from the receiver before returning. `handle_incoming()` in `node.rs` sends that ACK immediately after delivering each payload to the message handler. The `run_responder` test helper in both files is updated to send the ACK so existing tests keep working.

## Why

Quinn's `write_all()` writes to an internal send buffer; actual transmission is handled asynchronously by Quinn's IO task. When `try_send()` returned immediately after `session.send()`, the drop chain destroyed the last Quinn `Connection` handle, which triggered a `CONNECTION_CLOSE` frame. `CONNECTION_CLOSE` does not flush pending stream data before the receiver's IO task sees "connection lost". Messages were silently dropped even though `node.send()` returned `Ok(())`.

Confirmed with diagnostic tracing: the listener showed `handshake OK` followed immediately by `recv ended: transport error: connection lost` with no payload ever arriving.

After this fix, `Ok(())` from `node.send()` means the receiver confirmed delivery, not just that bytes were written to Quinn's internal buffer.

Closes #34

## How to test

- [x] `cargo test` passes (31 tests, 0 failures)
- [ ] Two-laptop pw-chat test: run `pw-chat --port 9001` on one machine and `pw-chat --port 9001 --peer <ip>:9001` on the other; messages typed on the initiator should appear on the listener

## Security considerations

Before this fix, `node.send()` returning `Ok(())` was misleading: the sender believed delivery succeeded when the payload was silently discarded. That silent failure could cause applications built on top of Pathweave to make incorrect assumptions about whether a message reached its destination.

The ACK itself is an empty message sent over the same Noise_XX-authenticated session, so it inherits the same confidentiality and authentication guarantees as the payload. A man-in-the-middle cannot forge an ACK without knowing the session key.