### PR TITLE
fix(node): eliminate accept loop startup race with tokio::sync::Notify

### DIFF
--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -3,6 +3,8 @@ use std::sync::{Arc, Mutex};
 
 use futures::stream::BoxStream;
 
+use tokio::sync::Notify;
+
 use crate::{
     BundleLayer, Connection, MessageHandler, NodeConfig, NodeIdentity, PathweaveError,
     PeerAnnouncement, PeerId, Result, Router, Session, Transport, TransportEvent,
@@ -47,8 +49,8 @@ impl PathweaveNode {
         let arc: Arc<dyn Transport> = Arc::from(transport);
         let identity = self.identity.clone();
         let handler = Arc::clone(&self.handler);
-        tokio::spawn(accept_loop(Arc::clone(&arc), identity, handler));
-        self.router.register_transport(arc);
+        let started = self.router.register_transport(Arc::clone(&arc));
+        tokio::spawn(accept_loop(arc, identity, handler, started));
     }
 
     /// Dials `announcement`, completes the Noise_XX handshake as the initiator, stores
@@ -105,14 +107,17 @@ impl PathweaveNode {
     }
 }
 
-/// Loops calling transport.accept(). Each accepted connection is handed to
-/// handle_incoming in a spawned task. On error, backs off for 5 seconds to
-/// avoid busy-looping for transports that don't support incoming connections.
+/// Loops calling transport.accept(). Waits for the transport's start() to complete
+/// before the first accept() call, eliminating the startup race. Each accepted
+/// connection is handed to handle_incoming in a spawned task. On error, backs off
+/// for 5 seconds to avoid busy-looping for transports that don't support inbound.
 async fn accept_loop(
     transport: Arc<dyn Transport>,
     identity: NodeIdentity,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
+    started: Arc<Notify>,
 ) {
+    started.notified().await;
     loop {
         match transport.accept().await {
             Ok(conn) => {

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -2,7 +2,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use futures::stream::{self, BoxStream};
-use tokio::sync::broadcast;
+use tokio::sync::{broadcast, Notify};
 use tokio::task::JoinHandle;
 
 use crate::{
@@ -36,18 +36,26 @@ impl Router {
     }
 
     /// Registers a transport and starts its availability monitoring task.
-    pub fn register_transport(&mut self, transport: Arc<dyn Transport>) {
+    ///
+    /// Returns a `Notify` that fires once after `start()` succeeds. Callers that
+    /// need to wait until the transport is ready (e.g. the accept loop) should
+    /// await `notified()` on the returned handle before proceeding.
+    pub fn register_transport(&mut self, transport: Arc<dyn Transport>) -> Arc<Notify> {
         let available = Arc::new(AtomicBool::new(false));
+        let started = Arc::new(Notify::new());
 
         let t = Arc::clone(&transport);
         let a = Arc::clone(&available);
-        let task = tokio::spawn(monitor(t, a));
+        let s = Arc::clone(&started);
+        let task = tokio::spawn(monitor(t, a, s));
 
         self.transports.push(TransportEntry {
             transport,
             available,
             task,
         });
+
+        started
     }
 
     /// Sends `payload` to `peer` through the lowest-cost available transport.
@@ -143,13 +151,12 @@ impl Drop for Router {
     }
 }
 
-/// Monitors a single transport. Marks it available after start() succeeds and
-/// keeps it marked available until the router is dropped (which aborts this task).
-async fn monitor(transport: Arc<dyn Transport>, available: Arc<AtomicBool>) {
+/// Monitors a single transport. Marks it available after start() succeeds, signals
+/// `started` so the accept loop can begin, then parks until the router is dropped.
+async fn monitor(transport: Arc<dyn Transport>, available: Arc<AtomicBool>, started: Arc<Notify>) {
     if transport.start().await.is_ok() {
         available.store(true, Ordering::Release);
-        // Runs until aborted by Router::drop. Real transport implementations
-        // replace this with QUIC keepalive loops or BLE scan loops.
+        started.notify_one();
         std::future::pending::<()>().await;
     }
 }


### PR DESCRIPTION
## What changed

`router::register_transport()` now returns an `Arc<Notify>` that the monitor task signals via `notify_one()` after `transport.start()` succeeds. The accept loop in `node.rs` waits on `started.notified()` before making its first `transport.accept()` call. `notify_one()` stores a permit so the signal is never lost even if the monitor fires before the accept loop reaches the await point.

## Why

The accept loop and the monitor task were spawned concurrently with no coordination. If the accept loop was scheduled first it called `transport.accept()` before `start()` had been called, received a transport error, and backed off for 5 seconds. This caused every startup to delay the first incoming connection by up to 5 seconds. In the pw-chat demo this meant an initiator connecting immediately after the listener starts would hit the backoff window. Closes #36.

## How to test

- [x] `cargo test` passes (31 tests, 0 failures)
- [x] The `incoming_message_delivered_to_handler` test previously caught this class of race condition (it timed out with `notify_waiters()` before the fix to `notify_one()`)
- [ ] Two-laptop pw-chat test: start listener, connect immediately from initiator — connection should succeed without any delay

## Security considerations

The `Notify` coordinates task startup timing only. It carries no data and has no interaction with the crypto or session layer.