### PR TITLE
docs: correct Noise_XK and cost intelligence scope in architecture docs

### DIFF
--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -220,8 +220,9 @@ pub enum TransportCost {
 }
 ```
 
-Simple for v0.1.0. Gets richer in v0.2.0 when we add real cost intelligence: battery
-level, signal quality, payload size, WiFi vs mobile data.
+Simple for v0.1.0. Gets richer in v0.2.0: WiFi vs mobile data detection for QUIC
+replaces the blanket Metered default. Battery level, signal quality, and payload-size
+routing are deferred beyond v0.2.0.
 
 `Metered` covers two situations that are not the same: QUIC over WiFi (flat monthly fee,
 functionally free) and QUIC over mobile data (per-megabyte, genuinely metered). Detecting
@@ -322,7 +323,7 @@ before you connect. Noise_XK requires knowing the responder's key before initiat
 means you can't use it for unknown nearby peers. Noise_XX lets both sides reveal keys
 during the handshake, so you can connect to anyone you discover.
 
-Noise_XK is the v0.2.0 upgrade, once we have a contact and key registry. The pattern
+Noise_XK is the v0.3.0 upgrade, once we have a contact and key registry. The pattern
 string changes; the crate doesn't.
 
 After the handshake, the peer's static public key is known. PeerId is derived here.
@@ -513,7 +514,7 @@ Being clear about this matters as much as being clear about what it does.
 - No at-least-once delivery
 - No automatic QUIC peer discovery (mDNS)
 - No multi-hop BLE routing (single-hop only)
-- No contact or key registry (Noise_XK upgrade deferred to v0.2.0)
+- No contact or key registry (Noise_XK upgrade deferred to v0.3.0)
 - No BLE peripheral mode (advertising) on macOS or Windows (deferred to v0.2.0)
 - No security audit completed
 

--- a/notes/decisions/001-noise-xx-not-xk.md
+++ b/notes/decisions/001-noise-xx-not-xk.md
@@ -1,4 +1,4 @@
-# ADR 001: Use Noise_XX for v0.1.0, defer Noise_XK to v0.2.0
+# ADR 001: Use Noise_XX for v0.1.0, defer Noise_XK to v0.3.0
 
 **Status:** Accepted
 
@@ -27,6 +27,6 @@ Both parties' static public keys are visible to a passive observer who can inter
 the handshake. This is a known limitation of Noise_XX and is documented in SECURITY.md
 under "What v0.1.0 does not provide."
 
-Noise_XK, which hides the initiator's identity, becomes the v0.2.0 upgrade once we have
+Noise_XK, which hides the initiator's identity, becomes the v0.3.0 upgrade once we have
 a contact and key registry. The pattern string changes; the snow crate and everything
 else stays the same.


### PR DESCRIPTION
## Summary

- Noise_XK deferred from v0.2.0 to v0.3.0 in ARCHITECTURE.md (session layer section and "What v0.1.0 doesn't do" list) and ADR 001 (title and body)
- TransportCost section in ARCHITECTURE.md scoped to reflect that v0.2.0 cost intelligence covers WiFi vs mobile data detection only; battery level, signal quality, and payload-size routing are deferred beyond v0.2.0

## Motivation

v0.2.0 scope was locked today. Noise_XK requires a contact and key registry, which is v0.3.0 work. The cost intelligence section was overpromising on what v0.2.0 will deliver.

## Test plan

- [x] Verify ARCHITECTURE.md contains no remaining "v0.2.0" references to Noise_XK
- [x] Verify ADR 001 title and consequences section both say v0.3.0

## Security considerations

Docs-only change. No code modified.