### PR TITLE
feat: message ID framing and deduplication cache for at-least-once delivery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1198,6 +1198,7 @@ dependencies = [
  "bs58",
  "bytes",
  "futures",
+ "getrandom 0.2.17",
  "proptest",
  "snow",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,5 +51,8 @@ clap = { version = "4", features = ["derive"] }
 # bundle protocol
 bp7 = { version = "0.10", default-features = false }
 
+# entropy
+getrandom = "0.2"
+
 # testing
 proptest = "1"

--- a/crates/pathweave-core/Cargo.toml
+++ b/crates/pathweave-core/Cargo.toml
@@ -19,6 +19,7 @@ blake3 = { workspace = true }
 bs58 = { workspace = true }
 x25519-dalek = { workspace = true }
 bp7 = { workspace = true }
+getrandom = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use futures::stream::BoxStream;
 
@@ -9,6 +10,55 @@ use crate::{
     BundleLayer, Connection, MessageHandler, NodeConfig, NodeIdentity, PathweaveError,
     PeerAnnouncement, PeerId, Result, Router, Session, Transport, TransportEvent,
 };
+
+const DEDUP_TTL: Duration = Duration::from_secs(60);
+
+/// Tracks recently seen (PeerId, message_id) pairs to suppress duplicate deliveries.
+///
+/// A retry that arrives after a lost ACK carries the same message ID as the original.
+/// The cache detects this and suppresses the second on_message() call while still
+/// sending the ACK so the sender does not time out. Entries expire after DEDUP_TTL.
+struct DeduplicationCache {
+    seen: HashMap<(PeerId, u64), Instant>,
+    ttl: Duration,
+}
+
+impl DeduplicationCache {
+    fn new() -> Self {
+        Self {
+            seen: HashMap::new(),
+            ttl: DEDUP_TTL,
+        }
+    }
+
+    /// Returns true if (peer_id, message_id) was seen within the TTL window.
+    ///
+    /// If not seen before, records the pair and returns false. Expired entries
+    /// are evicted lazily on each call.
+    fn check_and_insert(&mut self, peer_id: &PeerId, message_id: u64) -> bool {
+        let now = Instant::now();
+        let ttl = self.ttl;
+        self.seen.retain(|_, inserted_at| {
+            now.checked_duration_since(*inserted_at)
+                .map(|age| age < ttl)
+                .unwrap_or(true)
+        });
+        let key = (peer_id.clone(), message_id);
+        if self.seen.contains_key(&key) {
+            return true;
+        }
+        self.seen.insert(key, now);
+        false
+    }
+
+    #[cfg(test)]
+    fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            seen: HashMap::new(),
+            ttl,
+        }
+    }
+}
 
 /// The top-level entry point for the Pathweave library.
 ///
@@ -26,6 +76,7 @@ pub struct PathweaveNode {
     identity: NodeIdentity,
     peers: HashMap<PeerId, PeerAnnouncement>,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
+    dedup: Arc<Mutex<DeduplicationCache>>,
 }
 
 impl PathweaveNode {
@@ -37,6 +88,7 @@ impl PathweaveNode {
             identity,
             peers: HashMap::new(),
             handler: Arc::new(Mutex::new(None)),
+            dedup: Arc::new(Mutex::new(DeduplicationCache::new())),
         })
     }
 
@@ -49,8 +101,9 @@ impl PathweaveNode {
         let arc: Arc<dyn Transport> = Arc::from(transport);
         let identity = self.identity.clone();
         let handler = Arc::clone(&self.handler);
+        let dedup = Arc::clone(&self.dedup);
         let started = self.router.register_transport(Arc::clone(&arc));
-        tokio::spawn(accept_loop(arc, identity, handler, started));
+        tokio::spawn(accept_loop(arc, identity, handler, dedup, started));
     }
 
     /// Dials `announcement`, completes the Noise_XX handshake as the initiator, stores
@@ -115,6 +168,7 @@ async fn accept_loop(
     transport: Arc<dyn Transport>,
     identity: NodeIdentity,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
+    dedup: Arc<Mutex<DeduplicationCache>>,
     started: Arc<Notify>,
 ) {
     started.notified().await;
@@ -123,7 +177,8 @@ async fn accept_loop(
             Ok(conn) => {
                 let identity = identity.clone();
                 let handler = Arc::clone(&handler);
-                tokio::spawn(handle_incoming(conn, identity, handler));
+                let dedup = Arc::clone(&dedup);
+                tokio::spawn(handle_incoming(conn, identity, handler, dedup));
             }
             Err(e) => {
                 tracing::debug!(transport = transport.name(), "accept error: {}", e);
@@ -135,10 +190,16 @@ async fn accept_loop(
 
 /// Completes the Noise_XX handshake as the responder, then loops receiving
 /// messages and delivering them to the handler until the connection closes.
+///
+/// Each payload begins with an 8-byte big-endian message ID. The ID is checked
+/// against the deduplication cache: if the (peer_id, message_id) pair was seen
+/// recently, on_message() is skipped. The ACK is sent regardless so the sender
+/// does not time out (see ADR 009 and ADR 011).
 async fn handle_incoming(
     conn: Box<dyn Connection>,
     identity: NodeIdentity,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
+    dedup: Arc<Mutex<DeduplicationCache>>,
 ) {
     let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(conn));
     let mut session = match Session::respond(&identity, bundled).await {
@@ -150,14 +211,28 @@ async fn handle_incoming(
     };
     let peer_id = session.peer_id().clone();
     while let Ok(payload) = session.recv().await {
-        {
+        if payload.len() < 8 {
+            tracing::debug!(peer = %peer_id, "received payload shorter than 8 bytes; skipping");
+            let _ = session.send(b"").await;
+            continue;
+        }
+        let msg_id = u64::from_be_bytes([
+            payload[0], payload[1], payload[2], payload[3],
+            payload[4], payload[5], payload[6], payload[7],
+        ]);
+        let data = payload[8..].to_vec();
+
+        let is_dup = dedup.lock().unwrap().check_and_insert(&peer_id, msg_id);
+        if !is_dup {
             let guard = handler.lock().unwrap();
             if let Some(h) = guard.as_ref() {
-                h.on_message(peer_id.clone(), payload.to_vec());
+                h.on_message(peer_id.clone(), data);
             }
+        } else {
+            tracing::debug!(peer = %peer_id, "suppressed duplicate message");
         }
         // ACK so the sender knows the data was delivered before it tears
-        // down the QUIC connection (see try_send in router.rs).
+        // down the QUIC connection (see try_send in router.rs and ADR 009).
         let _ = session.send(b"").await;
     }
 }
@@ -474,7 +549,12 @@ mod tests {
         tokio::spawn(async move {
             let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(Box::new(client_conn)));
             let mut session = Session::initiate(&sender_id, bundled).await.unwrap();
-            session.send(b"hello from peer").await.unwrap();
+            // Prepend the 8-byte message ID as handle_incoming now expects (ADR 011).
+            let msg_id: u64 = 0x0102030405060708;
+            let mut framed = Vec::with_capacity(8 + b"hello from peer".len());
+            framed.extend_from_slice(&msg_id.to_be_bytes());
+            framed.extend_from_slice(b"hello from peer");
+            session.send(&framed).await.unwrap();
         });
 
         let payload = tokio::time::timeout(tokio::time::Duration::from_secs(5), done_rx)
@@ -524,5 +604,118 @@ mod tests {
             })
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
+    }
+
+    // --- DeduplicationCache unit tests ---------------------------------------
+
+    #[test]
+    fn dedup_cache_first_insert_not_duplicate() {
+        let mut cache = DeduplicationCache::new();
+        let peer = NodeIdentity::generate().peer_id().clone();
+        assert!(!cache.check_and_insert(&peer, 42));
+    }
+
+    #[test]
+    fn dedup_cache_second_insert_same_key_is_duplicate() {
+        let mut cache = DeduplicationCache::new();
+        let peer = NodeIdentity::generate().peer_id().clone();
+        cache.check_and_insert(&peer, 42);
+        assert!(cache.check_and_insert(&peer, 42));
+    }
+
+    #[test]
+    fn dedup_cache_different_message_id_not_duplicate() {
+        let mut cache = DeduplicationCache::new();
+        let peer = NodeIdentity::generate().peer_id().clone();
+        cache.check_and_insert(&peer, 1);
+        assert!(!cache.check_and_insert(&peer, 2));
+    }
+
+    #[test]
+    fn dedup_cache_different_peer_same_id_not_duplicate() {
+        let mut cache = DeduplicationCache::new();
+        let peer_a = NodeIdentity::generate().peer_id().clone();
+        let peer_b = NodeIdentity::generate().peer_id().clone();
+        cache.check_and_insert(&peer_a, 42);
+        assert!(!cache.check_and_insert(&peer_b, 42));
+    }
+
+    #[test]
+    fn dedup_cache_entry_redeliverable_after_ttl_expires() {
+        let mut cache = DeduplicationCache::with_ttl(Duration::from_millis(10));
+        let peer = NodeIdentity::generate().peer_id().clone();
+        cache.check_and_insert(&peer, 99);
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(!cache.check_and_insert(&peer, 99));
+    }
+
+    // --- duplicate suppression integration test ------------------------------
+
+    #[tokio::test]
+    async fn duplicate_message_delivered_only_once() {
+        let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel::<Box<dyn Connection>>();
+        let transport = AcceptMockTransport {
+            conn_rx: tokio::sync::Mutex::new(conn_rx),
+        };
+
+        let receiver_id = NodeIdentity::generate();
+        let sender_id = NodeIdentity::generate();
+
+        let call_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        struct CountingHandler {
+            count: Arc<std::sync::atomic::AtomicUsize>,
+        }
+        impl MessageHandler for CountingHandler {
+            fn on_message(&self, _peer_id: PeerId, _payload: Vec<u8>) {
+                self.count.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let mut node = PathweaveNode::new(NodeConfig::default(), receiver_id)
+            .await
+            .unwrap();
+        node.register_transport(Box::new(transport));
+        node.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&call_count),
+        }));
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let msg_id: u64 = 0xDEADBEEFCAFEBABE;
+        let mut framed = Vec::with_capacity(8 + b"hello".len());
+        framed.extend_from_slice(&msg_id.to_be_bytes());
+        framed.extend_from_slice(b"hello");
+
+        // Send two connections from the same sender with the same message ID.
+        for _ in 0..2 {
+            let (client_conn, server_conn) = conn_pair();
+            conn_tx
+                .send(Box::new(server_conn))
+                .expect("transport still alive");
+            let sender_id = sender_id.clone();
+            let framed = framed.clone();
+            tokio::spawn(async move {
+                let bundled: Box<dyn Connection> =
+                    Box::new(BundleLayer::new(Box::new(client_conn)));
+                let mut session = Session::initiate(&sender_id, bundled).await.unwrap();
+                session.send(&framed).await.unwrap();
+                // Wait for the ACK so handle_incoming has time to process.
+                let _ = tokio::time::timeout(
+                    tokio::time::Duration::from_secs(2),
+                    session.recv(),
+                )
+                .await;
+            });
+        }
+
+        // Give both connections time to be fully processed.
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            call_count.load(Ordering::Relaxed),
+            1,
+            "on_message must be called exactly once for a duplicated message"
+        );
     }
 }

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -217,8 +217,8 @@ async fn handle_incoming(
             continue;
         }
         let msg_id = u64::from_be_bytes([
-            payload[0], payload[1], payload[2], payload[3],
-            payload[4], payload[5], payload[6], payload[7],
+            payload[0], payload[1], payload[2], payload[3], payload[4], payload[5], payload[6],
+            payload[7],
         ]);
         let data = payload[8..].to_vec();
 
@@ -702,11 +702,8 @@ mod tests {
                 let mut session = Session::initiate(&sender_id, bundled).await.unwrap();
                 session.send(&framed).await.unwrap();
                 // Wait for the ACK so handle_incoming has time to process.
-                let _ = tokio::time::timeout(
-                    tokio::time::Duration::from_secs(2),
-                    session.recv(),
-                )
-                .await;
+                let _ =
+                    tokio::time::timeout(tokio::time::Duration::from_secs(2), session.recv()).await;
             });
         }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -63,12 +63,18 @@ impl Router {
     /// Tries transports in cost order (Free first). On connection or handshake
     /// failure, falls back to the next available transport. Returns
     /// NoTransportAvailable if no registered transport is available or all fail.
+    ///
+    /// A random 8-byte message ID is generated once per call and passed to
+    /// try_send(). The receiver uses this ID for deduplication so that future
+    /// retry attempts (issue #43) do not double-deliver.
     pub async fn send(
         &self,
         peer: &PeerAnnouncement,
         identity: &NodeIdentity,
         payload: Vec<u8>,
     ) -> Result<()> {
+        let message_id = new_message_id();
+
         let mut candidates: Vec<&TransportEntry> = self
             .transports
             .iter()
@@ -82,7 +88,7 @@ impl Router {
         });
 
         for entry in candidates {
-            if try_send(entry.transport.as_ref(), peer, identity, &payload)
+            if try_send(entry.transport.as_ref(), peer, identity, &payload, message_id)
                 .await
                 .is_ok()
             {
@@ -174,18 +180,35 @@ async fn try_connect(
     Ok(session.peer_id().clone())
 }
 
+/// Generates a cryptographically random 64-bit message ID from OS entropy.
+///
+/// Panics if the system entropy source is unavailable — the same condition
+/// that would have already caused NodeIdentity::generate() to panic.
+fn new_message_id() -> u64 {
+    let mut bytes = [0u8; 8];
+    getrandom::getrandom(&mut bytes).expect("system entropy unavailable");
+    u64::from_be_bytes(bytes)
+}
+
 /// Opens a connection through the given transport, wraps it in BundleLayer and
-/// Session, sends the payload, waits for the receiver's delivery ACK, then closes.
+/// Session, prepends the 8-byte message ID for receiver-side deduplication,
+/// sends the framed payload, waits for the receiver's delivery ACK, then closes.
 async fn try_send(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
     identity: &NodeIdentity,
     payload: &[u8],
+    message_id: u64,
 ) -> Result<()> {
     let raw = transport.connect(peer).await?;
     let bundled = Box::new(BundleLayer::new(raw));
     let mut session = Session::initiate(identity, bundled).await?;
-    session.send(payload).await?;
+
+    let mut framed = Vec::with_capacity(8 + payload.len());
+    framed.extend_from_slice(&message_id.to_be_bytes());
+    framed.extend_from_slice(payload);
+
+    session.send(&framed).await?;
     // Quinn's write_all() buffers internally; CONNECTION_CLOSE fires when the last
     // connection handle drops, which happens before the buffer is flushed. Waiting
     // for the receiver's ACK keeps the connection alive until the data is delivered.

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -88,9 +88,15 @@ impl Router {
         });
 
         for entry in candidates {
-            if try_send(entry.transport.as_ref(), peer, identity, &payload, message_id)
-                .await
-                .is_ok()
+            if try_send(
+                entry.transport.as_ref(),
+                peer,
+                identity,
+                &payload,
+                message_id,
+            )
+            .await
+            .is_ok()
             {
                 return Ok(());
             }

--- a/notes/decisions/011-at-least-once-delivery.md
+++ b/notes/decisions/011-at-least-once-delivery.md
@@ -1,0 +1,145 @@
+# ADR 011: At-least-once delivery via message ID framing and retry loop
+
+**Status:** Accepted
+
+## Context
+
+v0.1.0 provides single-attempt confirmed delivery. `send()` returns `Ok(())` when the
+receiver ACKs via the session round-trip (ADR 009), or an error if the ACK times out.
+There is no retry. If the ACK is lost after delivery (connection drops between delivery
+and ACK), the sender cannot distinguish "delivery failed" from "delivery succeeded, ACK
+lost." Callers that retry at the application layer will double-deliver.
+
+The goal for v0.2.0 is at-least-once delivery: `send()` retries up to N times before
+returning an error, and the receiver deduplicates retried messages.
+
+## Why BPv7 bundle IDs are not usable for deduplication
+
+The natural deduplication key for a bundle protocol is the BPv7 bundle ID, which RFC 9171
+defines as `(source_node_id, creation_timestamp)`. In the current implementation:
+
+- Source node ID is always `pathweave/local` for every bundle.
+- The creation timestamp is `(DTN_TIME_EPOCH, seq)` where `seq` is a monotonically
+  increasing counter on each `BundleLayer` instance.
+
+`BundleLayer` is created fresh for every connection, and every `try_send()` call opens
+a new connection. So `seq` resets to 0 for every message sent. Every message has bundle
+ID `(pathweave/local, (0, 0))`. Using this as a dedup key would cause every second
+message from the same sender to be treated as a duplicate.
+
+Fixing the timestamp to use actual wall-clock time would help for messages sent more
+than one second apart, but retries (which happen within the 5-second ACK timeout) often
+arrive within the same second — and the next new message sent by the same sender after
+the TTL expires would get seq=0 again and collide anyway. The lazy-connection model
+makes BPv7 bundle IDs unreliable as dedup keys without a deeper refactor of the bundle
+layer.
+
+## Decision
+
+Add an 8-byte random message ID, generated once per `router.send()` call and prepended
+to the encrypted payload. The receiver extracts this ID and uses `(peer_id, message_id)`
+as the deduplication key.
+
+### Message ID framing
+
+In `router.send()`, generate a cryptographically random `u64` using `getrandom`. Pass
+this ID to `try_send()`. In `try_send()`, prepend the ID as a big-endian `u64` (8 bytes)
+before calling `session.send()`. The ID is inside the Noise_XX-encrypted stream, so it
+is not visible to passive observers and cannot be forged.
+
+When the retry loop (see below) retries a failed send, it calls `try_send()` with the
+same message ID. The receiver sees the same `(peer_id, message_id)` tuple and suppresses
+the second delivery.
+
+### Deduplication cache
+
+The receiver maintains a `DeduplicationCache` on `PathweaveNode`, shared across all
+accept loops via `Arc<Mutex<...>>`. The cache maps `(PeerId, u64)` to the insertion
+`Instant`.
+
+On receiving a payload in `handle_incoming()`:
+
+1. Extract the 8-byte message ID from the first 8 bytes of the decrypted payload.
+2. Call `cache.check_and_insert(peer_id, message_id)`:
+   - Evict entries older than the TTL (lazy eviction on access).
+   - If the key is present: return `true` (duplicate).
+   - If the key is absent: insert it with the current time, return `false` (new).
+3. If duplicate: skip `on_message()`. Always send the ACK regardless, so the sender
+   does not time out.
+4. If new: call `on_message(data)` with the payload bytes after the 8-byte prefix. Then
+   send the ACK.
+
+Default TTL: 60 seconds. This gives a large margin over the 5-second ACK timeout.
+
+### Retry loop
+
+`router.send()` generates the message ID once, then calls `try_send()` in a loop:
+
+- On ACK timeout: retry on the same transport (if still available), then fall back to
+  the next available transport.
+- Max attempts: 3 (configurable).
+- Backoff: 1 second between attempts.
+- If all attempts exhausted: return `PathweaveError::DeliveryFailed`.
+
+The same message ID is reused across all attempts of the same `router.send()` call.
+
+### Wire format change
+
+Payload as seen by the session layer is now:
+
+```
+[message_id: u64 big-endian, 8 bytes][application payload: variable]
+```
+
+This is a breaking change to the wire format. v0.1.0 and v0.2.0 nodes are not
+wire-compatible for application payloads. This is acceptable: v0.x.0 provides no
+stability guarantees.
+
+`pw-chat` does not need updating for the framing itself since it communicates through
+`node.send()`, which picks up the new framing automatically. Tests that construct
+sessions directly (bypassing `try_send()`) must be updated to include the 8-byte prefix.
+
+## Rationale
+
+**Why a random ID and not a counter?**
+
+A monotonic counter resets on node restart. If the node restarts within the cache TTL
+and sends a new message, it gets counter=0 again. If the receiver still has counter=0
+from before the restart in its cache, the new message is incorrectly deduplicated.
+A random u64 has negligible collision probability (approximately 1 in 2^64) and is
+unaffected by restarts.
+
+**Why getrandom and not rand?**
+
+`getrandom` is the minimal primitive: it calls the OS entropy source directly and has
+no dependencies beyond platform-specific OS bindings. The `rand` crate is larger and
+provides PRNG facilities we do not need. For a security-focused library, using the
+smallest, most audited primitive is the right call.
+
+**Why prepend the ID inside the encryption and not in the bundle header?**
+
+Putting the ID in a BPv7 extension block would expose it in plaintext at the bundle
+layer, allowing a passive observer to correlate retried messages. Inside the encryption,
+the ID is not visible. The receiver can still extract it after decryption.
+
+**Why 60 seconds TTL?**
+
+The ACK timeout is 5 seconds and the max retry window is 3 attempts × (5 second timeout
++ 1 second backoff) ≈ 18 seconds. A 60-second TTL provides more than 3× margin. Memory
+cost is bounded: at typical chat message rates, the cache holds at most a few dozen
+entries.
+
+## Implications
+
+**Double-delivery edge case reduced, not eliminated:** If `on_message()` is called
+successfully but the ACK is lost and all retries are also lost, `send()` returns
+`DeliveryFailed`. The message was delivered but the sender cannot know this. This is
+the irreducible at-least-once edge case and is documented behaviour.
+
+**Timeout semantics change:** In v0.1.0, a 5-second timeout on the first attempt meant
+the sender gave up. In v0.2.0, `DeliveryFailed` means the sender gave up after N
+attempts, each of which waited up to 5 seconds. Callers that interpret error return
+values need to be aware that the elapsed time can be up to N × 5 seconds + backoff.
+
+**Implementation order:** The deduplication cache (#42) must be merged before the retry
+loop (#43). A retry loop without deduplication would double-deliver on ACK loss.


### PR DESCRIPTION
## Summary

- Adds ADR 011 documenting the full at-least-once delivery design: why BPv7 bundle IDs cannot be used for deduplication, the message ID framing approach, and the retry loop design (issue #43)
- `router.send()` generates a cryptographically random 8-byte message ID via `getrandom` once per call; this ID is reused across all retry attempts of the same send
- `try_send()` prepends the 8-byte ID to the payload inside the Noise_XX-encrypted session; the ID is invisible to passive observers
- `DeduplicationCache` on `PathweaveNode` tracks `(PeerId, message_id)` pairs with a 60-second TTL; `handle_incoming()` uses it to suppress duplicate `on_message()` calls while still sending the ACK
- Adds `getrandom = "0.2"` as a new direct dependency

## Motivation

This is the receiver-side prerequisite for the retry loop (#43). Without deduplication, a retry following a lost ACK would double-deliver. The retry loop must not be merged before this.

## Test plan

- [ ] `cargo test -p pathweave-core` passes (31 tests)
- [ ] `cargo clippy -p pathweave-core -- -D warnings` clean
- [ ] `dedup_cache_first_insert_not_duplicate`: first insert returns false
- [ ] `dedup_cache_second_insert_same_key_is_duplicate`: same key returns true
- [ ] `dedup_cache_different_message_id_not_duplicate`: different IDs are not deduped
- [ ] `dedup_cache_different_peer_same_id_not_duplicate`: same ID, different peer is not deduped
- [ ] `dedup_cache_entry_redeliverable_after_ttl_expires`: entry is re-deliverable after TTL
- [ ] `duplicate_message_delivered_only_once`: two connections with same message ID call on_message() exactly once

## Security considerations

The message ID is generated from OS entropy (`getrandom`) and transmitted inside the Noise_XX-encrypted session. It is not visible to passive observers and cannot be forged. The deduplication cache is keyed on `(PeerId, message_id)` where `PeerId` is derived from the sender's authenticated Noise static key, so a message from a different peer with the same ID is not treated as a duplicate.