### PR TITLE
feat(quic): mDNS peer discovery and router consumer task

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,6 +160,12 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -211,7 +217,7 @@ version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84ae4213cc2a8dc663acecac67bbdad05142be4d8ef372b6903abf878b0c690a"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "bluez-generated",
  "dbus",
  "dbus-tokio",
@@ -240,7 +246,7 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0dd4a4f935d4040f93aa8b0ccda0ce210911631673ee62a35efba619954b937"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "crc",
  "humantime",
  "nanorand",
@@ -268,7 +274,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9a11621cb2c8c024e444734292482b1ad86fb50ded066cf46252e46643c8748"
 dependencies = [
  "async-trait",
- "bitflags",
+ "bitflags 2.11.1",
  "bluez-async",
  "dashmap 6.1.0",
  "dbus",
@@ -418,6 +424,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -656,6 +671,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -861,6 +887,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,6 +1093,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdns-sd"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe7c11a1eb3cfbfcf702d1601c1f5f4c102cdc8665b8a557783ef634741676e"
+dependencies = [
+ "flume",
+ "if-addrs",
+ "log",
+ "polling",
+ "socket2 0.5.10",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1128,7 +1177,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "objc2",
  "objc2-foundation",
 ]
@@ -1145,7 +1194,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "block2",
  "libc",
  "objc2",
@@ -1229,6 +1278,8 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
+ "getrandom 0.2.17",
+ "mdns-sd",
  "pathweave-core",
  "quinn",
  "rcgen",
@@ -1266,6 +1317,22 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "polling"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b2d323e8ca7996b3e23126511a523f7e62924d93ecd5ae73b333815b0eb3dce"
+dependencies = [
+ "autocfg",
+ "bitflags 1.3.2",
+ "cfg-if",
+ "concurrent-queue",
+ "libc",
+ "log",
+ "pin-project-lite",
+ "windows-sys 0.48.0",
+]
 
 [[package]]
 name = "poly1305"
@@ -1332,7 +1399,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags",
+ "bitflags 2.11.1",
  "num-traits",
  "rand",
  "rand_chacha",
@@ -1375,7 +1442,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -1414,7 +1481,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -1503,7 +1570,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -1567,7 +1634,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1696,7 +1763,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1887,12 +1954,31 @@ dependencies = [
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
 ]
 
 [[package]]
@@ -2092,7 +2178,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -2379,7 +2465,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver 1.0.28",
@@ -2532,9 +2618,27 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2570,6 +2674,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -2622,6 +2741,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -2640,6 +2765,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -2655,6 +2786,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2688,6 +2825,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -2703,6 +2846,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2724,6 +2873,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -2739,6 +2894,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2816,7 +2977,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,5 +54,8 @@ bp7 = { version = "0.10", default-features = false }
 # entropy
 getrandom = "0.2"
 
+# discovery
+mdns-sd = "0.11"
+
 # testing
 proptest = "1"

--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -218,7 +218,7 @@ pub trait MessageHandler: Send + Sync {
 pub trait Transport: Send + Sync {
     async fn start(&self) -> Result<()>;
     async fn stop(&self) -> Result<()>;
-    fn discover(&self) -> BoxStream<'_, PeerAnnouncement>;
+    fn discover(&self) -> BoxStream<'static, PeerAnnouncement>;
     async fn connect(&self, peer: &PeerAnnouncement) -> Result<Box<dyn Connection>>;
     async fn accept(&self) -> Result<Box<dyn Connection>>;
     fn mtu_hint(&self) -> usize;

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -1,13 +1,14 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures::stream::BoxStream;
 
-use tokio::sync::Notify;
+use tokio::sync::watch;
 
 use crate::{
-    BundleLayer, Connection, MessageHandler, NodeConfig, NodeIdentity, PathweaveError,
+    BundleLayer, Connection, MessageHandler, NodeConfig, NodeIdentity, PathweaveError, PeerAddress,
     PeerAnnouncement, PeerId, Result, Router, Session, Transport, TransportEvent,
 };
 
@@ -66,15 +67,19 @@ impl DeduplicationCache {
 /// Callers create a node, register transports, inject any known peer addresses, and
 /// then use the four documented API surfaces (send, on_message, events, new).
 ///
-/// The peer table maps PeerId -> PeerAnnouncement. send() looks up the announcement
-/// here; if the peer is not present, NoTransportAvailable is returned immediately.
-/// Use add_peer() to inject a known address (e.g. a QUIC address from the command
-/// line) or wait for a future connect() implementation that dials and learns the
-/// remote PeerId via the Noise_XX handshake.
+/// The peer table maps PeerId -> PeerAnnouncement. The discover task (one per
+/// transport) populates it automatically via mDNS. add_peer() and connect() also
+/// insert into the table for manually-supplied addresses.
 pub struct PathweaveNode {
     router: Router,
     identity: NodeIdentity,
-    peers: HashMap<PeerId, PeerAnnouncement>,
+    peers: Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>,
+    // Dedup-only: tracks addresses currently in-flight or already connected.
+    // Not authoritative for routing — peers is. peer_stream only upserts to
+    // peers; it never removes. This invariant is what makes the concurrent
+    // add_peer() edge case benign: even if known_addrs loses an entry, the
+    // peers entry remains intact and send() continues to work.
+    known_addrs: Arc<Mutex<HashSet<SocketAddr>>>,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
 }
@@ -86,14 +91,16 @@ impl PathweaveNode {
         Ok(Self {
             router: Router::new(),
             identity,
-            peers: HashMap::new(),
+            peers: Arc::new(Mutex::new(HashMap::new())),
+            known_addrs: Arc::new(Mutex::new(HashSet::new())),
             handler: Arc::new(Mutex::new(None)),
             dedup: Arc::new(Mutex::new(DeduplicationCache::new())),
         })
     }
 
     /// Registers a transport, starts its background availability monitor, and
-    /// spawns an accept loop that delivers incoming connections to the message handler.
+    /// spawns an accept loop that delivers incoming connections to the message
+    /// handler and a discover loop that populates the peer table via mDNS.
     ///
     /// Not part of the UniFFI boundary; Rust callers use this during setup.
     /// Must be called before any send() calls that depend on this transport.
@@ -103,7 +110,23 @@ impl PathweaveNode {
         let handler = Arc::clone(&self.handler);
         let dedup = Arc::clone(&self.dedup);
         let started = self.router.register_transport(Arc::clone(&arc));
-        tokio::spawn(accept_loop(arc, identity, handler, dedup, started));
+
+        tokio::spawn(accept_loop(
+            Arc::clone(&arc),
+            identity.clone(),
+            handler,
+            dedup,
+            started.clone(),
+        ));
+
+        tokio::spawn(crate::router::peer_stream(
+            arc,
+            identity,
+            started,
+            Arc::clone(&self.peers),
+            Arc::clone(&self.known_addrs),
+            self.identity.peer_id().clone(),
+        ));
     }
 
     /// Dials `announcement`, completes the Noise_XX handshake as the initiator, stores
@@ -115,7 +138,13 @@ impl PathweaveNode {
     /// Returns NoTransportAvailable if no registered transport is available or all fail.
     pub async fn connect(&mut self, announcement: PeerAnnouncement) -> Result<PeerId> {
         let peer_id = self.router.connect(&announcement, &self.identity).await?;
-        self.peers.insert(peer_id.clone(), announcement);
+        if let PeerAddress::Quic(addr) = &announcement.address {
+            self.known_addrs.lock().unwrap().insert(*addr);
+        }
+        self.peers
+            .lock()
+            .unwrap()
+            .insert(peer_id.clone(), announcement);
         Ok(peer_id)
     }
 
@@ -124,7 +153,10 @@ impl PathweaveNode {
     /// Not part of the UniFFI boundary. Used by pw-chat to inject a QUIC peer
     /// address resolved from the command line, and by tests to set up known peers.
     pub fn add_peer(&mut self, peer_id: PeerId, announcement: PeerAnnouncement) {
-        self.peers.insert(peer_id, announcement);
+        if let PeerAddress::Quic(addr) = &announcement.address {
+            self.known_addrs.lock().unwrap().insert(*addr);
+        }
+        self.peers.lock().unwrap().insert(peer_id, announcement);
     }
 
     /// Sends `payload` to the peer identified by `peer_id`.
@@ -138,10 +170,13 @@ impl PathweaveNode {
     pub async fn send(&self, peer_id: PeerId, payload: Vec<u8>) -> Result<()> {
         let announcement = self
             .peers
+            .lock()
+            .unwrap()
             .get(&peer_id)
+            .cloned()
             .ok_or(PathweaveError::NoTransportAvailable)?;
         self.router
-            .send(announcement, &self.identity, payload)
+            .send(&announcement, &self.identity, payload)
             .await
     }
 
@@ -169,9 +204,9 @@ async fn accept_loop(
     identity: NodeIdentity,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
-    started: Arc<Notify>,
+    mut started: watch::Receiver<bool>,
 ) {
-    started.notified().await;
+    let _ = started.wait_for(|v| *v).await;
     loop {
         match transport.accept().await {
             Ok(conn) => {
@@ -309,7 +344,7 @@ mod tests {
             Ok(())
         }
 
-        fn discover(&self) -> BoxStream<'_, PeerAnnouncement> {
+        fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
             Box::pin(stream::empty())
         }
 
@@ -377,7 +412,7 @@ mod tests {
             Ok(())
         }
 
-        fn discover(&self) -> BoxStream<'_, PeerAnnouncement> {
+        fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
             Box::pin(stream::empty())
         }
 
@@ -589,7 +624,7 @@ mod tests {
         let peer_id = node.connect(dummy_peer()).await.unwrap();
         assert_eq!(peer_id, expected_peer_id);
         // Verify the mapping was stored so send() can now route to this peer.
-        assert!(node.peers.contains_key(&peer_id));
+        assert!(node.peers.lock().unwrap().contains_key(&peer_id));
     }
 
     #[tokio::test]

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -1,14 +1,16 @@
+use std::collections::{HashMap, HashSet};
+use std::net::SocketAddr;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use futures::stream::{self, BoxStream};
-use tokio::sync::{broadcast, Notify};
+use futures::stream::{self, BoxStream, StreamExt};
+use tokio::sync::{broadcast, watch};
 use tokio::task::JoinHandle;
 
 use crate::{
-    BundleLayer, NodeIdentity, PathweaveError, PeerAnnouncement, PeerId, Result, Session,
-    Transport, TransportCost, TransportEvent,
+    BundleLayer, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId, Result,
+    Session, Transport, TransportCost, TransportEvent,
 };
 
 const MAX_SEND_ATTEMPTS: usize = 3;
@@ -41,17 +43,18 @@ impl Router {
 
     /// Registers a transport and starts its availability monitoring task.
     ///
-    /// Returns a `Notify` that fires once after `start()` succeeds. Callers that
-    /// need to wait until the transport is ready (e.g. the accept loop) should
-    /// await `notified()` on the returned handle before proceeding.
-    pub fn register_transport(&mut self, transport: Arc<dyn Transport>) -> Arc<Notify> {
+    /// Returns a watch receiver that fires once `start()` succeeds. Callers
+    /// that need to wait until the transport is ready (e.g. the accept loop or
+    /// the discover loop) should `wait_for(|v| *v).await` on a clone of the
+    /// returned receiver. Unlike `Notify`, a watch receiver that arrives late
+    /// still sees `true` because the value is retained.
+    pub fn register_transport(&mut self, transport: Arc<dyn Transport>) -> watch::Receiver<bool> {
         let available = Arc::new(AtomicBool::new(false));
-        let started = Arc::new(Notify::new());
+        let (started_tx, started_rx) = watch::channel(false);
 
         let t = Arc::clone(&transport);
         let a = Arc::clone(&available);
-        let s = Arc::clone(&started);
-        let task = tokio::spawn(monitor(t, a, s));
+        let task = tokio::spawn(monitor(t, a, started_tx));
 
         self.transports.push(TransportEntry {
             transport,
@@ -59,7 +62,7 @@ impl Router {
             task,
         });
 
-        started
+        started_rx
     }
 
     /// Sends `payload` to `peer`, retrying up to MAX_SEND_ATTEMPTS times.
@@ -181,12 +184,18 @@ impl Drop for Router {
     }
 }
 
-/// Monitors a single transport. Marks it available after start() succeeds, signals
-/// `started` so the accept loop can begin, then parks until the router is dropped.
-async fn monitor(transport: Arc<dyn Transport>, available: Arc<AtomicBool>, started: Arc<Notify>) {
+/// Monitors a single transport. Marks it available after start() succeeds,
+/// signals `started` so waiting tasks can begin, then parks until the router
+/// is dropped. Using a watch::Sender means any task that subscribes late still
+/// sees the `true` value without a race.
+async fn monitor(
+    transport: Arc<dyn Transport>,
+    available: Arc<AtomicBool>,
+    started: watch::Sender<bool>,
+) {
     if transport.start().await.is_ok() {
         available.store(true, Ordering::Release);
-        started.notify_one();
+        let _ = started.send(true);
         std::future::pending::<()>().await;
     }
 }
@@ -240,6 +249,57 @@ async fn try_send(
         Ok(Ok(_)) => Ok(()),
         Ok(Err(e)) => Err(e),
         Err(_) => Err(PathweaveError::Transport("delivery ACK timed out".into())),
+    }
+}
+
+/// Drives mDNS peer discovery for a single transport.
+///
+/// Waits for the transport to start, then drains its discover() stream. For
+/// each announced address that is not already in `known_addrs`, performs a
+/// Noise_XX handshake to learn the remote PeerId. On success, upserts the
+/// PeerId -> PeerAnnouncement mapping into the shared peer table. On failure,
+/// removes the address from `known_addrs` so the next re-announcement retries.
+/// Skips self-announcements by comparing the remote PeerId with `local_peer_id`.
+///
+/// Address-based dedup (not PeerId-based) handles peer roaming: if a known
+/// peer reappears at a new address, the new address is not in `known_addrs`
+/// and a fresh handshake is performed, updating the peer table entry.
+pub(crate) async fn peer_stream(
+    transport: Arc<dyn Transport>,
+    identity: NodeIdentity,
+    mut started: watch::Receiver<bool>,
+    peers: Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>,
+    known_addrs: Arc<Mutex<HashSet<SocketAddr>>>,
+    local_peer_id: PeerId,
+) {
+    let _ = started.wait_for(|v| *v).await;
+    let mut discover = transport.discover();
+    while let Some(announcement) = discover.next().await {
+        let addr = match &announcement.address {
+            PeerAddress::Quic(addr) => *addr,
+            _ => continue,
+        };
+
+        // Skip re-announcements from already-connected addresses (O(1) check).
+        if !known_addrs.lock().unwrap().insert(addr) {
+            continue;
+        }
+
+        match try_connect(transport.as_ref(), &announcement, &identity).await {
+            Ok(peer_id) if peer_id == local_peer_id => {
+                // Self-discovery: keep addr in known_addrs so we don't retry.
+                tracing::debug!(addr = %addr, "mDNS: discovered self; skipping");
+            }
+            Ok(peer_id) => {
+                tracing::debug!(addr = %addr, peer = %peer_id, "mDNS: peer connected");
+                peers.lock().unwrap().insert(peer_id, announcement);
+            }
+            Err(e) => {
+                tracing::debug!(addr = %addr, "mDNS: handshake failed: {}", e);
+                // Remove so we retry on the next re-announcement.
+                known_addrs.lock().unwrap().remove(&addr);
+            }
+        }
     }
 }
 
@@ -310,7 +370,7 @@ mod tests {
             Ok(())
         }
 
-        fn discover(&self) -> BoxStream<'_, PeerAnnouncement> {
+        fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
             Box::pin(stream::empty())
         }
 

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -82,7 +82,7 @@ impl Transport for BleTransport {
     /// for the Pathweave service UUID and decodes the short_id from service data.
     /// The stream ends when the sender is dropped (i.e., after `stop()` clears the
     /// adapter and the event stream closes).
-    fn discover(&self) -> BoxStream<'_, PeerAnnouncement> {
+    fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
         let adapter_arc = Arc::clone(&self.adapter);
         let (tx, rx) = mpsc::unbounded::<PeerAnnouncement>();
 

--- a/crates/pathweave-transport-quic/Cargo.toml
+++ b/crates/pathweave-transport-quic/Cargo.toml
@@ -17,6 +17,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 quinn = { workspace = true }
 rcgen = { workspace = true }
+mdns-sd = { workspace = true }
+getrandom = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -1,8 +1,12 @@
-use std::{net::SocketAddr, sync::Arc};
+use std::{
+    net::{IpAddr, Ipv4Addr, SocketAddr},
+    sync::Arc,
+};
 
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use mdns_sd::{ServiceDaemon, ServiceEvent, ServiceInfo};
 use pathweave_core::{
     Connection, PathweaveError, PeerAddress, PeerAnnouncement, Result, Transport, TransportCost,
     TransportKind,
@@ -19,6 +23,20 @@ use quinn::{
 use rcgen::CertifiedKey;
 use tokio::sync::Mutex;
 
+const SERVICE_TYPE: &str = "_pathweave._udp.local.";
+
+// --------------------------------------------------------------------------
+// mDNS state
+// --------------------------------------------------------------------------
+
+struct MdnsState {
+    daemon: ServiceDaemon,
+    service_fullname: String,
+    // Taken by discover() on first call; None afterwards.
+    announce_rx: Option<tokio::sync::mpsc::UnboundedReceiver<PeerAnnouncement>>,
+    bridge: tokio::task::JoinHandle<()>,
+}
+
 // --------------------------------------------------------------------------
 // Transport
 // --------------------------------------------------------------------------
@@ -26,13 +44,20 @@ use tokio::sync::Mutex;
 pub struct QuicTransport {
     listen_addr: SocketAddr,
     endpoint: Mutex<Option<Endpoint>>,
+    mdns: std::sync::Mutex<Option<MdnsState>>,
+    instance_name: String,
 }
 
 impl QuicTransport {
     pub fn new(listen_addr: SocketAddr) -> Self {
+        let mut bytes = [0u8; 8];
+        getrandom::getrandom(&mut bytes).expect("system entropy unavailable");
+        let instance_name = bytes.iter().map(|b| format!("{b:02x}")).collect::<String>();
         Self {
             listen_addr,
             endpoint: Mutex::new(None),
+            mdns: std::sync::Mutex::new(None),
+            instance_name,
         }
     }
 
@@ -44,6 +69,22 @@ impl QuicTransport {
             .as_ref()
             .and_then(|e| e.local_addr().ok())
     }
+}
+
+/// Finds the local IPv4 address the OS would route through when reaching an
+/// external host. Opens a UDP socket but sends no packets — just queries the
+/// routing table. Falls back to loopback if the query fails.
+fn local_ipv4() -> Ipv4Addr {
+    std::net::UdpSocket::bind("0.0.0.0:0")
+        .ok()
+        .and_then(|s| {
+            s.connect("8.8.8.8:80").ok()?;
+            match s.local_addr().ok()?.ip() {
+                IpAddr::V4(ip) => Some(ip),
+                _ => None,
+            }
+        })
+        .unwrap_or(Ipv4Addr::LOCALHOST)
 }
 
 fn make_server_config() -> Result<ServerConfig> {
@@ -138,7 +179,63 @@ impl Transport for QuicTransport {
         let server_config = make_server_config()?;
         let endpoint =
             Endpoint::server(server_config, self.listen_addr).map_err(PathweaveError::Io)?;
+        let local_addr = endpoint.local_addr().map_err(PathweaveError::Io)?;
         *self.endpoint.lock().await = Some(endpoint);
+
+        let daemon = ServiceDaemon::new().map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let host_name = format!("{}.local.", self.instance_name);
+        let info = ServiceInfo::new(
+            SERVICE_TYPE,
+            &self.instance_name,
+            &host_name,
+            IpAddr::V4(local_ipv4()),
+            local_addr.port(),
+            None,
+        )
+        .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let service_fullname = info.get_fullname().to_string();
+
+        daemon
+            .register(info)
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let browse_rx = daemon
+            .browse(SERVICE_TYPE)
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        // Bridge: drains flume ServiceEvents into a tokio mpsc channel so that
+        // discover() can return a BoxStream<'static, PeerAnnouncement> without
+        // borrowing from self.
+        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<PeerAnnouncement>();
+        let bridge = tokio::spawn(async move {
+            while let Ok(event) = browse_rx.recv_async().await {
+                if let ServiceEvent::ServiceResolved(info) = event {
+                    let port = info.get_port();
+                    for ip in info.get_addresses_v4() {
+                        let addr = SocketAddr::new(IpAddr::V4(*ip), port);
+                        if tx
+                            .send(PeerAnnouncement {
+                                address: PeerAddress::Quic(addr),
+                                short_id: None,
+                            })
+                            .is_err()
+                        {
+                            return;
+                        }
+                    }
+                }
+            }
+        });
+
+        *self.mdns.lock().unwrap() = Some(MdnsState {
+            daemon,
+            service_fullname,
+            announce_rx: Some(rx),
+            bridge,
+        });
+
         Ok(())
     }
 
@@ -146,11 +243,29 @@ impl Transport for QuicTransport {
         if let Some(ep) = self.endpoint.lock().await.take() {
             ep.close(0u32.into(), b"shutdown");
         }
+        if let Some(state) = self.mdns.lock().unwrap().take() {
+            let _ = state.daemon.unregister(&state.service_fullname);
+            let _ = state.daemon.stop_browse(SERVICE_TYPE);
+            state.bridge.abort();
+            let _ = state.daemon.shutdown();
+        }
         Ok(())
     }
 
-    fn discover(&self) -> BoxStream<'_, PeerAnnouncement> {
-        Box::pin(futures::stream::empty())
+    fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
+        let rx = self
+            .mdns
+            .lock()
+            .unwrap()
+            .as_mut()
+            .and_then(|state| state.announce_rx.take());
+
+        match rx {
+            Some(rx) => Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+                rx.recv().await.map(|ann| (ann, rx))
+            })),
+            None => Box::pin(futures::stream::empty()),
+        }
     }
 
     async fn connect(&self, peer: &PeerAnnouncement) -> Result<Box<dyn Connection>> {

--- a/notes/decisions/012-mdns-peer-discovery.md
+++ b/notes/decisions/012-mdns-peer-discovery.md
@@ -1,0 +1,155 @@
+# ADR 012: mDNS peer discovery via mdns-sd with background connect
+
+**Status:** Accepted
+
+## Context
+
+v0.1.0 requires callers to supply peer addresses manually (e.g. a `--peer` flag or
+`add_peer()` call). For the pw-chat demo to work without any configuration, QUIC nodes
+on the same LAN need to find each other automatically.
+
+mDNS (RFC 6762) with DNS-SD (RFC 6763) is the standard mechanism for local service
+discovery. It uses IP multicast to announce and browse services on the local link.
+Because multicast does not route across network boundaries, mDNS is inherently
+local-only: a Pathweave node can only discover and be discovered by other nodes on the
+same network segment.
+
+## Crate choice: mdns-sd
+
+Two viable Rust crates exist for mDNS:
+
+| Crate | Approach | System deps | Notes |
+|---|---|---|---|
+| `mdns-sd` | Pure Rust UDP multicast | None | Cross-platform: Linux, macOS, Windows |
+| `zeroconf` | Wraps Bonjour / avahi | avahi-daemon on Linux, Bonjour on macOS/Windows | Requires a running system daemon |
+
+`mdns-sd` is the right choice for Pathweave:
+
+- No system daemon dependency. A node on a freshly provisioned Linux machine does not
+  need avahi installed. On Windows, Bonjour is not present by default.
+- Pure Rust. No FFI boundary. Easier to audit, consistent behaviour across platforms.
+- Active maintenance and a straightforward browse/register API.
+
+## Service type and TXT record
+
+Service type: `_pathweave._udp.local.`
+
+The `_udp` suffix is correct: DNS-SD convention labels the service type with the
+underlying transport protocol of the application service being announced. QUIC runs
+over UDP.
+
+TXT record: empty (no fields).
+
+The TXT record deliberately contains no identity information. Specifically, the PeerId
+is not included. See the Privacy section below for the rationale.
+
+The mDNS instance name is a random hex string generated at node startup, distinct from
+the PeerId. A passive mDNS observer sees a service at an address but learns nothing
+about the Pathweave identity behind it.
+
+## Discovery and peer table population
+
+When `discover()` emits a `PeerAnnouncement`, the node does not yet know the remote
+peer's PeerId. A `peer_stream()` free function in `router.rs` drives this process:
+
+1. Calls `transport.discover()` to get a stream of `PeerAnnouncement`s.
+2. For each announcement, checks whether the announced address is already recorded in
+   the known addresses set (`known_addrs: Arc<Mutex<HashSet<SocketAddr>>>`). If it is,
+   the address is already being handled and the announcement is skipped.
+3. If the address is new, calls `try_connect()` to initiate a Noise_XX handshake. The
+   handshake authenticates both sides and reveals the remote static public key, from
+   which the PeerId is derived.
+4. On success, upserts `(PeerId, PeerAnnouncement)` into the shared peer table. If the
+   PeerId was already known at a different address (peer roamed), the entry is updated
+   to the new address.
+5. On handshake failure, logs and continues. The peer may not be a Pathweave node, or
+   may be temporarily unreachable.
+6. Skips the announcement if the discovered PeerId matches the local node's own
+   identity, to avoid adding a self-entry to the peer table.
+
+`peer_stream()` is a `pub(crate)` async function in `router.rs`, consistent with the
+module's existing pattern of private free functions (`try_connect`, `try_send`,
+`monitor`). It takes owned values so it can be spawned as a `'static` task. It accepts
+the shared peer table and known addresses set directly and writes to them internally,
+rather than returning a stream for the caller to drain:
+
+```rust
+pub(crate) async fn peer_stream(
+    transport: Arc<dyn Transport>,
+    identity: NodeIdentity,
+    started: watch::Receiver<bool>,
+    peers: Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>,
+    known_addrs: Arc<Mutex<HashSet<SocketAddr>>>,
+    local_peer_id: PeerId,
+)
+```
+
+`try_connect()` remains private to `router.rs`. No cross-module visibility is needed.
+
+`node.rs` spawns `peer_stream()` per transport in `register_transport()`, alongside the
+existing `accept_loop`. Both tasks receive a clone of the same `watch::Receiver<bool>`
+so they both wait for `started` to be `true` before doing work. Unlike `Arc<Notify>`,
+a watch receiver retains its last value, so a task that subscribes after the monitor
+fires still sees `true` without a race.
+
+### Deduplication: address-based, not PeerId-based
+
+Deduplication in the discover loop is keyed on announced address (IP:port), not PeerId,
+for the following reason:
+
+mDNS re-announces services periodically. A peer can also roam between addresses: DHCP
+lease renewal, switching between WiFi networks, interface changes. In all these cases,
+the discover loop receives a new announcement. If dedup were PeerId-based, the loop
+would skip the re-announcement for a known peer even when the address has changed,
+leaving a stale address in the peer table indefinitely. Subsequent sends would fail on
+connection refused with no recovery path.
+
+Address-based dedup handles both cases correctly:
+- Re-announcement with same address: address already in known addresses set, skip.
+- Peer roamed to new address: new address, do the handshake, upsert with updated
+  address.
+
+**Edge case:** If a node restarts with a new identity at the same IP:port (violating
+ADR 005's requirement that the static keypair be persisted across restarts), address-
+based dedup will keep the stale PeerId until the address disappears from mDNS and
+reappears. This is an operational error rather than a protocol gap. The assumption
+address-based dedup makes is: at any given IP:port, the Pathweave identity is stable
+for the lifetime of a process.
+
+## Privacy rationale
+
+Including the PeerId in the mDNS TXT record would be a privacy regression:
+
+- The PeerId is a stable, globally unique identifier derived from the node's static
+  public key. It does not change across sessions or network changes.
+- mDNS announcements are sent as multicast to the entire local network segment. Every
+  device on that segment receives them, including devices not running Pathweave.
+- A passive observer (a neighbour on a public WiFi, a network administrator) could
+  record which PeerId is at which IP address and build a persistent identity graph
+  across sessions and locations.
+
+By keeping the TXT record empty, a passive mDNS observer learns only that a Pathweave
+node exists at a given address. The PeerId is exchanged only inside the Noise_XX
+handshake, which is encrypted. A passive observer cannot derive the PeerId from the
+handshake transcript.
+
+This is consistent with the project's security-first principle. The trade-off is one
+background Noise_XX handshake per newly discovered address. The privacy gain is that
+stable identity is not broadcast in plaintext.
+
+**Remaining limitation:** A passive observer can still observe that a node at a given
+IP is running Pathweave (from the `_pathweave._udp.local.` service type). Protocol
+obfuscation and traffic analysis resistance are not in scope for v0.2.0.
+
+## Implications
+
+- `peers` in `PathweaveNode` changes from `HashMap<PeerId, PeerAnnouncement>` to
+  `Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>` so the peer_stream task can write to
+  it from a spawned context.
+- A second lookup structure — `Arc<Mutex<HashSet<SocketAddr>>>` — tracks known
+  addresses so the discover loop can skip re-announcements in O(1) without scanning
+  the peer table values.
+- `try_connect()` in `router.rs` remains private. `peer_stream()` is added as a new
+  `pub(crate)` free function in the same module.
+- mDNS is currently implemented only for the QUIC transport. BLE peer discovery uses
+  the existing GATT scanning mechanism and is out of scope for this ADR.


### PR DESCRIPTION
## What changed

- `QuicTransport` registers a `_pathweave._udp.local.` mDNS service on `start()` and browses for peers. A bridge task drains flume `ServiceEvent`s into a tokio mpsc channel so `discover()` returns `BoxStream<'static, PeerAnnouncement>` without borrowing from `self`. `stop()` unregisters the service and shuts the daemon down cleanly.

- `Transport::discover()` signature changed from `BoxStream<'_, ...>` to `BoxStream<'static, ...>`. The stream owns its state; the old lifetime bound was overly conservative. All implementations and test mocks return self-contained streams, so this is a no-friction change everywhere.

- `Router::register_transport()` now returns `watch::Receiver<bool>` instead of `Arc<Notify>`. Both `accept_loop` and `peer_stream` receive a clone of the same receiver and wait on it. A `watch` receiver retains its last value, so a task that subscribes after the monitor fires still sees `true` without a race — the key correctness improvement over `Notify`.

- New `pub(crate) peer_stream()` async fn in `router.rs` drives discovery: waits for transport start, drains `transport.discover()`, and for each new address performs a Noise_XX handshake to learn the remote PeerId. Dedup is address-based (not PeerId-based) so roaming peers get a fresh handshake at the new address rather than a stale skip.

- `PathweaveNode.peers` changes to `Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>` so the discover task can write to it from a spawned context. `known_addrs: Arc<Mutex<HashSet<SocketAddr>>>` added as a dedup-only set — not authoritative for routing. `peer_stream` only upserts to `peers`, never removes. This invariant is documented in a code comment and is what makes the concurrent `add_peer()` edge case benign.

- ADR 012 committed alongside implementation.

## Why

Closes #46. Manual `--peer` flags are the only way to connect nodes today. mDNS makes the pw-chat demo work with zero configuration on a LAN, which is the intended v0.2.0 experience.

Privacy: the TXT record is empty. No PeerId or key material is advertised over mDNS. Identity is learned only inside the Noise_XX handshake, whose transcript is encrypted. A passive observer sees only that a Pathweave node exists at a given address.

Two deviations from the original issue spec, both improvements: `peer_stream` is an `async fn` that writes to the peer table directly rather than returning a `Stream` for the caller to drain (avoids lifetime complexity); `watch::Receiver<bool>` replaces `Arc<Notify>` for the started signal (eliminates the multiple-waiter race).

## How to test

```
# Terminal 1
cargo run -p pw-chat

# Terminal 2 (same LAN, no --peer flag needed)
cargo run -p pw-chat
```

Both nodes should discover each other within a few seconds and exchange messages. To verify manually: `cargo test` passes on all platforms; the full-stack QUIC roundtrip test exercises the transport layer end to end.

## Security considerations

- mDNS advertisements are multicast to the entire local network segment. The TXT record is intentionally empty — no PeerId, no public key. A passive observer learns only that a Pathweave process is running at a given IP and port, consistent with ADR 012.
- The Noise_XX handshake triggered per discovered address is the same authenticated exchange used for all Pathweave connections. No new authentication surface is introduced.
- `local_ipv4()` opens a UDP socket to `8.8.8.8:80` to determine the outbound interface IP. No packets are sent; this is a routing table query only. Falls back to loopback if the query fails, in which case mDNS registration is limited to loopback (expected behaviour on an isolated machine).