### PR TITLE
feat(router): network health monitoring via interface polling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1248,6 +1248,7 @@ dependencies = [
  "bytes",
  "futures",
  "getrandom 0.2.17",
+ "if-addrs",
  "proptest",
  "snow",
  "thiserror 2.0.18",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ getrandom = "0.2"
 
 # discovery
 mdns-sd = "0.11"
+if-addrs = "0.13"
 
 # testing
 proptest = "1"

--- a/crates/pathweave-core/Cargo.toml
+++ b/crates/pathweave-core/Cargo.toml
@@ -20,6 +20,7 @@ bs58 = { workspace = true }
 x25519-dalek = { workspace = true }
 bp7 = { workspace = true }
 getrandom = { workspace = true }
+if-addrs = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
+use std::net::{Ipv4Addr, SocketAddr};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -15,6 +15,7 @@ use crate::{
 
 const MAX_SEND_ATTEMPTS: usize = 3;
 const RETRY_BACKOFF: Duration = Duration::from_secs(1);
+const NETWORK_POLL_INTERVAL: Duration = Duration::from_secs(3);
 
 struct TransportEntry {
     transport: Arc<dyn Transport>,
@@ -54,7 +55,7 @@ impl Router {
 
         let t = Arc::clone(&transport);
         let a = Arc::clone(&available);
-        let task = tokio::spawn(monitor(t, a, started_tx));
+        let task = tokio::spawn(health_monitor(t, started_tx, a));
 
         self.transports.push(TransportEntry {
             transport,
@@ -184,20 +185,77 @@ impl Drop for Router {
     }
 }
 
-/// Monitors a single transport. Marks it available after start() succeeds,
-/// signals `started` so waiting tasks can begin, then parks until the router
-/// is dropped. Using a watch::Sender means any task that subscribes late still
-/// sees the `true` value without a race.
-async fn monitor(
+/// Manages the full lifecycle of a single transport: initial start, periodic
+/// interface polling, and restart on address change.
+///
+/// Operates in one of two modes. Normal mode: polls the non-loopback IPv4
+/// address set every NETWORK_POLL_INTERVAL; restarts the transport when the
+/// set changes. Recovery mode: entered when start() fails; retries start()
+/// unconditionally on every tick without comparing address sets. This handles
+/// the case where the interface stays down: empty == empty would never trigger
+/// a restart in normal mode, so an unconditional retry path is required.
+///
+/// Sets available and sends on the started watch channel to signal consumers
+/// (accept_loop, peer_stream) on each transition.
+pub(crate) async fn health_monitor(
     transport: Arc<dyn Transport>,
-    available: Arc<AtomicBool>,
     started: watch::Sender<bool>,
+    available: Arc<AtomicBool>,
 ) {
-    if transport.start().await.is_ok() {
+    let mut prev_addrs = current_ipv4_addrs();
+    let mut in_recovery = if transport.start().await.is_ok() {
         available.store(true, Ordering::Release);
         let _ = started.send(true);
-        std::future::pending::<()>().await;
+        false
+    } else {
+        tracing::warn!(
+            transport = transport.name(),
+            "initial start failed; entering recovery mode"
+        );
+        true
+    };
+
+    loop {
+        tokio::time::sleep(NETWORK_POLL_INTERVAL).await;
+        let curr_addrs = current_ipv4_addrs();
+
+        if !in_recovery && curr_addrs == prev_addrs {
+            continue;
+        }
+
+        available.store(false, Ordering::Release);
+        let _ = started.send(false);
+        let _ = transport.stop().await;
+
+        if transport.start().await.is_ok() {
+            available.store(true, Ordering::Release);
+            let _ = started.send(true);
+            prev_addrs = curr_addrs;
+            in_recovery = false;
+            tracing::info!(
+                transport = transport.name(),
+                "transport restarted after address change"
+            );
+        } else {
+            tracing::warn!(
+                transport = transport.name(),
+                "transport restart failed; will retry"
+            );
+            in_recovery = true;
+        }
     }
+}
+
+fn current_ipv4_addrs() -> HashSet<Ipv4Addr> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|i| !i.is_loopback())
+        .filter_map(|i| match i.addr {
+            if_addrs::IfAddr::V4(v4) => Some(v4.ip),
+            _ => None,
+        })
+        .collect()
 }
 
 /// Dials the transport, completes the Noise_XX handshake, and returns the remote PeerId.
@@ -252,7 +310,7 @@ async fn try_send(
     }
 }
 
-/// Drives mDNS peer discovery for a single transport.
+/// Drives mDNS peer discovery for a single transport across restarts.
 ///
 /// Waits for the transport to start, then drains its discover() stream. For
 /// each announced address that is not already in `known_addrs`, performs a
@@ -261,9 +319,10 @@ async fn try_send(
 /// removes the address from `known_addrs` so the next re-announcement retries.
 /// Skips self-announcements by comparing the remote PeerId with `local_peer_id`.
 ///
-/// Address-based dedup (not PeerId-based) handles peer roaming: if a known
-/// peer reappears at a new address, the new address is not in `known_addrs`
-/// and a fresh handshake is performed, updating the peer table entry.
+/// When the discover stream ends (transport stopped by health_monitor), loops
+/// back and waits for the next started -> stopped -> started cycle. The
+/// wait_for(false) step prevents a spin loop on transports whose discover()
+/// returns an empty stream immediately.
 pub(crate) async fn peer_stream(
     transport: Arc<dyn Transport>,
     identity: NodeIdentity,
@@ -272,34 +331,39 @@ pub(crate) async fn peer_stream(
     known_addrs: Arc<Mutex<HashSet<SocketAddr>>>,
     local_peer_id: PeerId,
 ) {
-    let _ = started.wait_for(|v| *v).await;
-    let mut discover = transport.discover();
-    while let Some(announcement) = discover.next().await {
-        let addr = match &announcement.address {
-            PeerAddress::Quic(addr) => *addr,
-            _ => continue,
-        };
+    loop {
+        let _ = started.wait_for(|v| *v).await;
+        let mut discover = transport.discover();
+        while let Some(announcement) = discover.next().await {
+            let addr = match &announcement.address {
+                PeerAddress::Quic(addr) => *addr,
+                _ => continue,
+            };
 
-        // Skip re-announcements from already-connected addresses (O(1) check).
-        if !known_addrs.lock().unwrap().insert(addr) {
-            continue;
-        }
+            // Skip re-announcements from already-connected addresses (O(1) check).
+            if !known_addrs.lock().unwrap().insert(addr) {
+                continue;
+            }
 
-        match try_connect(transport.as_ref(), &announcement, &identity).await {
-            Ok(peer_id) if peer_id == local_peer_id => {
-                // Self-discovery: keep addr in known_addrs so we don't retry.
-                tracing::debug!(addr = %addr, "mDNS: discovered self; skipping");
-            }
-            Ok(peer_id) => {
-                tracing::debug!(addr = %addr, peer = %peer_id, "mDNS: peer connected");
-                peers.lock().unwrap().insert(peer_id, announcement);
-            }
-            Err(e) => {
-                tracing::debug!(addr = %addr, "mDNS: handshake failed: {}", e);
-                // Remove so we retry on the next re-announcement.
-                known_addrs.lock().unwrap().remove(&addr);
+            match try_connect(transport.as_ref(), &announcement, &identity).await {
+                Ok(peer_id) if peer_id == local_peer_id => {
+                    // Self-discovery: keep addr in known_addrs so we don't retry.
+                    tracing::debug!(addr = %addr, "mDNS: discovered self; skipping");
+                }
+                Ok(peer_id) => {
+                    tracing::debug!(addr = %addr, peer = %peer_id, "mDNS: peer connected");
+                    peers.lock().unwrap().insert(peer_id, announcement);
+                }
+                Err(e) => {
+                    tracing::debug!(addr = %addr, "mDNS: handshake failed: {}", e);
+                    // Remove so we retry on the next re-announcement.
+                    known_addrs.lock().unwrap().remove(&addr);
+                }
             }
         }
+        // Stream ended (transport stopped). Wait for the stopped signal before
+        // looping so we don't spin if discover() returns an empty stream.
+        let _ = started.wait_for(|v| !v).await;
     }
 }
 
@@ -695,5 +759,248 @@ mod tests {
         let identity = NodeIdentity::generate();
         let result = router.connect(&dummy_peer(), &identity).await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
+    }
+
+    // --- health_monitor tests -------------------------------------------------
+
+    struct StartFailNTimes {
+        remaining_failures: Arc<AtomicUsize>,
+        stop_count: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Transport for StartFailNTimes {
+        async fn start(&self) -> Result<()> {
+            let n =
+                self.remaining_failures
+                    .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
+                        if n > 0 {
+                            Some(n - 1)
+                        } else {
+                            None
+                        }
+                    });
+            if n.is_ok() {
+                Err(PathweaveError::Transport("start: injected failure".into()))
+            } else {
+                Ok(())
+            }
+        }
+        async fn stop(&self) -> Result<()> {
+            self.stop_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+        fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
+            Box::pin(stream::empty())
+        }
+        async fn connect(&self, _: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
+            Err(PathweaveError::Transport("not used".into()))
+        }
+        async fn accept(&self) -> Result<Box<dyn Connection>> {
+            futures::future::pending::<()>().await;
+            unreachable!()
+        }
+        fn mtu_hint(&self) -> usize {
+            65535
+        }
+        fn cost(&self) -> TransportCost {
+            TransportCost::Free
+        }
+        fn kind(&self) -> TransportKind {
+            TransportKind::Ble
+        }
+        fn name(&self) -> &'static str {
+            "start-fail-n-times"
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn health_monitor_initial_success_sets_available() {
+        let (t, _, _) = make_transport(TransportCost::Free, TransportKind::Ble, false);
+        let available = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = watch::channel(false);
+
+        tokio::spawn(health_monitor(t, started_tx, Arc::clone(&available)));
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert!(available.load(Ordering::Acquire));
+        assert!(*started_rx.borrow());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn health_monitor_enters_recovery_and_retries_on_next_tick() {
+        let failures = Arc::new(AtomicUsize::new(1));
+        let stop_count = Arc::new(AtomicUsize::new(0));
+        let transport = Arc::new(StartFailNTimes {
+            remaining_failures: Arc::clone(&failures),
+            stop_count: Arc::clone(&stop_count),
+        });
+        let available = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = watch::channel(false);
+
+        tokio::spawn(health_monitor(
+            transport,
+            started_tx,
+            Arc::clone(&available),
+        ));
+
+        // Yield so the initial start() runs and fails.
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            !available.load(Ordering::Acquire),
+            "should be unavailable after failed start"
+        );
+        assert!(!*started_rx.borrow());
+
+        // Advance one poll interval: recovery mode retries start() unconditionally.
+        tokio::time::advance(NETWORK_POLL_INTERVAL + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert!(
+            available.load(Ordering::Acquire),
+            "should be available after recovery retry"
+        );
+        assert!(*started_rx.borrow());
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn health_monitor_recovery_does_not_require_address_change() {
+        // Transport fails twice, then succeeds. Verifies that recovery mode retries
+        // on every tick without needing the address set to change between ticks.
+        let failures = Arc::new(AtomicUsize::new(2));
+        let stop_count = Arc::new(AtomicUsize::new(0));
+        let transport = Arc::new(StartFailNTimes {
+            remaining_failures: Arc::clone(&failures),
+            stop_count: Arc::clone(&stop_count),
+        });
+        let available = Arc::new(AtomicBool::new(false));
+        let (started_tx, started_rx) = watch::channel(false);
+
+        tokio::spawn(health_monitor(
+            transport,
+            started_tx,
+            Arc::clone(&available),
+        ));
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        assert!(!available.load(Ordering::Acquire));
+
+        // First tick: recovery retry fails again (second failure).
+        tokio::time::advance(NETWORK_POLL_INTERVAL + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        assert!(
+            !available.load(Ordering::Acquire),
+            "still in recovery after second failure"
+        );
+
+        // Second tick: recovery retry succeeds (no third failure).
+        tokio::time::advance(NETWORK_POLL_INTERVAL + Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+        assert!(
+            available.load(Ordering::Acquire),
+            "recovered on second retry"
+        );
+        assert!(*started_rx.borrow());
+    }
+
+    // --- peer_stream tests ----------------------------------------------------
+
+    struct ControllableDiscoverTransport {
+        // Each pop_front dequeues the next discover() stream in call order.
+        streams: std::sync::Mutex<std::collections::VecDeque<BoxStream<'static, PeerAnnouncement>>>,
+        discover_calls: Arc<AtomicUsize>,
+    }
+
+    #[async_trait]
+    impl Transport for ControllableDiscoverTransport {
+        async fn start(&self) -> Result<()> {
+            Ok(())
+        }
+        async fn stop(&self) -> Result<()> {
+            Ok(())
+        }
+        fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
+            self.discover_calls.fetch_add(1, Ordering::Relaxed);
+            self.streams
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Box::pin(stream::empty()))
+        }
+        async fn connect(&self, _: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
+            Err(PathweaveError::Transport("not used".into()))
+        }
+        async fn accept(&self) -> Result<Box<dyn Connection>> {
+            futures::future::pending::<()>().await;
+            unreachable!()
+        }
+        fn mtu_hint(&self) -> usize {
+            65535
+        }
+        fn cost(&self) -> TransportCost {
+            TransportCost::Free
+        }
+        fn kind(&self) -> TransportKind {
+            TransportKind::Quic
+        }
+        fn name(&self) -> &'static str {
+            "controllable-discover"
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_stream_calls_discover_again_after_restart() {
+        // Two streams: both empty. Verify discover() is called twice after a
+        // stopped -> started cycle.
+        let discover_calls = Arc::new(AtomicUsize::new(0));
+        let transport = Arc::new(ControllableDiscoverTransport {
+            streams: std::sync::Mutex::new(std::collections::VecDeque::from([
+                Box::pin(stream::empty()) as BoxStream<'static, PeerAnnouncement>,
+                Box::pin(stream::empty()) as BoxStream<'static, PeerAnnouncement>,
+            ])),
+            discover_calls: Arc::clone(&discover_calls),
+        });
+        let (started_tx, started_rx) = watch::channel(false);
+        let peers = Arc::new(Mutex::new(HashMap::new()));
+        let known_addrs = Arc::new(Mutex::new(HashSet::new()));
+        let local_peer_id = NodeIdentity::generate().peer_id().clone();
+
+        tokio::spawn(peer_stream(
+            transport,
+            NodeIdentity::generate(),
+            started_rx,
+            Arc::clone(&peers),
+            Arc::clone(&known_addrs),
+            local_peer_id,
+        ));
+
+        // Start the transport: peer_stream calls discover() (first call, empty stream ends).
+        let _ = started_tx.send(true);
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // peer_stream is now in wait_for(false). Send false to let it proceed.
+        let _ = started_tx.send(false);
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Send true again: peer_stream calls discover() a second time.
+        let _ = started_tx.send(true);
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        assert_eq!(
+            discover_calls.load(Ordering::Relaxed),
+            2,
+            "discover() must be called again after a restart cycle"
+        );
     }
 }

--- a/notes/decisions/013-network-health-monitoring.md
+++ b/notes/decisions/013-network-health-monitoring.md
@@ -1,0 +1,211 @@
+# ADR 013: Network health monitoring via interface polling and transport restart
+
+**Status:** Accepted
+
+## Context
+
+v0.2.0 adds mDNS peer discovery (ADR 012). mDNS registrations include the node's current
+local IPv4 address, obtained at `start()` time via a UDP routing-table query. If the
+network interface changes after startup (DHCP lease renewal, a WiFi switch, or an
+interface bounce), two things go wrong simultaneously:
+
+1. The mDNS record still advertises the old address. Peers that resolve it find an
+   unreachable endpoint.
+2. The QUIC endpoint, bound to `0.0.0.0:PORT`, will re-bind correctly on the next
+   incoming connection attempt (because `0.0.0.0` accepts all interfaces), but new
+   outgoing connections from this node use the wrong source address as the mDNS hint
+   until mDNS is re-registered.
+
+The primary failure mode is that discovered peers can no longer reach this node. The
+fix is to restart the transport on interface change: `stop()` tears down the mDNS
+registration and QUIC endpoint, `start()` re-queries the routing table and re-registers
+with the current address.
+
+## What to monitor
+
+The minimum signal needed is: have the non-loopback IPv4 addresses on this machine
+changed since the last check?
+
+Full OS event integration would deliver this with minimal latency:
+
+| Platform | API |
+|---|---|
+| Linux | `rtnetlink` NEWADDR/DELADDR events via the `netlink-sys` or `rtnetlink` crates |
+| macOS / iOS | `NWPathMonitor` (Network.framework) |
+| Windows | `WinRT NetworkInformation.NetworkStatusChanged` |
+
+Each API is platform-specific. Wrapping all three for a single feature adds significant
+complexity and conditional compilation surface. None of them is available via a
+single cross-platform Rust crate at the level of stability we require.
+
+The `if-addrs` crate (already present as a transitive dependency via `mdns-sd`) provides
+a synchronous `get_if_addrs()` call that returns the current interface address list.
+Polling this on a fixed interval is a workable approximation. The lag is at most one
+poll interval. For a LAN mesh application, a few seconds of stale advertisement is
+acceptable: peers will fail to connect, retry, and succeed after the re-registration
+propagates.
+
+OS event integration is deferred to v0.3.0.
+
+## Decision
+
+### Polling
+
+A background task, `health_monitor()` in `router.rs`, polls `get_if_addrs()` every
+`NETWORK_POLL_INTERVAL` (3 seconds). On each tick it computes the set of non-loopback
+IPv4 addresses currently assigned to the machine and compares it against the set from
+the previous tick. If the sets differ, it triggers a transport restart.
+
+`NETWORK_POLL_INTERVAL` is a named constant in `router.rs`:
+
+```rust
+const NETWORK_POLL_INTERVAL: Duration = Duration::from_secs(3);
+```
+
+The function signature:
+
+```rust
+pub(crate) async fn health_monitor(
+    transport: Arc<dyn Transport>,
+    started: watch::Sender<bool>,
+    available: Arc<AtomicBool>,
+)
+```
+
+`node.rs` spawns `health_monitor()` in `register_transport()` alongside the existing
+`accept_loop` and `peer_stream` tasks. It receives the `watch::Sender<bool>` that was
+created for the same transport.
+
+### Transport restart
+
+`health_monitor()` operates in one of two modes.
+
+**Normal mode:** On each tick, compute the current set of non-loopback IPv4 addresses.
+If it equals the set from the previous tick, do nothing. If the sets differ, execute the
+restart sequence below. On a successful restart, update the previous address set to the
+current one and remain in normal mode.
+
+**Recovery mode:** Entered when `start()` fails. On each tick, unconditionally retry
+`start()` without comparing address sets. The previous address set is not updated while
+in recovery mode. On a successful `start()`, update the previous address set to the
+current one and return to normal mode.
+
+Recovery mode exists because the change-detection path fails if `start()` fails and the
+interface stays down: both the current and previous address sets would be empty, the
+comparison would show no change, and the transport would stay stopped indefinitely. An
+unconditional retry path is required.
+
+The restart sequence (executed from normal mode on address-set change, and on every tick
+in recovery mode):
+
+1. Sends `false` on the `started` watch channel and sets `available` to `false`. This
+   causes `peer_stream` to re-enter `started.wait_for(|v| *v)` and prevents `send()`
+   from routing new messages to this transport.
+2. Calls `transport.stop().await`. This unregisters the mDNS service, aborts the bridge
+   task, shuts down the mDNS daemon, and closes the QUIC endpoint, releasing the port.
+3. Calls `transport.start().await`. This re-queries the routing table for the current
+   local IPv4 address, creates a fresh `MdnsState` (including a new bridge channel and
+   a new `announce_rx`), re-registers the service with the new address, spawns the bridge
+   task, and re-binds the QUIC endpoint to `0.0.0.0:PORT`. Creating a fresh `MdnsState`
+   each time is what allows `transport.discover()` to return a valid stream on subsequent
+   calls: the first call takes `announce_rx` out of the state via `Option::take()`,
+   leaving `None`; `start()` repopulates it.
+4. On success: sets `available` to `true` and sends `true` on the `started` watch
+   channel. `peer_stream` wakes, calls `transport.discover()`, and resumes discovery.
+   `send()` can route to this transport again.
+5. On failure: logs the error and enters (or remains in) recovery mode.
+
+Re-binding to `0.0.0.0:PORT` after an interface change does not conflict with the
+previous endpoint because `stop()` closes the endpoint and releases the port before
+`start()` re-binds.
+
+v0.2.0 uses lazy connections: `try_send()` opens a new QUIC connection per send and
+closes it after the ACK round-trip (ADR 009). There are no persistent connections to
+lose during a restart. A message in-flight during a restart will time out and the
+at-least-once retry loop (ADR 011) will retry it on the restarted transport.
+
+### peer_stream resilience
+
+`peer_stream` is a long-running task that must survive transport restarts. The current
+implementation calls `transport.discover()` once and drains the resulting stream. After
+a restart, the old bridge task is aborted and the old stream yields `None`. The while
+loop exits and the task dies silently.
+
+`peer_stream` is changed to loop across restarts:
+
+```rust
+loop {
+    let _ = started.wait_for(|v| *v).await;
+    let mut discover = transport.discover();
+    while let Some(announcement) = discover.next().await {
+        // same body as before
+    }
+    // stream ended: transport was stopped. loop back and wait for restart.
+}
+```
+
+The watch channel carries the restart signal without any additional mechanism:
+`health_monitor()` sends `false` before `stop()` and `true` after a successful `start()`.
+`peer_stream` observes the transition and re-calls `discover()` at the right moment.
+
+`known_addrs` is not cleared on restart. An address that was in-flight before the restart
+remains in the set. This is conservative: the peer at that address may now be
+unreachable (their interface also changed), but the next mDNS re-announcement from that
+peer will arrive at a new address (or the same address if only this node's interface
+changed), and the discover loop will handle it correctly. Clearing `known_addrs` on
+restart would cause redundant handshake attempts to all previously known peers; keeping
+it avoids that churn.
+
+## Rationale
+
+**Why not clear known_addrs on restart?**
+
+If this node's interface changes but a peer's interface did not, the peer is still at
+the same address. Its mDNS re-announcement arrives at the same address that is already
+in `known_addrs`. Clearing the set would trigger a redundant handshake to every
+previously known peer on every restart. Keeping the set means we only handshake peers
+at genuinely new addresses.
+
+**Why polling and not OS events for v0.2.0?**
+
+Three platform-specific event integrations with conditional compilation, separate
+dependency trees, and distinct testing requirements. Polling with `if-addrs` is one
+function call on all platforms using a dependency already in the graph. The latency
+trade-off (up to 3 seconds) is acceptable for a LAN mesh where peers are persistent
+and re-registration propagates quickly.
+
+**Why 3 seconds?**
+
+Fast enough that a roaming node re-announces within one handshake timeout (5 seconds,
+ADR 009). Slow enough that a brief interface flap (a WiFi reconnect that resolves in
+under a second) does not trigger an unnecessary restart. One syscall every 3 seconds
+per node is negligible overhead.
+
+**Why does health_monitor own the watch::Sender exclusively?**
+
+`monitor()` currently takes the `watch::Sender<bool>` to send the initial `true` after
+`start()` succeeds. `health_monitor()` also needs the sender to toggle between `false`
+and `true` on restart. Sharing the sender between the two functions would require an
+`Arc<watch::Sender<bool>>`, adding complexity for no benefit.
+
+The clean resolution: absorb the initial `start()` call into `health_monitor()`. The
+task is responsible for the full transport lifecycle (initial start, detection, and
+restart) and owns the sender exclusively. `monitor()` as a standalone function is
+removed. `register_transport()` spawns `health_monitor()` first (which calls `start()`
+and sends the initial `true`), then spawns `accept_loop` and `peer_stream` with cloned
+receivers. This eliminates the split responsibility and the sharing problem at once.
+
+## Implications
+
+- `monitor()` in `router.rs` is removed. `health_monitor()` absorbs its responsibility.
+- `peer_stream()` gains an outer `loop` so it survives transport restarts.
+- `register_transport()` in `node.rs` spawns three tasks per transport:
+  `health_monitor`, `accept_loop`, and `peer_stream`.
+- `health_monitor()` receives `available: Arc<AtomicBool>` from `TransportEntry` and
+  updates it alongside the watch sender. The `send()` path continues to read `available`
+  without change.
+- `known_addrs` is not cleared on restart (see rationale above).
+- `if-addrs` is added as a direct dependency of `pathweave-core` even though it is
+  already transitively present, to make the dependency explicit and prevent it from
+  disappearing silently if `mdns-sd` ever changes its own dependency tree.
+- OS event integration (rtnetlink / NWPathMonitor / WinRT) is deferred to v0.3.0.


### PR DESCRIPTION
## What changed

Replaces the one-shot `monitor()` with `health_monitor()`, which manages the full transport lifecycle for the life of the node. Adds a two-state polling loop (normal mode / recovery mode) that detects network interface changes and restarts the transport so mDNS re-registers with the current address. Adds an outer loop to `peer_stream` so it survives transport restarts. Adds `if-addrs` as a direct dependency of `pathweave-core`. Commits ADR 013.

## Why

`monitor()` called `start()` once and parked forever. If the network interface changed after startup, mDNS kept advertising a stale address and there was no recovery path short of restarting the process. This was the last gap blocking mDNS from working reliably on roaming nodes.

The two-state machine is necessary because a single change-detection loop is not enough: if `start()` fails and the interface stays down, both the current and previous address sets are empty, the comparison shows no change, and the transport stays stopped indefinitely. Recovery mode retries `start()` unconditionally on every tick until it succeeds.

The `wait_for(false)` step added to `peer_stream` after the inner loop exits prevents a spin loop on transports whose `discover()` returns an empty stream immediately (e.g. BLE), while still correctly restarting discovery after a health-monitor-driven restart.

Closes #47

## How to test

- [x] `health_monitor_initial_success_sets_available`: initial `start()` success sets `available = true` and fires the watch channel
- [x] `health_monitor_enters_recovery_and_retries_on_next_tick`: single initial failure enters recovery; one poll interval later the retry succeeds
- [x] `health_monitor_recovery_does_not_require_address_change`: two consecutive failures both retry without needing the address set to change between ticks
- [x] `peer_stream_calls_discover_again_after_restart`: `discover()` is called again after a stopped/started cycle; outer loop confirmed
- [x] All 37 existing tests pass
- [x] `cargo fmt --all` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean

## Security considerations

No new network surface is introduced. `health_monitor` calls `get_if_addrs()` (a read-only OS call) and drives the existing `stop()`/`start()` lifecycle that was already trusted. The mDNS re-registration on restart keeps the TXT record empty (no PeerId advertised) per ADR 012. The 3-second polling interval is long enough that it cannot be used as a timing side-channel by a local network observer.