### PR TITLE
feat(ble): Linux peripheral mode and Transport::start(&NodeIdentity)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "bluer"
+version = "0.17.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af68112f5c60196495c8b0eea68349817855f565df5b04b2477916d09fb1a901"
+dependencies = [
+ "custom_debug",
+ "dbus",
+ "dbus-crossroads",
+ "dbus-tokio",
+ "displaydoc",
+ "futures",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "macaddr",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "strum",
+ "tokio",
+ "tokio-stream",
+ "uuid",
+]
+
+[[package]]
 name = "bluez-async"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -542,6 +571,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "custom_debug"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2da7d1ad9567b3e11e877f1d7a0fa0360f04162f94965fc4448fbed41a65298e"
+dependencies = [
+ "custom_debug_derive",
+]
+
+[[package]]
+name = "custom_debug_derive"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a707ceda8652f6c7624f2be725652e9524c815bf3b9d55a0b2320be2303f9c11"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "synstructure",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "dashmap"
 version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +668,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dbus-crossroads"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64bff0bd181fba667660276c6b7ebdc50cff37ce593e7adf9e734f89c8f444e8"
+dependencies = [
+ "dbus",
+]
+
+[[package]]
 name = "dbus-tokio"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,6 +712,17 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "either"
@@ -875,6 +981,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "humantime"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -885,6 +997,12 @@ name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "if-addrs"
@@ -1084,6 +1202,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1132,6 +1256,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1145,6 +1281,17 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -1262,6 +1409,7 @@ name = "pathweave-transport-ble"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bluer",
  "btleplug",
  "bytes",
  "futures",
@@ -1305,6 +1453,26 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64",
  "serde_core",
+]
+
+[[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2046,6 +2214,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +2261,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2334,7 +2535,9 @@ version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
+ "getrandom 0.4.2",
  "js-sys",
+ "serde_core",
  "wasm-bindgen",
 ]
 

--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -216,7 +216,7 @@ pub trait MessageHandler: Send + Sync {
 
 #[async_trait]
 pub trait Transport: Send + Sync {
-    async fn start(&self) -> Result<()>;
+    async fn start(&self, identity: &NodeIdentity) -> Result<()>;
     async fn stop(&self) -> Result<()>;
     fn discover(&self) -> BoxStream<'static, PeerAnnouncement>;
     async fn connect(&self, peer: &PeerAnnouncement) -> Result<Box<dyn Connection>>;

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -109,7 +109,9 @@ impl PathweaveNode {
         let identity = self.identity.clone();
         let handler = Arc::clone(&self.handler);
         let dedup = Arc::clone(&self.dedup);
-        let started = self.router.register_transport(Arc::clone(&arc));
+        let started = self
+            .router
+            .register_transport(Arc::clone(&arc), Arc::new(self.identity.clone()));
 
         tokio::spawn(accept_loop(
             Arc::clone(&arc),
@@ -336,7 +338,7 @@ mod tests {
 
     #[async_trait]
     impl crate::Transport for MockTransport {
-        async fn start(&self) -> Result<()> {
+        async fn start(&self, _identity: &NodeIdentity) -> Result<()> {
             Ok(())
         }
 
@@ -404,7 +406,7 @@ mod tests {
 
     #[async_trait]
     impl crate::Transport for AcceptMockTransport {
-        async fn start(&self) -> Result<()> {
+        async fn start(&self, _identity: &NodeIdentity) -> Result<()> {
             Ok(())
         }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -49,13 +49,17 @@ impl Router {
     /// the discover loop) should `wait_for(|v| *v).await` on a clone of the
     /// returned receiver. Unlike `Notify`, a watch receiver that arrives late
     /// still sees `true` because the value is retained.
-    pub fn register_transport(&mut self, transport: Arc<dyn Transport>) -> watch::Receiver<bool> {
+    pub fn register_transport(
+        &mut self,
+        transport: Arc<dyn Transport>,
+        identity: Arc<NodeIdentity>,
+    ) -> watch::Receiver<bool> {
         let available = Arc::new(AtomicBool::new(false));
         let (started_tx, started_rx) = watch::channel(false);
 
         let t = Arc::clone(&transport);
         let a = Arc::clone(&available);
-        let task = tokio::spawn(health_monitor(t, started_tx, a));
+        let task = tokio::spawn(health_monitor(t, started_tx, a, identity));
 
         self.transports.push(TransportEntry {
             transport,
@@ -201,9 +205,10 @@ pub(crate) async fn health_monitor(
     transport: Arc<dyn Transport>,
     started: watch::Sender<bool>,
     available: Arc<AtomicBool>,
+    identity: Arc<NodeIdentity>,
 ) {
     let mut prev_addrs = current_ipv4_addrs();
-    let mut in_recovery = if transport.start().await.is_ok() {
+    let mut in_recovery = if transport.start(&identity).await.is_ok() {
         available.store(true, Ordering::Release);
         let _ = started.send(true);
         false
@@ -227,7 +232,7 @@ pub(crate) async fn health_monitor(
         let _ = started.send(false);
         let _ = transport.stop().await;
 
-        if transport.start().await.is_ok() {
+        if transport.start(&identity).await.is_ok() {
             available.store(true, Ordering::Release);
             let _ = started.send(true);
             prev_addrs = curr_addrs;
@@ -426,7 +431,7 @@ mod tests {
 
     #[async_trait]
     impl Transport for MockTransport {
-        async fn start(&self) -> Result<()> {
+        async fn start(&self, _identity: &NodeIdentity) -> Result<()> {
             Ok(())
         }
 
@@ -561,9 +566,10 @@ mod tests {
         let (quic, _quic_rx, quic_count) =
             make_transport(TransportCost::Metered, TransportKind::Quic, false);
 
+        let identity = Arc::new(NodeIdentity::generate());
         let mut router = Router::new();
-        router.register_transport(ble);
-        router.register_transport(quic);
+        router.register_transport(ble, Arc::clone(&identity));
+        router.register_transport(quic, Arc::clone(&identity));
 
         // Yield so monitoring tasks run start() and set available = true.
         tokio::task::yield_now().await;
@@ -597,9 +603,10 @@ mod tests {
         let (quic, mut quic_rx, quic_count) =
             make_transport(TransportCost::Metered, TransportKind::Quic, false);
 
+        let identity = Arc::new(NodeIdentity::generate());
         let mut router = Router::new();
-        router.register_transport(ble);
-        router.register_transport(quic);
+        router.register_transport(ble, Arc::clone(&identity));
+        router.register_transport(quic, Arc::clone(&identity));
 
         tokio::task::yield_now().await;
         tokio::task::yield_now().await;
@@ -636,9 +643,10 @@ mod tests {
         let (quic, _quic_rx, quic_count) =
             make_transport(TransportCost::Metered, TransportKind::Quic, true);
 
+        let identity = Arc::new(NodeIdentity::generate());
         let mut router = Router::new();
-        router.register_transport(ble);
-        router.register_transport(quic);
+        router.register_transport(ble, Arc::clone(&identity));
+        router.register_transport(quic, Arc::clone(&identity));
 
         tokio::task::yield_now().await;
         tokio::task::yield_now().await;
@@ -680,8 +688,9 @@ mod tests {
         let (transport, mut rx, count) =
             make_transport_with_failures(TransportCost::Free, TransportKind::Ble, 1);
 
+        let identity = Arc::new(NodeIdentity::generate());
         let mut router = Router::new();
-        router.register_transport(transport);
+        router.register_transport(transport, Arc::clone(&identity));
 
         tokio::task::yield_now().await;
         tokio::task::yield_now().await;
@@ -710,8 +719,9 @@ mod tests {
         let (ble, _ble_rx, ble_count) =
             make_transport(TransportCost::Free, TransportKind::Ble, false);
 
+        let identity = Arc::new(NodeIdentity::generate());
         let mut router = Router::new();
-        router.register_transport(ble);
+        router.register_transport(ble, Arc::clone(&identity));
 
         // No yield: monitoring task has not run, available = false.
         let sender_id = NodeIdentity::generate();
@@ -734,8 +744,9 @@ mod tests {
     async fn connect_returns_peer_id_on_success() {
         let (transport, mut rx, _) = make_transport(TransportCost::Free, TransportKind::Ble, false);
 
+        let identity = Arc::new(NodeIdentity::generate());
         let mut router = Router::new();
-        router.register_transport(transport);
+        router.register_transport(transport, Arc::clone(&identity));
 
         tokio::task::yield_now().await;
         tokio::task::yield_now().await;
@@ -770,7 +781,7 @@ mod tests {
 
     #[async_trait]
     impl Transport for StartFailNTimes {
-        async fn start(&self) -> Result<()> {
+        async fn start(&self, _identity: &NodeIdentity) -> Result<()> {
             let n =
                 self.remaining_failures
                     .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |n| {
@@ -820,7 +831,12 @@ mod tests {
         let available = Arc::new(AtomicBool::new(false));
         let (started_tx, started_rx) = watch::channel(false);
 
-        tokio::spawn(health_monitor(t, started_tx, Arc::clone(&available)));
+        tokio::spawn(health_monitor(
+            t,
+            started_tx,
+            Arc::clone(&available),
+            Arc::new(NodeIdentity::generate()),
+        ));
 
         tokio::task::yield_now().await;
         tokio::task::yield_now().await;
@@ -844,6 +860,7 @@ mod tests {
             transport,
             started_tx,
             Arc::clone(&available),
+            Arc::new(NodeIdentity::generate()),
         ));
 
         // Yield so the initial start() runs and fails.
@@ -885,6 +902,7 @@ mod tests {
             transport,
             started_tx,
             Arc::clone(&available),
+            Arc::new(NodeIdentity::generate()),
         ));
 
         tokio::task::yield_now().await;
@@ -921,7 +939,7 @@ mod tests {
 
     #[async_trait]
     impl Transport for ControllableDiscoverTransport {
-        async fn start(&self) -> Result<()> {
+        async fn start(&self, _identity: &NodeIdentity) -> Result<()> {
             Ok(())
         }
         async fn stop(&self) -> Result<()> {

--- a/crates/pathweave-transport-ble/Cargo.toml
+++ b/crates/pathweave-transport-ble/Cargo.toml
@@ -18,5 +18,8 @@ tracing = { workspace = true }
 btleplug = { workspace = true }
 uuid = { workspace = true }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+bluer = { workspace = true }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -10,8 +10,8 @@ use btleplug::{
 use bytes::Bytes;
 use futures::{channel::mpsc, stream::BoxStream, StreamExt};
 use pathweave_core::{
-    Connection, PathweaveError, PeerAddress, PeerAnnouncement, Result, Transport, TransportCost,
-    TransportKind,
+    Connection, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result, Transport,
+    TransportCost, TransportKind,
 };
 use tokio::sync::Mutex;
 use uuid::{uuid, Uuid};
@@ -28,17 +28,139 @@ const NOTIFY_CHAR_UUID: Uuid = uuid!("6de63378-8bc3-4e87-8892-0a9a80efff64");
 const ADVERTISEMENT_VERSION: u8 = 0x01;
 
 // --------------------------------------------------------------------------
+// Linux-only peripheral types (ADR 014)
+// --------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+struct BlePeripheralState {
+    _adv_handle: bluer::adv::AdvertisementHandle,
+    _app_handle: bluer::gatt::local::ApplicationHandle,
+    conn_rx: Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>>>,
+}
+
+#[cfg(target_os = "linux")]
+struct BlePeripheralConnection {
+    write_rx: Mutex<tokio::sync::mpsc::UnboundedReceiver<Bytes>>,
+    reply_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
+}
+
+#[cfg(target_os = "linux")]
+#[async_trait]
+impl Connection for BlePeripheralConnection {
+    async fn send_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        self.reply_tx
+            .send(Bytes::copy_from_slice(bytes))
+            .map_err(|_| PathweaveError::Transport("peripheral reply channel closed".into()))
+    }
+
+    async fn recv_bytes(&mut self) -> Result<Bytes> {
+        self.write_rx
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or_else(|| PathweaveError::Transport("peripheral write channel closed".into()))
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn mtu(&self) -> usize {
+        512
+    }
+}
+
+// peripheral_loop: sole owner of CharacteristicWriter, bridges bluer events to connections.
+//
+// Creates a BlePeripheralConnection on Subscribe (Notify event) and forwards each
+// Write event's bytes to the connection's internal channel. Multiple writes from the
+// same subscriber map to multiple channel sends, allowing Session::respond() to call
+// recv_bytes() twice for the Noise_XX handshake (messages 1 and 3).
+//
+// Rejects a second subscriber while a connection is active (v0.2.0 limitation).
+// Clears active_write_tx when the connection's receiver is dropped, allowing the
+// next subscriber to open a fresh connection.
+#[cfg(target_os = "linux")]
+async fn peripheral_loop(
+    mut write_ctrl: bluer::gatt::local::CharacteristicControl,
+    mut notify_ctrl: bluer::gatt::local::CharacteristicControl,
+    conn_tx: tokio::sync::mpsc::UnboundedSender<BlePeripheralConnection>,
+) {
+    use bluer::gatt::local::CharacteristicControlEvent;
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+    let mut writer: Option<bluer::gatt::local::CharacteristicWriter> = None;
+    let mut active_write_tx: Option<tokio::sync::mpsc::UnboundedSender<Bytes>> = None;
+
+    loop {
+        tokio::select! {
+            evt = notify_ctrl.next() => match evt {
+                Some(CharacteristicControlEvent::Notify(w)) => {
+                    if active_write_tx.as_ref().is_some_and(|tx| !tx.is_closed()) {
+                        tracing::debug!("BLE peripheral: second subscriber while connection active; ignored");
+                    } else {
+                        writer = Some(w);
+                        let (write_tx, write_rx) = tokio::sync::mpsc::unbounded_channel();
+                        active_write_tx = Some(write_tx);
+                        let _ = conn_tx.send(BlePeripheralConnection {
+                            write_rx: Mutex::new(write_rx),
+                            reply_tx: reply_tx.clone(),
+                        });
+                    }
+                }
+                _ => return,
+            },
+            evt = write_ctrl.next() => match evt {
+                Some(CharacteristicControlEvent::Write(req)) => {
+                    match &active_write_tx {
+                        Some(tx) => {
+                            if let Ok(mut reader) = req.accept() {
+                                let mut buf = Vec::new();
+                                if reader.read_to_end(&mut buf).await.is_ok() {
+                                    if tx.send(Bytes::from(buf)).is_err() {
+                                        active_write_tx = None;
+                                    }
+                                }
+                            }
+                        }
+                        None => {
+                            let _ = req.accept();
+                            tracing::debug!("BLE peripheral: write with no active connection; frame discarded");
+                        }
+                    }
+                }
+                _ => return,
+            },
+            data = reply_rx.recv(), if writer.is_some() => {
+                if let (Some(bytes), Some(w)) = (data, writer.as_mut()) {
+                    if w.write_all(&bytes).await.is_err() {
+                        writer = None;
+                        active_write_tx = None;
+                    }
+                }
+            },
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
 // Transport
 // --------------------------------------------------------------------------
 
 pub struct BleTransport {
     adapter: Arc<Mutex<Option<Adapter>>>,
+    #[cfg(target_os = "linux")]
+    peripheral: Arc<Mutex<Option<BlePeripheralState>>>,
 }
 
 impl BleTransport {
     pub fn new() -> Self {
         Self {
             adapter: Arc::new(Mutex::new(None)),
+            #[cfg(target_os = "linux")]
+            peripheral: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -51,7 +173,8 @@ impl Default for BleTransport {
 
 #[async_trait]
 impl Transport for BleTransport {
-    async fn start(&self) -> Result<()> {
+    async fn start(&self, identity: &NodeIdentity) -> Result<()> {
+        // Central mode: acquire btleplug adapter for scanning.
         let manager = Manager::new()
             .await
             .map_err(|e| PathweaveError::Transport(e.to_string()))?;
@@ -64,6 +187,15 @@ impl Transport for BleTransport {
             .next()
             .ok_or_else(|| PathweaveError::Transport("no Bluetooth adapter found".into()))?;
         *self.adapter.lock().await = Some(adapter);
+
+        // Peripheral mode: register GATT application and begin advertising (Linux only).
+        #[cfg(target_os = "linux")]
+        self.start_peripheral(identity).await?;
+
+        // Suppress unused-variable warning on non-Linux.
+        #[cfg(not(target_os = "linux"))]
+        let _ = identity;
+
         Ok(())
     }
 
@@ -73,6 +205,17 @@ impl Transport for BleTransport {
             let _ = adapter.stop_scan().await;
         }
         *guard = None;
+
+        #[cfg(target_os = "linux")]
+        {
+            // Dropping BlePeripheralState drops _adv_handle and _app_handle,
+            // which unregisters the advertisement and GATT application via bluer's
+            // RAII guards. This also closes peripheral_loop's control streams,
+            // causing it to exit and drop conn_tx, which unblocks any waiting
+            // accept() call (recv() returns None).
+            *self.peripheral.lock().await = None;
+        }
+
         Ok(())
     }
 
@@ -228,11 +371,31 @@ impl Transport for BleTransport {
         }))
     }
 
-    /// Not yet implemented. Peripheral mode (advertising + GATT server) requires
-    /// Linux with BlueZ via the `bluer` crate. Tracked in issue #20.
+    #[cfg(target_os = "linux")]
+    async fn accept(&self) -> Result<Box<dyn Connection>> {
+        // Clone the Arc to conn_rx inside the lock, then release the outer lock before
+        // awaiting recv(). This prevents a deadlock with stop(): if accept() held the
+        // outer lock across recv(), stop() could not acquire it to drop BlePeripheralState
+        // and unblock the recv() (see ADR 014 rationale).
+        let rx = {
+            let guard = self.peripheral.lock().await;
+            let state = guard
+                .as_ref()
+                .ok_or_else(|| PathweaveError::Transport("transport not started".into()))?;
+            Arc::clone(&state.conn_rx)
+        };
+        rx.lock()
+            .await
+            .recv()
+            .await
+            .map(|c| Box::new(c) as Box<dyn Connection>)
+            .ok_or_else(|| PathweaveError::Transport("peripheral loop ended".into()))
+    }
+
+    #[cfg(not(target_os = "linux"))]
     async fn accept(&self) -> Result<Box<dyn Connection>> {
         Err(PathweaveError::Transport(
-            "BLE peripheral mode not yet implemented; see issue #20".into(),
+            "BLE peripheral mode requires Linux with BlueZ".into(),
         ))
     }
 
@@ -253,8 +416,96 @@ impl Transport for BleTransport {
     }
 }
 
+#[cfg(target_os = "linux")]
+impl BleTransport {
+    async fn start_peripheral(&self, identity: &NodeIdentity) -> Result<()> {
+        use bluer::gatt::local::{
+            characteristic_control, Application, Characteristic, CharacteristicNotify,
+            CharacteristicNotifyMethod, CharacteristicWrite, CharacteristicWriteMethod, Service,
+        };
+        use std::collections::BTreeMap;
+
+        let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8].try_into().unwrap();
+
+        let session = bluer::Session::new()
+            .await
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        let adapter = session
+            .default_adapter()
+            .await
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let (write_ctrl, write_handle) = characteristic_control();
+        let (notify_ctrl, notify_handle) = characteristic_control();
+
+        let app = Application {
+            services: vec![Service {
+                uuid: PATHWEAVE_SERVICE_UUID,
+                primary: true,
+                characteristics: vec![
+                    Characteristic {
+                        uuid: WRITE_CHAR_UUID,
+                        write: Some(CharacteristicWrite {
+                            write_without_response: true,
+                            method: CharacteristicWriteMethod::Io,
+                            ..Default::default()
+                        }),
+                        control_handle: write_handle,
+                        ..Default::default()
+                    },
+                    Characteristic {
+                        uuid: NOTIFY_CHAR_UUID,
+                        notify: Some(CharacteristicNotify {
+                            notify: true,
+                            method: CharacteristicNotifyMethod::Io,
+                            ..Default::default()
+                        }),
+                        control_handle: notify_handle,
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let app_handle = adapter
+            .serve_gatt_application(app)
+            .await
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let mut svc_data = BTreeMap::new();
+        let mut payload = Vec::with_capacity(9);
+        payload.push(ADVERTISEMENT_VERSION);
+        payload.extend_from_slice(&short_id);
+        svc_data.insert(PATHWEAVE_SERVICE_UUID, payload);
+
+        let adv = bluer::adv::Advertisement {
+            advertisement_type: bluer::adv::Type::Peripheral,
+            service_data: svc_data,
+            ..Default::default()
+        };
+
+        let adv_handle = adapter
+            .advertise(adv)
+            .await
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel();
+        tokio::spawn(peripheral_loop(write_ctrl, notify_ctrl, conn_tx));
+
+        *self.peripheral.lock().await = Some(BlePeripheralState {
+            _adv_handle: adv_handle,
+            _app_handle: app_handle,
+            conn_rx: Arc::new(Mutex::new(conn_rx)),
+        });
+
+        Ok(())
+    }
+}
+
 // --------------------------------------------------------------------------
-// Connection
+// Central-mode connection (btleplug)
 // --------------------------------------------------------------------------
 
 pub struct BleConnection {
@@ -329,8 +580,17 @@ mod tests {
         assert!(matches!(result, Err(PathweaveError::Transport(_))));
     }
 
+    #[cfg(not(target_os = "linux"))]
     #[tokio::test]
-    async fn accept_returns_not_implemented() {
+    async fn accept_returns_not_implemented_on_non_linux() {
+        let transport = BleTransport::new();
+        let result = transport.accept().await;
+        assert!(matches!(result, Err(PathweaveError::Transport(_))));
+    }
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test]
+    async fn accept_before_start_returns_error() {
         let transport = BleTransport::new();
         let result = transport.accept().await;
         assert!(matches!(result, Err(PathweaveError::Transport(_))));

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -117,10 +117,10 @@ async fn peripheral_loop(
                         Some(tx) => {
                             if let Ok(mut reader) = req.accept() {
                                 let mut buf = Vec::new();
-                                if reader.read_to_end(&mut buf).await.is_ok() {
-                                    if tx.send(Bytes::from(buf)).is_err() {
-                                        active_write_tx = None;
-                                    }
+                                if reader.read_to_end(&mut buf).await.is_ok()
+                                    && tx.send(Bytes::from(buf)).is_err()
+                                {
+                                    active_write_tx = None;
                                 }
                             }
                         }

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -35,7 +35,6 @@ const ADVERTISEMENT_VERSION: u8 = 0x01;
 struct BlePeripheralState {
     _adv_handle: bluer::adv::AdvertisementHandle,
     _app_handle: bluer::gatt::local::ApplicationHandle,
-    conn_rx: Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>>>,
 }
 
 #[cfg(target_os = "linux")]
@@ -91,7 +90,7 @@ async fn peripheral_loop(
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
     let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
-    let mut writer: Option<bluer::gatt::local::CharacteristicWriter> = None;
+    let mut writer = None;
     let mut active_write_tx: Option<tokio::sync::mpsc::UnboundedSender<Bytes>> = None;
 
     loop {
@@ -153,6 +152,8 @@ pub struct BleTransport {
     adapter: Arc<Mutex<Option<Adapter>>>,
     #[cfg(target_os = "linux")]
     peripheral: Arc<Mutex<Option<BlePeripheralState>>>,
+    #[cfg(target_os = "linux")]
+    conn_rx: Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>>>,
 }
 
 impl BleTransport {
@@ -161,6 +162,8 @@ impl BleTransport {
             adapter: Arc::new(Mutex::new(None)),
             #[cfg(target_os = "linux")]
             peripheral: Arc::new(Mutex::new(None)),
+            #[cfg(target_os = "linux")]
+            conn_rx: Mutex::new(None),
         }
     }
 }
@@ -212,8 +215,11 @@ impl Transport for BleTransport {
             // which unregisters the advertisement and GATT application via bluer's
             // RAII guards. This also closes peripheral_loop's control streams,
             // causing it to exit and drop conn_tx, which unblocks any waiting
-            // accept() call (recv() returns None).
+            // accept() call (recv() returns None and releases the conn_rx lock).
             *self.peripheral.lock().await = None;
+            // Clear conn_rx after peripheral is dropped so subsequent accept() calls
+            // return "transport not started" rather than "peripheral loop ended".
+            *self.conn_rx.lock().await = None;
         }
 
         Ok(())
@@ -373,23 +379,19 @@ impl Transport for BleTransport {
 
     #[cfg(target_os = "linux")]
     async fn accept(&self) -> Result<Box<dyn Connection>> {
-        // Clone the Arc to conn_rx inside the lock, then release the outer lock before
-        // awaiting recv(). This prevents a deadlock with stop(): if accept() held the
-        // outer lock across recv(), stop() could not acquire it to drop BlePeripheralState
-        // and unblock the recv() (see ADR 014 rationale).
-        let rx = {
-            let guard = self.peripheral.lock().await;
-            let state = guard
-                .as_ref()
-                .ok_or_else(|| PathweaveError::Transport("transport not started".into()))?;
-            Arc::clone(&state.conn_rx)
-        };
-        rx.lock()
-            .await
-            .recv()
-            .await
-            .map(|c| Box::new(c) as Box<dyn Connection>)
-            .ok_or_else(|| PathweaveError::Transport("peripheral loop ended".into()))
+        // Borrow conn_rx from self (lifetime 'life0: 'async_trait). Holding the guard
+        // across recv() is safe: stop() drops BlePeripheralState first (which closes
+        // conn_tx via peripheral_loop exit), causing recv() to return None and accept()
+        // to release the guard. stop() then acquires the lock to clear it.
+        let mut guard = self.conn_rx.lock().await;
+        match guard.as_mut() {
+            Some(rx) => rx
+                .recv()
+                .await
+                .map(|c| Box::new(c) as Box<dyn Connection>)
+                .ok_or_else(|| PathweaveError::Transport("peripheral loop ended".into())),
+            None => Err(PathweaveError::Transport("transport not started".into())),
+        }
     }
 
     #[cfg(not(target_os = "linux"))]
@@ -494,10 +496,10 @@ impl BleTransport {
         let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel();
         tokio::spawn(peripheral_loop(write_ctrl, notify_ctrl, conn_tx));
 
+        *self.conn_rx.lock().await = Some(conn_rx);
         *self.peripheral.lock().await = Some(BlePeripheralState {
             _adv_handle: adv_handle,
             _app_handle: app_handle,
-            conn_rx: Arc::new(Mutex::new(conn_rx)),
         });
 
         Ok(())

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -175,7 +175,7 @@ impl ServerCertVerifier for SkipServerVerification {
 
 #[async_trait]
 impl Transport for QuicTransport {
-    async fn start(&self) -> Result<()> {
+    async fn start(&self, _identity: &pathweave_core::NodeIdentity) -> Result<()> {
         let server_config = make_server_config()?;
         let endpoint =
             Endpoint::server(server_config, self.listen_addr).map_err(PathweaveError::Io)?;
@@ -416,7 +416,7 @@ mod tests {
     #[tokio::test]
     async fn full_stack_roundtrip() {
         let server = Arc::new(QuicTransport::new(loopback(0)));
-        server.start().await.unwrap();
+        server.start(&NodeIdentity::generate()).await.unwrap();
         let server_addr = server.local_addr().await.unwrap();
 
         let server_identity = NodeIdentity::generate();

--- a/notes/decisions/014-ble-peripheral-linux.md
+++ b/notes/decisions/014-ble-peripheral-linux.md
@@ -1,0 +1,374 @@
+# ADR 014: Linux BLE peripheral mode via bluer v0.17
+
+**Status:** Accepted
+
+## Context
+
+Phase 3 of v0.2.0 implements BLE peripheral mode: advertising this node's identity
+and accepting GATT connections from scanning centrals. ADR 006 settled the split:
+central mode uses `btleplug` on all platforms; peripheral mode uses `bluer` v0.17 on
+Linux. ADR 010 settled that `Transport::start()` takes `&NodeIdentity`.
+
+Three design questions remained open:
+
+1. Which bluer data-path API to use for the GATT server
+2. How `accept()` maps onto bluer's event-driven model
+3. How `bluer` and `btleplug` coexist inside the same crate
+
+This ADR settles all three.
+
+## bluer v0.17 GATT server data API
+
+bluer exposes two data-path variants for GATT server characteristics:
+
+| Variant | Field values | Execution context |
+|---|---|---|
+| Callback | `CharacteristicWriteMethod::Fn` / `CharacteristicNotifyMethod::Fn` | Closures called on a BlueZ D-Bus thread, outside Tokio |
+| Async IO | `CharacteristicWriteMethod::Io` / `CharacteristicNotifyMethod::Io` | Async stream, inside the Tokio runtime |
+
+The `Fn` variants call closures on a BlueZ D-Bus event thread. Getting data into
+async tasks from those closures requires `Arc<Mutex<...>>` bridges with no benefit:
+the closures cannot `await` and data must leave the Tokio executor regardless.
+
+The `Io` variants are driven by `characteristic_control()`, a factory that returns a
+`(CharacteristicControl, CharacteristicControlHandle)` pair:
+
+- `CharacteristicControlHandle` goes into the `Characteristic` struct and is
+  registered with bluer when `adapter.serve_gatt_application(app).await` is called.
+- `CharacteristicControl` is a `Stream<Item = CharacteristicControlEvent>` that
+  drives the application event loop inside the Tokio runtime.
+
+Events on the write characteristic:
+
+- `CharacteristicControlEvent::Write(req)`: a central wrote a frame. `req.accept()?`
+  returns a `CharacteristicReader` (implements `AsyncRead`) containing the frame bytes.
+  The reader reaches EOF after one write operation's data is consumed.
+
+Events on the notify characteristic:
+
+- `CharacteristicControlEvent::Notify(writer)`: a central subscribed. The yielded
+  `CharacteristicWriter` (implements `AsyncWrite`) remains valid until the central
+  disconnects or `_app_handle` is dropped.
+
+## Decision
+
+### GATT characteristic configuration
+
+Both characteristics use the `Io` variant:
+
+```rust
+CharacteristicWrite {
+    write_without_response: true,
+    method: CharacteristicWriteMethod::Io,
+    ..Default::default()
+}
+
+CharacteristicNotify {
+    notify: true,
+    method: CharacteristicNotifyMethod::Io,
+    ..Default::default()
+}
+```
+
+`write_without_response: true` matches ADR 002: the central writes without a GATT
+acknowledgement. Delivery guarantees are provided by the at-least-once retry loop
+(ADR 011) at the application layer.
+
+### bluer/btleplug coexistence
+
+`BleTransport` gains one Linux-only field:
+
+```rust
+#[cfg(target_os = "linux")]
+peripheral: Arc<tokio::sync::Mutex<Option<BlePeripheralState>>>,
+```
+
+All bluer types are gated under `#[cfg(target_os = "linux")]`. The btleplug
+central-mode field (`adapter: Arc<Mutex<Option<Adapter>>>`) is unchanged and
+platform-independent. On macOS and Windows, `bluer` is absent from the dependency
+tree and `accept()` returns the existing not-implemented error.
+
+`pathweave-transport-ble/Cargo.toml` adds a
+`[target.'cfg(target_os = "linux")'.dependencies]` section with
+`bluer = { workspace = true }`.
+
+### Handle lifetime and peripheral state
+
+```rust
+#[cfg(target_os = "linux")]
+struct BlePeripheralState {
+    _adv_handle: bluer::adv::AdvertisementHandle,
+    _app_handle: bluer::gatt::local::ApplicationHandle,
+    conn_rx: Arc<tokio::sync::Mutex<
+        tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>
+    >>,
+}
+```
+
+`AdvertisementHandle` and `ApplicationHandle` are RAII guards: bluer unregisters
+the advertisement and the GATT application when they are dropped. The `_` prefix
+makes the intent explicit.
+
+`conn_rx` is wrapped in `Arc<tokio::sync::Mutex<...>>` so `accept()` can clone the
+Arc, release the outer `self.peripheral` lock, and then await `recv()` without
+holding the outer lock. This prevents a deadlock when `stop()` needs to acquire
+the same outer lock while `accept()` is blocked. See the `accept()` section below.
+
+Dropping `BlePeripheralState` in `stop()` drops the two handles, which closes the
+characteristic control streams in `peripheral_loop`, which causes it to return and
+drop `conn_tx`. The `conn_rx.recv()` call in `accept()` then returns `None` and
+`accept()` returns an error, unblocking `accept_loop`.
+
+### Advertisement format
+
+```rust
+bluer::adv::Advertisement {
+    advertisement_type: bluer::adv::Type::Peripheral,
+    service_data: BTreeMap::from([(
+        PATHWEAVE_SERVICE_UUID,
+        [&[ADVERTISEMENT_VERSION], short_id.as_slice()].concat(),
+    )]),
+    ..Default::default()
+}
+```
+
+`short_id` is the first 8 bytes of `identity.peer_id()`. This matches ADR 002.
+BlueZ constructs the `ServiceData` AD structure from this map. btleplug's
+`CentralEvent::ServiceDataAdvertisement` on the central side reports the same UUID
+key and byte payload, so the advertisement format is consistent end to end.
+
+The service UUID does not appear in `service_uuids` as a separate field. ADR 002's
+byte analysis showed that adding a `Complete List of 128-bit UUIDs` AD structure
+would exceed the 31-byte advertisement limit. BlueZ extracts the UUID from
+`service_data` when filtering advertisements; btleplug's scan filter works
+correctly with this layout.
+
+### Transport::start() on Linux
+
+`BleTransport::start(&identity)` on Linux executes the following sequence:
+
+1. Create a `bluer::Session` and acquire the default adapter.
+2. Derive `short_id`: first 8 bytes of `identity.peer_id()`.
+3. Call `characteristic_control()` twice, once for each characteristic. Retain the
+   `CharacteristicControl` streams; pass the `CharacteristicControlHandle` values
+   into their respective `Characteristic` structs.
+4. Call `adapter.serve_gatt_application(app).await`; retain `ApplicationHandle`.
+5. Call `adapter.advertise(adv).await`; retain `AdvertisementHandle`.
+6. Create an unbounded channel `(conn_tx, conn_rx)`.
+7. Spawn `peripheral_loop(write_ctrl, notify_ctrl, conn_tx)`.
+8. Store `BlePeripheralState { _adv_handle, _app_handle, conn_rx: Arc::new(Mutex::new(conn_rx)) }`.
+
+On non-Linux platforms, `start()` uses `_identity` and performs the existing
+btleplug adapter initialization unchanged.
+
+### peripheral_loop
+
+`peripheral_loop` runs as a background task and is the sole owner of
+`CharacteristicWriter`. It drives a `tokio::select!` loop over the write control
+stream, the notify control stream, and a reply channel from connections:
+
+```rust
+async fn peripheral_loop(
+    mut write_ctrl: CharacteristicControl,
+    mut notify_ctrl: CharacteristicControl,
+    conn_tx: UnboundedSender<BlePeripheralConnection>,
+) {
+    let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+    let mut writer: Option<CharacteristicWriter> = None;
+    let mut active_write_tx: Option<UnboundedSender<Bytes>> = None;
+
+    loop {
+        tokio::select! {
+            evt = notify_ctrl.next() => match evt {
+                Some(CharacteristicControlEvent::Notify(w)) => {
+                    if active_write_tx.is_some() {
+                        // v0.2.0 supports one central at a time.
+                        tracing::debug!("BLE peripheral: second subscriber while connection active; ignored");
+                    } else {
+                        writer = Some(w);
+                        let (write_tx, write_rx) = tokio::sync::mpsc::unbounded_channel();
+                        active_write_tx = Some(write_tx);
+                        let _ = conn_tx.send(BlePeripheralConnection {
+                            write_rx: tokio::sync::Mutex::new(write_rx),
+                            reply_tx: reply_tx.clone(),
+                        });
+                    }
+                }
+                _ => return,
+            },
+            evt = write_ctrl.next() => match evt {
+                Some(CharacteristicControlEvent::Write(req)) => {
+                    match &active_write_tx {
+                        Some(tx) => {
+                            if let Ok(mut reader) = req.accept() {
+                                let mut buf = Vec::new();
+                                if tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut buf).await.is_ok() {
+                                    if tx.send(Bytes::from(buf)).is_err() {
+                                        active_write_tx = None;
+                                    }
+                                }
+                            }
+                        }
+                        None => {
+                            let _ = req.accept();
+                            tracing::debug!("BLE peripheral: write with no active connection; frame discarded");
+                        }
+                    }
+                }
+                _ => return,
+            },
+            data = reply_rx.recv(), if writer.is_some() => {
+                if let (Some(bytes), Some(w)) = (data, writer.as_mut()) {
+                    if tokio::io::AsyncWriteExt::write_all(w, &bytes).await.is_err() {
+                        writer = None;
+                        active_write_tx = None;
+                    }
+                }
+            },
+        }
+    }
+}
+```
+
+On a `Notify` event, `peripheral_loop` creates the connection immediately and sends
+it to `accept()`. The connection carries an internal channel (`write_rx`) that
+receives frames forwarded from subsequent `Write` events. Multiple `Write` events
+from the same subscriber map to multiple channel receives, which is what
+`Session::respond()` requires: two separate `recv_bytes()` calls for Noise_XX
+messages 1 and 3.
+
+On a `Write` event, `peripheral_loop` reads all bytes from `CharacteristicReader`
+via `read_to_end` (one write operation = one frame = EOF) and forwards the frame to
+the active connection's channel. If `active_write_tx.send()` returns an error, the
+connection was dropped by the router; `active_write_tx` is cleared so the next
+`Notify` event can create a fresh connection.
+
+`CharacteristicWriter` is owned by `peripheral_loop` so it persists across multiple
+write events from the same subscriber. Reply bytes flow from connections through
+`reply_rx` and are written to the subscriber via `write_all`. If `write_all` fails
+(central disconnected), both `writer` and `active_write_tx` are cleared.
+
+### accept()
+
+```rust
+#[cfg(target_os = "linux")]
+async fn accept(&self) -> Result<Box<dyn Connection>> {
+    let rx = {
+        let guard = self.peripheral.lock().await;
+        let state = guard.as_ref()
+            .ok_or_else(|| PathweaveError::Transport("transport not started".into()))?;
+        Arc::clone(&state.conn_rx)
+    }; // outer Mutex released before awaiting
+    rx.lock().await.recv().await
+        .map(|c| Box::new(c) as Box<dyn Connection>)
+        .ok_or_else(|| PathweaveError::Transport("peripheral loop ended".into()))
+}
+```
+
+The outer `self.peripheral` lock is acquired only to clone the `Arc<Mutex<...>>`
+for `conn_rx`. It is released before `recv()` blocks. This allows `stop()` to
+acquire `self.peripheral`, drop `BlePeripheralState`, and unblock the waiting
+`recv()` without deadlock.
+
+### BlePeripheralConnection
+
+```rust
+#[cfg(target_os = "linux")]
+struct BlePeripheralConnection {
+    write_rx: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<Bytes>>,
+    reply_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
+}
+```
+
+`write_rx` is wrapped in `tokio::sync::Mutex` to satisfy `Connection: Sync`.
+`recv_bytes` takes `&mut self`, so there is never actual contention on this lock.
+
+`recv_bytes()` receives the next frame from the channel. Each call blocks until
+`peripheral_loop` forwards a write frame. Multiple sequential `recv_bytes()` calls
+on the same connection map to multiple sequential write events from the central,
+which is the correct model for `Session::respond()`.
+
+`send_bytes()` sends via `reply_tx`. The actual write to `CharacteristicWriter`
+happens in `peripheral_loop`. `close()` is a no-op: dropping the connection
+drops `write_rx` and the cloned `reply_tx`. `peripheral_loop` detects the dropped
+receiver when `active_write_tx.send()` fails and clears the active connection state.
+
+`mtu()` returns 512, consistent with `BleConnection` and ADR 002's GATT MTU.
+
+### NodeIdentity propagation chain
+
+Implementing ADR 010 requires changes across several layers in addition to the BLE
+crate itself:
+
+- `Transport` trait (`pathweave-core/src/lib.rs`): `start(&self) -> Result<()>`
+  becomes `start(&self, identity: &NodeIdentity) -> Result<()>`.
+- `QuicTransport::start()`: adds `_identity` parameter; no other changes.
+- All mock `Transport` implementations in `pathweave-core` tests: add `_identity`.
+- `health_monitor()` in `router.rs`: gains `identity: Arc<NodeIdentity>`; calls
+  `transport.start(&identity).await` in place of `transport.start().await`.
+- `Router::register_transport()`: gains `identity: Arc<NodeIdentity>`; passes it to
+  `health_monitor`.
+- `PathweaveNode::add_transport()` in `node.rs`: acquires identity from `self` and
+  passes `Arc::clone(&self.identity)` to `register_transport()`.
+
+## Rationale
+
+**Why accept on Subscribe, not on Write?**
+
+`Session::respond()` performs the Noise_XX three-message handshake, which requires
+two sequential `recv_bytes()` calls on the same connection: read message 1, send
+message 2, read message 3. If the connection is created on a Write event with a
+single `CharacteristicReader`, the first `recv_bytes()` reads the frame and the
+reader reaches EOF. The second `recv_bytes()` returns zero bytes; the Noise layer
+cannot parse that as message 3 and fails. Meanwhile the second Write event (message
+3) creates a new connection in `conn_rx`, which `accept_loop` picks up and tries to
+parse as message 1, also failing.
+
+Creating the connection on Subscribe and forwarding each Write event to the channel
+gives `Session::respond()` what it needs: multiple sequential `recv_bytes()` calls
+that block on the channel until data arrives.
+
+**Why own CharacteristicWriter in peripheral_loop?**
+
+`CharacteristicWriter` does not implement `Clone`. A single notify subscription
+persists across multiple write events from the same central: the central subscribes
+once per GATT connection and then writes multiple times. Moving the writer into the
+connection (or into the first write's connection) leaves subsequent writes with no
+way to reply. Owning the writer in `peripheral_loop` and routing replies through a
+channel gives each connection an independent reply path without ownership conflicts.
+
+**Why reject a second subscriber rather than replacing the writer?**
+
+If a second central subscribes while a connection is active and the writer is
+replaced silently, the ACK for the first central's message is sent to the second
+central. The first central never receives its ACK, its at-least-once retry fires,
+and it writes again to the peripheral, which creates a new connection that is also
+routed to the wrong writer. Silent replacement produces confused state; an explicit
+rejection with a debug log is predictable and honest about the v0.2.0 limitation.
+The at-least-once retry loop on the first central handles the missed ACK.
+
+**Why release the outer lock before recv() in accept()?**
+
+`stop()` calls `transport.stop().await`, which must acquire `self.peripheral` to
+drop `BlePeripheralState`. If `accept()` holds that lock across the blocking
+`recv()` call, `stop()` waits for the lock. But the unblock signal (`conn_tx` drop
+that causes `recv()` to return `None`) only arrives after `BlePeripheralState` is
+dropped, which requires `stop()` to acquire the lock first: a deadlock. Cloning the
+Arc before releasing the lock breaks the cycle: `stop()` can acquire the outer lock,
+drop the state and its handles, which closes `peripheral_loop` and drops `conn_tx`,
+which causes the already-waiting `recv()` to return `None`.
+
+## Implications
+
+- `bluer` is added as a `[target.'cfg(target_os = "linux")'.dependencies]` entry
+  in `pathweave-transport-ble/Cargo.toml`.
+- `BleTransport` gains `peripheral` field, `BlePeripheralState`, and
+  `BlePeripheralConnection` under `#[cfg(target_os = "linux")]`.
+- `Transport::start()` signature changes to `start(&self, identity: &NodeIdentity)`.
+- `QuicTransport`, all mock transports in tests: add `_identity`.
+- `health_monitor()`, `Router::register_transport()`, `PathweaveNode::add_transport()`:
+  propagate `Arc<NodeIdentity>` as described above.
+- `accept()` on non-Linux platforms returns the not-implemented error unchanged.
+- Multiple simultaneous centrals are not supported in v0.2.0. A second subscriber
+  while a connection is active is dropped with a debug log.
+- macOS and Windows peripheral mode remain deferred per ADR 006.

--- a/notes/decisions/014-ble-peripheral-linux.md
+++ b/notes/decisions/014-ble-peripheral-linux.md
@@ -99,9 +99,6 @@ tree and `accept()` returns the existing not-implemented error.
 struct BlePeripheralState {
     _adv_handle: bluer::adv::AdvertisementHandle,
     _app_handle: bluer::gatt::local::ApplicationHandle,
-    conn_rx: Arc<tokio::sync::Mutex<
-        tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>
-    >>,
 }
 ```
 
@@ -109,10 +106,18 @@ struct BlePeripheralState {
 the advertisement and the GATT application when they are dropped. The `_` prefix
 makes the intent explicit.
 
-`conn_rx` is wrapped in `Arc<tokio::sync::Mutex<...>>` so `accept()` can clone the
-Arc, release the outer `self.peripheral` lock, and then await `recv()` without
-holding the outer lock. This prevents a deadlock when `stop()` needs to acquire
-the same outer lock while `accept()` is blocked. See the `accept()` section below.
+`conn_rx` (the receiver side of the connection channel created in
+`start_peripheral()`) is held on `BleTransport` directly as a separate field:
+
+```rust
+#[cfg(target_os = "linux")]
+conn_rx: tokio::sync::Mutex<Option<
+    tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>
+>>,
+```
+
+See the `accept()` section for why it lives here rather than inside
+`BlePeripheralState`.
 
 Dropping `BlePeripheralState` in `stop()` drops the two handles, which closes the
 characteristic control streams in `peripheral_loop`, which causes it to return and
@@ -156,7 +161,8 @@ correctly with this layout.
 5. Call `adapter.advertise(adv).await`; retain `AdvertisementHandle`.
 6. Create an unbounded channel `(conn_tx, conn_rx)`.
 7. Spawn `peripheral_loop(write_ctrl, notify_ctrl, conn_tx)`.
-8. Store `BlePeripheralState { _adv_handle, _app_handle, conn_rx: Arc::new(Mutex::new(conn_rx)) }`.
+8. Store `conn_rx` in `self.conn_rx`, then store
+   `BlePeripheralState { _adv_handle, _app_handle }` in `self.peripheral`.
 
 On non-Linux platforms, `start()` uses `_identity` and performs the existing
 btleplug adapter initialization unchanged.
@@ -174,15 +180,18 @@ async fn peripheral_loop(
     conn_tx: UnboundedSender<BlePeripheralConnection>,
 ) {
     let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
-    let mut writer: Option<CharacteristicWriter> = None;
+    let mut writer = None;
     let mut active_write_tx: Option<UnboundedSender<Bytes>> = None;
 
     loop {
         tokio::select! {
             evt = notify_ctrl.next() => match evt {
                 Some(CharacteristicControlEvent::Notify(w)) => {
-                    if active_write_tx.is_some() {
-                        // v0.2.0 supports one central at a time.
+                    // Check is_closed() not just is_some(): after a connection
+                    // completes and write_rx is dropped, active_write_tx stays
+                    // Some(dead_sender). is_closed() detects this and allows
+                    // the next subscriber to open a fresh connection.
+                    if active_write_tx.as_ref().is_some_and(|tx| !tx.is_closed()) {
                         tracing::debug!("BLE peripheral: second subscriber while connection active; ignored");
                     } else {
                         writer = Some(w);
@@ -202,10 +211,10 @@ async fn peripheral_loop(
                         Some(tx) => {
                             if let Ok(mut reader) = req.accept() {
                                 let mut buf = Vec::new();
-                                if tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut buf).await.is_ok() {
-                                    if tx.send(Bytes::from(buf)).is_err() {
-                                        active_write_tx = None;
-                                    }
+                                if tokio::io::AsyncReadExt::read_to_end(&mut reader, &mut buf).await.is_ok()
+                                    && tx.send(Bytes::from(buf)).is_err()
+                                {
+                                    active_write_tx = None;
                                 }
                             }
                         }
@@ -253,22 +262,21 @@ write events from the same subscriber. Reply bytes flow from connections through
 ```rust
 #[cfg(target_os = "linux")]
 async fn accept(&self) -> Result<Box<dyn Connection>> {
-    let rx = {
-        let guard = self.peripheral.lock().await;
-        let state = guard.as_ref()
-            .ok_or_else(|| PathweaveError::Transport("transport not started".into()))?;
-        Arc::clone(&state.conn_rx)
-    }; // outer Mutex released before awaiting
-    rx.lock().await.recv().await
-        .map(|c| Box::new(c) as Box<dyn Connection>)
-        .ok_or_else(|| PathweaveError::Transport("peripheral loop ended".into()))
+    let mut guard = self.conn_rx.lock().await;
+    match guard.as_mut() {
+        Some(rx) => rx
+            .recv()
+            .await
+            .map(|c| Box::new(c) as Box<dyn Connection>)
+            .ok_or_else(|| PathweaveError::Transport("peripheral loop ended".into())),
+        None => Err(PathweaveError::Transport("transport not started".into())),
+    }
 }
 ```
 
-The outer `self.peripheral` lock is acquired only to clone the `Arc<Mutex<...>>`
-for `conn_rx`. It is released before `recv()` blocks. This allows `stop()` to
-acquire `self.peripheral`, drop `BlePeripheralState`, and unblock the waiting
-`recv()` without deadlock.
+The guard on `self.conn_rx` is held across `recv()`. See the rationale section for
+why this is safe with respect to `stop()`, and why `conn_rx` must live on
+`BleTransport` rather than inside `BlePeripheralState`.
 
 ### BlePeripheralConnection
 
@@ -347,22 +355,46 @@ routed to the wrong writer. Silent replacement produces confused state; an expli
 rejection with a debug log is predictable and honest about the v0.2.0 limitation.
 The at-least-once retry loop on the first central handles the missed ACK.
 
-**Why release the outer lock before recv() in accept()?**
+**Why does conn_rx live on BleTransport rather than inside BlePeripheralState?**
 
-`stop()` calls `transport.stop().await`, which must acquire `self.peripheral` to
-drop `BlePeripheralState`. If `accept()` holds that lock across the blocking
-`recv()` call, `stop()` waits for the lock. But the unblock signal (`conn_tx` drop
-that causes `recv()` to return `None`) only arrives after `BlePeripheralState` is
-dropped, which requires `stop()` to acquire the lock first: a deadlock. Cloning the
-Arc before releasing the lock breaks the cycle: `stop()` can acquire the outer lock,
-drop the state and its handles, which closes `peripheral_loop` and drops `conn_tx`,
-which causes the already-waiting `recv()` to return `None`.
+Two constraints interact here.
+
+The deadlock constraint: `stop()` must acquire `self.peripheral` to drop
+`BlePeripheralState`. The unblock signal that causes `recv()` to return `None`
+(the `conn_tx` drop via `peripheral_loop` exit) only arrives after
+`BlePeripheralState` is dropped. So `accept()` cannot hold `self.peripheral` across
+`recv()` without creating a deadlock.
+
+The async_trait lifetime constraint: `async_trait` transforms `accept()` into
+`Box<dyn Future + Send + 'async_trait>` where `'life0: 'async_trait` (`'life0` is
+the lifetime of `&self`). Any borrow held across an `.await` point inside that
+future must also satisfy `'life0: 'async_trait`.
+
+The first instinct is to clone an `Arc<Mutex<conn_rx>>` from inside
+`BlePeripheralState`, release `self.peripheral`, then lock the inner Arc and await
+`recv()`. This avoids the peripheral-lock deadlock. But the borrow checker rejects
+it: the `MutexGuard` borrows from a local `Arc` variable with a lifetime shorter
+than `'async_trait`, and `async_trait` requires every borrow held across `.await` to
+satisfy `'life0: 'async_trait`. The compiler reports E0597.
+
+Moving `conn_rx` to `BleTransport` directly fixes both constraints. `accept()` locks
+`self.conn_rx` directly; the guard borrows from `self`, which has lifetime `'life0`,
+satisfying `'life0: 'async_trait`. And the `self.peripheral` lock is never held
+across `recv()`, so the deadlock cannot occur.
+
+The stop() + accept() interaction with this design: `stop()` acquires
+`self.peripheral`, drops `BlePeripheralState` (closing the GATT application and
+advertisement), and releases `self.peripheral`. `peripheral_loop` sees its control
+streams close, exits, and drops `conn_tx`. The `recv()` waiting in `accept()`
+returns `None`; `accept()` returns an error and releases the `conn_rx` guard. `stop()`
+then acquires `self.conn_rx` and clears it so subsequent `accept()` calls return
+"transport not started" rather than "peripheral loop ended".
 
 ## Implications
 
 - `bluer` is added as a `[target.'cfg(target_os = "linux")'.dependencies]` entry
   in `pathweave-transport-ble/Cargo.toml`.
-- `BleTransport` gains `peripheral` field, `BlePeripheralState`, and
+- `BleTransport` gains `peripheral` and `conn_rx` fields, `BlePeripheralState`, and
   `BlePeripheralConnection` under `#[cfg(target_os = "linux")]`.
 - `Transport::start()` signature changes to `start(&self, identity: &NodeIdentity)`.
 - `QuicTransport`, all mock transports in tests: add `_identity`.


### PR DESCRIPTION
## What changed

- `Transport::start()` signature changed to `start(&self, identity: &NodeIdentity)` (ADR 010). `QuicTransport` ignores the parameter with `_identity`. All mock transports in tests updated.
- `Router::register_transport()` and `health_monitor()` now accept `Arc<NodeIdentity>` and thread it through to `transport.start()`. `PathweaveNode::register_transport()` passes `Arc::new(self.identity.clone())`.
- `BleTransport` gains a Linux-only `peripheral` field backed by `BlePeripheralState`, which holds the bluer `AdvertisementHandle`, `ApplicationHandle` (RAII guards), and `conn_rx`.
- On Linux, `BleTransport::start()` registers a bluer v0.17 GATT application (write-without-response + notify characteristics, `Io` method), advertises the Pathweave service UUID with `short_id` service data, and spawns `peripheral_loop`.
- `peripheral_loop` creates a `BlePeripheralConnection` on the `Notify` (Subscribe) event — not on `Write` — so `Session::respond()` can call `recv_bytes()` twice for the Noise_XX handshake. Write events are forwarded to the connection's internal channel. `active_write_tx.is_closed()` detects a completed connection so subsequent subscribers are accepted, not permanently rejected.
- `accept()` clones `Arc<Mutex<conn_rx>>` inside the outer lock, releases it, then awaits `recv()`, preventing a deadlock with `stop()` during health_monitor restarts.
- `stop()` drops `BlePeripheralState`, which drops the RAII handles, closes `peripheral_loop`'s control streams, and unblocks any waiting `accept()` call.
- `bluer` added as `[target.'cfg(target_os = "linux")'.dependencies]` in `pathweave-transport-ble`.
- ADR 014 committed documenting bluer API choices, accept-on-subscribe model, deadlock avoidance, and the `is_closed()` fix.

## Why

Phase 3 of v0.2.0. BLE peripheral mode is required for the pw-chat BLE fallback demo: at least one peer must advertise and accept incoming GATT connections. This issue also lands the `Transport::start(&NodeIdentity)` signature change (ADR 010) that was deferred from v0.1.0.

## How to test

On a Linux machine with BlueZ:

1. Run the peripheral: `cargo run --example pw-chat` (once pw-chat is updated in Phase 5). Until then, the peripheral path is exercised by the accept loop automatically when `BleTransport` is registered.
2. Run the central on a second machine: scan finds the Pathweave service UUID in advertisements, connects, completes the Noise_XX handshake.

Non-Linux: `cargo build --workspace` and `cargo test --workspace` must pass (both confirmed on Windows in CI).

Linux unit test: `accept_before_start_returns_error` confirms `accept()` returns an error before `start()` is called.

## Security considerations

- `short_id` (first 8 bytes of PeerId) is broadcast in the BLE advertisement. This is a deliberate tradeoff documented in ADR 002: partial identity disclosure in exchange for fast peer filtering without a full GATT connection. It was already the case for the central-mode advertisement parser; this PR adds the peripheral side of the same protocol.
- Private key material never leaves `NodeIdentity`. `start_peripheral` receives `&NodeIdentity` and immediately extracts 8 bytes of the public peer ID. No private key bytes are accessed or stored in the BLE crate.
- `peripheral_loop` does not authenticate writes before forwarding them to the connection channel. Authentication happens at the Noise_XX layer in `Session::respond()`, which is the first thing `handle_incoming` does with the accepted connection. Unauthenticated bytes can reach the channel but cannot pass the handshake.