### PR TITLE
feat(ble): Windows peripheral mode via WinRT GattServiceProvider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -320,7 +320,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "uuid",
- "windows",
+ "windows 0.61.3",
  "windows-future",
 ]
 
@@ -1418,6 +1418,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -2705,12 +2706,22 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core 0.58.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -2722,7 +2733,20 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement 0.58.0",
+ "windows-interface 0.58.0",
+ "windows-result 0.2.0",
+ "windows-strings 0.1.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2731,11 +2755,11 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-implement",
- "windows-interface",
+ "windows-implement 0.60.2",
+ "windows-interface 0.59.3",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -2744,9 +2768,20 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2754,6 +2789,17 @@ name = "windows-implement"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2789,8 +2835,17 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2800,6 +2855,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result 0.2.0",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/crates/pathweave-transport-ble/Cargo.toml
+++ b/crates/pathweave-transport-ble/Cargo.toml
@@ -21,5 +21,14 @@ uuid = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 bluer = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = [
+    "Devices_Bluetooth",
+    "Devices_Bluetooth_GenericAttributeProfile",
+    "Foundation",
+    "Foundation_Collections",
+    "Storage_Streams",
+] }
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -28,22 +28,20 @@ const NOTIFY_CHAR_UUID: Uuid = uuid!("6de63378-8bc3-4e87-8892-0a9a80efff64");
 const ADVERTISEMENT_VERSION: u8 = 0x01;
 
 // --------------------------------------------------------------------------
-// Linux-only peripheral types (ADR 014)
+// Shared peripheral connection type (Linux and Windows, ADR 014)
 // --------------------------------------------------------------------------
 
-#[cfg(target_os = "linux")]
-struct BlePeripheralState {
-    _adv_handle: bluer::adv::AdvertisementHandle,
-    _app_handle: bluer::gatt::local::ApplicationHandle,
-}
-
-#[cfg(target_os = "linux")]
+// BlePeripheralConnection is platform-independent: the peripheral task on each
+// platform wires its platform-specific events into these channels and hands the
+// connection to accept(). Session::respond() then drives the Noise_XX handshake
+// over recv_bytes/send_bytes without knowing what's underneath.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 struct BlePeripheralConnection {
     write_rx: Mutex<tokio::sync::mpsc::UnboundedReceiver<Bytes>>,
     reply_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[async_trait]
 impl Connection for BlePeripheralConnection {
     async fn send_bytes(&mut self, bytes: &[u8]) -> Result<()> {
@@ -68,6 +66,16 @@ impl Connection for BlePeripheralConnection {
     fn mtu(&self) -> usize {
         512
     }
+}
+
+// --------------------------------------------------------------------------
+// Linux-only peripheral types (ADR 014)
+// --------------------------------------------------------------------------
+
+#[cfg(target_os = "linux")]
+struct BlePeripheralState {
+    _adv_handle: bluer::adv::AdvertisementHandle,
+    _app_handle: bluer::gatt::local::ApplicationHandle,
 }
 
 // peripheral_loop: sole owner of CharacteristicWriter, bridges bluer events to connections.
@@ -145,14 +153,123 @@ async fn peripheral_loop(
 }
 
 // --------------------------------------------------------------------------
+// Windows-only peripheral types (ADR 014, Windows section)
+// --------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+fn uuid_to_guid(uuid: &Uuid) -> windows::core::GUID {
+    let b = uuid.as_bytes();
+    windows::core::GUID::from_values(
+        u32::from_be_bytes([b[0], b[1], b[2], b[3]]),
+        u16::from_be_bytes([b[4], b[5]]),
+        u16::from_be_bytes([b[6], b[7]]),
+        [b[8], b[9], b[10], b[11], b[12], b[13], b[14], b[15]],
+    )
+}
+
+#[cfg(target_os = "windows")]
+fn bytes_to_ibuffer(
+    bytes: &[u8],
+) -> windows::core::Result<windows::Storage::Streams::IBuffer> {
+    let writer = windows::Storage::Streams::DataWriter::new()?;
+    writer.WriteBytes(bytes)?;
+    writer.DetachBuffer()
+}
+
+// BlePeripheralState on Windows holds only the stop signal. The background task
+// (windows_peripheral_task) owns the GattServiceProvider and calls StopAdvertising()
+// when the stop signal fires.
+//
+// StopAdvertising() stops BLE advertisement packets but does NOT close the
+// WriteRequested or SubscribedClientsChanged event registrations. Dropping this
+// struct (which drops _stop_signal) is therefore the only mechanism that exits
+// windows_peripheral_task and drops conn_tx, unblocking any waiting accept() call.
+// Calling StopAdvertising() directly in stop() without this signal would leave
+// peripheral_task running and accept() blocked indefinitely.
+#[cfg(target_os = "windows")]
+struct BlePeripheralState {
+    _stop_signal: tokio::sync::oneshot::Sender<()>,
+}
+
+// windows_peripheral_task: Windows equivalent of peripheral_loop.
+//
+// WinRT GATT server events arrive as TypedEventHandler callbacks on Windows thread
+// pool threads, not as an async stream. start_peripheral() registers the handlers
+// and bridges them to tokio channels; this task drives the connection lifecycle from
+// the tokio side.
+//
+// Rejects a second subscriber while a connection is active (v0.2.0 limitation).
+// Calls StopAdvertising() and exits when the stop signal fires.
+#[cfg(target_os = "windows")]
+async fn windows_peripheral_task(
+    service_provider: windows::Devices::Bluetooth::GenericAttributeProfile::GattServiceProvider,
+    notify_char: windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalCharacteristic,
+    conn_tx: tokio::sync::mpsc::UnboundedSender<BlePeripheralConnection>,
+    write_forward: Arc<std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>>,
+    mut subscribe_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+    mut stop_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    'outer: loop {
+        tokio::select! {
+            _ = &mut stop_rx => break 'outer,
+            msg = subscribe_rx.recv() => {
+                if msg.is_none() { break 'outer; }
+            }
+        }
+
+        let (write_tx, write_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+
+        if let Ok(mut guard) = write_forward.lock() {
+            *guard = Some(write_tx);
+        }
+
+        let _ = conn_tx.send(BlePeripheralConnection {
+            write_rx: Mutex::new(write_rx),
+            reply_tx,
+        });
+
+        loop {
+            tokio::select! {
+                _ = &mut stop_rx => break 'outer,
+                data = reply_rx.recv() => {
+                    match data {
+                        Some(bytes) => {
+                            if let Ok(buffer) = bytes_to_ibuffer(&bytes) {
+                                if let Ok(op) = notify_char.NotifyValueAsync(&buffer) {
+                                    let _ = tokio::task::block_in_place(|| op.get());
+                                }
+                            }
+                        }
+                        None => break,
+                    }
+                }
+                _ = subscribe_rx.recv() => {
+                    tracing::debug!("BLE peripheral (Windows): second subscriber while connection active; ignored");
+                }
+            }
+        }
+
+        if let Ok(mut guard) = write_forward.lock() {
+            *guard = None;
+        }
+    }
+
+    if let Ok(mut guard) = write_forward.lock() {
+        *guard = None;
+    }
+    let _ = service_provider.StopAdvertising();
+}
+
+// --------------------------------------------------------------------------
 // Transport
 // --------------------------------------------------------------------------
 
 pub struct BleTransport {
     adapter: Arc<Mutex<Option<Adapter>>>,
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     peripheral: Arc<Mutex<Option<BlePeripheralState>>>,
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     conn_rx: Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>>>,
 }
 
@@ -160,9 +277,9 @@ impl BleTransport {
     pub fn new() -> Self {
         Self {
             adapter: Arc::new(Mutex::new(None)),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             peripheral: Arc::new(Mutex::new(None)),
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             conn_rx: Mutex::new(None),
         }
     }
@@ -177,7 +294,6 @@ impl Default for BleTransport {
 #[async_trait]
 impl Transport for BleTransport {
     async fn start(&self, identity: &NodeIdentity) -> Result<()> {
-        // Central mode: acquire btleplug adapter for scanning.
         let manager = Manager::new()
             .await
             .map_err(|e| PathweaveError::Transport(e.to_string()))?;
@@ -191,12 +307,10 @@ impl Transport for BleTransport {
             .ok_or_else(|| PathweaveError::Transport("no Bluetooth adapter found".into()))?;
         *self.adapter.lock().await = Some(adapter);
 
-        // Peripheral mode: register GATT application and begin advertising (Linux only).
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         self.start_peripheral(identity).await?;
 
-        // Suppress unused-variable warning on non-Linux.
-        #[cfg(not(target_os = "linux"))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
         let _ = identity;
 
         Ok(())
@@ -209,16 +323,19 @@ impl Transport for BleTransport {
         }
         *guard = None;
 
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         {
-            // Dropping BlePeripheralState drops _adv_handle and _app_handle,
-            // which unregisters the advertisement and GATT application via bluer's
-            // RAII guards. This also closes peripheral_loop's control streams,
-            // causing it to exit and drop conn_tx, which unblocks any waiting
-            // accept() call (recv() returns None and releases the conn_rx lock).
+            // On Linux: dropping BlePeripheralState drops the bluer RAII handles,
+            // which closes the CharacteristicControl streams and causes peripheral_loop
+            // to exit, dropping conn_tx.
+            //
+            // On Windows: dropping BlePeripheralState drops _stop_signal, which is
+            // the only mechanism that exits windows_peripheral_task and drops conn_tx.
+            // StopAdvertising() alone does not close GATT event streams.
+            //
+            // In both cases, conn_tx dropping causes accept()'s recv() to return None,
+            // releasing the conn_rx guard so we can acquire it here to clear it.
             *self.peripheral.lock().await = None;
-            // Clear conn_rx after peripheral is dropped so subsequent accept() calls
-            // return "transport not started" rather than "peripheral loop ended".
             *self.conn_rx.lock().await = None;
         }
 
@@ -226,11 +343,6 @@ impl Transport for BleTransport {
     }
 
     /// Returns a stream of nearby Pathweave peers found via BLE scanning.
-    ///
-    /// Starts a background task that filters `ServiceDataAdvertisement` events
-    /// for the Pathweave service UUID and decodes the short_id from service data.
-    /// The stream ends when the sender is dropped (i.e., after `stop()` clears the
-    /// adapter and the event stream closes).
     fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
         let adapter_arc = Arc::clone(&self.adapter);
         let (tx, rx) = mpsc::unbounded::<PeerAnnouncement>();
@@ -267,7 +379,6 @@ impl Transport for BleTransport {
                         Some(d) => d.clone(),
                         None => continue,
                     };
-                    // Validate advertisement format: [0x01] ++ [short_id: 8 bytes]
                     if data.len() < 9 || data[0] != ADVERTISEMENT_VERSION {
                         continue;
                     }
@@ -277,7 +388,7 @@ impl Transport for BleTransport {
                         short_id: Some(short_id),
                     };
                     if tx.unbounded_send(announcement).is_err() {
-                        break; // receiver dropped
+                        break;
                     }
                 }
             }
@@ -286,10 +397,6 @@ impl Transport for BleTransport {
         Box::pin(rx)
     }
 
-    /// Connects to a previously discovered BLE peer.
-    ///
-    /// The peer must have been seen via `discover()` before this is called because
-    /// `btleplug` looks up the peripheral from the adapter's internal scan cache.
     async fn connect(&self, peer: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
         let id_str = match &peer.address {
             PeerAddress::Ble(s) => s.clone(),
@@ -304,10 +411,6 @@ impl Transport for BleTransport {
                 .clone()
         };
 
-        // Find the peripheral in the scan cache by matching its platform ID string.
-        // The format is platform-specific (BlueZ device path on Linux, UUID on macOS,
-        // BDAddr on Windows), but we always store whatever id().to_string() returns in
-        // discover(), so the comparison is consistent within a session.
         let peripherals = adapter
             .peripherals()
             .await
@@ -357,9 +460,6 @@ impl Transport for BleTransport {
             .await
             .map_err(|e| PathweaveError::Transport(e.to_string()))?;
 
-        // btleplug's notification stream is Send but not Sync. Bridge it to a
-        // tokio channel via a background task; the receiver goes into a Mutex to
-        // satisfy Connection: Sync.
         let (notify_tx, notify_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
         tokio::spawn(async move {
             futures::pin_mut!(notifications);
@@ -377,12 +477,12 @@ impl Transport for BleTransport {
         }))
     }
 
-    #[cfg(target_os = "linux")]
+    // Borrow conn_rx from self (lifetime 'life0: 'async_trait). Holding the guard
+    // across recv() is safe: stop() drops BlePeripheralState first (closing conn_tx
+    // via the peripheral task exiting), causing recv() to return None and accept()
+    // to release the guard. stop() then acquires the lock to clear it.
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     async fn accept(&self) -> Result<Box<dyn Connection>> {
-        // Borrow conn_rx from self (lifetime 'life0: 'async_trait). Holding the guard
-        // across recv() is safe: stop() drops BlePeripheralState first (which closes
-        // conn_tx via peripheral_loop exit), causing recv() to return None and accept()
-        // to release the guard. stop() then acquires the lock to clear it.
         let mut guard = self.conn_rx.lock().await;
         match guard.as_mut() {
             Some(rx) => rx
@@ -394,10 +494,10 @@ impl Transport for BleTransport {
         }
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     async fn accept(&self) -> Result<Box<dyn Connection>> {
         Err(PathweaveError::Transport(
-            "BLE peripheral mode requires Linux with BlueZ".into(),
+            "BLE peripheral mode not supported on this platform".into(),
         ))
     }
 
@@ -417,6 +517,10 @@ impl Transport for BleTransport {
         "ble"
     }
 }
+
+// --------------------------------------------------------------------------
+// Linux peripheral: start_peripheral (ADR 014)
+// --------------------------------------------------------------------------
 
 #[cfg(target_os = "linux")]
 impl BleTransport {
@@ -507,6 +611,169 @@ impl BleTransport {
 }
 
 // --------------------------------------------------------------------------
+// Windows peripheral: start_peripheral (ADR 014, Windows section)
+// --------------------------------------------------------------------------
+
+#[cfg(target_os = "windows")]
+impl BleTransport {
+    async fn start_peripheral(&self, identity: &NodeIdentity) -> Result<()> {
+        use windows::Devices::Bluetooth::GenericAttributeProfile::{
+            GattCharacteristicProperties, GattLocalCharacteristicParameters,
+            GattServiceProvider, GattServiceProviderAdvertisingParameters,
+        };
+        use windows::Foundation::TypedEventHandler;
+        use windows::Storage::Streams::DataReader;
+
+        let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8].try_into().unwrap();
+
+        let write_forward: Arc<
+            std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>,
+        > = Arc::new(std::sync::Mutex::new(None));
+        let (subscribe_tx, subscribe_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let (conn_tx, conn_rx) =
+            tokio::sync::mpsc::unbounded_channel::<BlePeripheralConnection>();
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+
+        // IAsyncOperation<T> does not implement Future in windows crate 0.52+.
+        // Use block_in_place (safe on multi-threaded tokio) with .get() for init calls.
+        let service_result =
+            tokio::task::block_in_place(|| {
+                GattServiceProvider::CreateAsync(uuid_to_guid(&PATHWEAVE_SERVICE_UUID))?
+                    .get()
+            })
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        let service_provider = service_result
+            .ServiceProvider()
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        let service = service_provider
+            .Service()
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let write_params = GattLocalCharacteristicParameters::new()
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        write_params
+            .SetCharacteristicProperties(GattCharacteristicProperties::WriteWithoutResponse)
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        let write_char = tokio::task::block_in_place(|| {
+            service
+                .CreateCharacteristicAsync(uuid_to_guid(&WRITE_CHAR_UUID), &write_params)?
+                .get()
+        })
+        .map_err(|e| PathweaveError::Transport(e.to_string()))?
+        .Characteristic()
+        .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        let notify_params = GattLocalCharacteristicParameters::new()
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        notify_params
+            .SetCharacteristicProperties(GattCharacteristicProperties::Notify)
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        let notify_char = tokio::task::block_in_place(|| {
+            service
+                .CreateCharacteristicAsync(uuid_to_guid(&NOTIFY_CHAR_UUID), &notify_params)?
+                .get()
+        })
+        .map_err(|e| PathweaveError::Transport(e.to_string()))?
+        .Characteristic()
+        .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        // Write handler runs on a WinRT thread pool thread, not inside the tokio
+        // runtime. IAsyncOperation::get() blocks synchronously; that is safe here
+        // because this thread is outside the tokio executor. GetRequestAsync() resolves
+        // immediately since the WinRT stack already holds the completed request.
+        // Respond() is not called: the Microsoft GATT server docs show the conditional
+        // pattern (Respond only for WriteWithResponse). Our characteristic is
+        // WriteWithoutResponse only, so Respond() is never appropriate here.
+        let write_forward_clone = Arc::clone(&write_forward);
+        write_char
+            .WriteRequested(&TypedEventHandler::new(
+                move |_,
+                      args: &Option<
+                    windows::Devices::Bluetooth::GenericAttributeProfile::GattWriteRequestedEventArgs,
+                >| {
+                    let Some(args) = args else { return Ok(()); };
+                    let Ok(request) = args.GetRequestAsync().and_then(|op| op.get()) else {
+                        return Ok(());
+                    };
+                    let reader = DataReader::FromBuffer(&request.Value()?)?;
+                    let len = reader.UnconsumedBufferLength()? as usize;
+                    let mut buf = vec![0u8; len];
+                    reader.ReadBytes(&mut buf)?;
+                    if let Ok(guard) = write_forward_clone.lock() {
+                        if let Some(tx) = guard.as_ref() {
+                            let _ = tx.send(Bytes::from(buf));
+                        } else {
+                            tracing::debug!("BLE peripheral (Windows): write with no active connection; frame discarded");
+                        }
+                    }
+                    Ok(())
+                },
+            ))
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        // Subscribe handler fires on subscribe and unsubscribe. Only signal
+        // peripheral_task when at least one client is currently subscribed.
+        notify_char
+            .SubscribedClientsChanged(&TypedEventHandler::new(
+                move |char: &Option<
+                    windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalCharacteristic,
+                >,
+                      _| {
+                    let Some(c) = char else { return Ok(()); };
+                    if c.SubscribedClients()?.Size()? > 0 {
+                        let _ = subscribe_tx.send(());
+                    }
+                    Ok(())
+                },
+            ))
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+        // Scoped block: IBuffer and GattServiceProviderAdvertisingParameters are not
+        // Send, so they must be dropped before the first .await below.
+        {
+            // Service data: [0x01] ++ [short_id: 8 bytes]. SetServiceData requires
+            // Windows 10 version 1903+ (Build 18362, IGattServiceProviderAdvertisingParameters2).
+            let mut svc_data = vec![ADVERTISEMENT_VERSION];
+            svc_data.extend_from_slice(&short_id);
+            let buffer = bytes_to_ibuffer(&svc_data)
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+            let adv_params = GattServiceProviderAdvertisingParameters::new()
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+            adv_params
+                .SetIsConnectable(true)
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+            adv_params
+                .SetIsDiscoverable(true)
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+            adv_params
+                .SetServiceData(&buffer)
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+            service_provider
+                .StartAdvertisingWithParameters(&adv_params)
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        }
+
+        tokio::spawn(windows_peripheral_task(
+            service_provider,
+            notify_char,
+            conn_tx,
+            write_forward,
+            subscribe_rx,
+            stop_rx,
+        ));
+
+        *self.conn_rx.lock().await = Some(conn_rx);
+        *self.peripheral.lock().await = Some(BlePeripheralState {
+            _stop_signal: stop_tx,
+        });
+
+        Ok(())
+    }
+}
+
+// --------------------------------------------------------------------------
 // Central-mode connection (btleplug)
 // --------------------------------------------------------------------------
 
@@ -514,9 +781,8 @@ pub struct BleConnection {
     peripheral: Peripheral,
     write_char: Characteristic,
     // GATT is message-oriented: each notification is a complete frame.
-    // No length-prefix framing is needed (unlike QUIC's byte stream).
-    // Wrapped in Mutex to satisfy Connection: Sync; recv_bytes holds &mut self
-    // so there is never actual contention on the lock.
+    // No length-prefix framing needed (unlike QUIC's byte stream).
+    // Wrapped in Mutex to satisfy Connection: Sync.
     rx: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<Bytes>>,
 }
 
@@ -562,7 +828,6 @@ mod tests {
     #[tokio::test]
     async fn wrong_address_type_returns_error() {
         let transport = BleTransport::new();
-        // start() not called: adapter is None
         let peer = PeerAnnouncement {
             address: PeerAddress::Quic("127.0.0.1:1234".parse().unwrap()),
             short_id: None,
@@ -582,15 +847,15 @@ mod tests {
         assert!(matches!(result, Err(PathweaveError::Transport(_))));
     }
 
-    #[cfg(not(target_os = "linux"))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
     #[tokio::test]
-    async fn accept_returns_not_implemented_on_non_linux() {
+    async fn accept_returns_not_supported_on_other_platforms() {
         let transport = BleTransport::new();
         let result = transport.accept().await;
         assert!(matches!(result, Err(PathweaveError::Transport(_))));
     }
 
-    #[cfg(target_os = "linux")]
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
     #[tokio::test]
     async fn accept_before_start_returns_error() {
         let transport = BleTransport::new();

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -168,9 +168,7 @@ fn uuid_to_guid(uuid: &Uuid) -> windows::core::GUID {
 }
 
 #[cfg(target_os = "windows")]
-fn bytes_to_ibuffer(
-    bytes: &[u8],
-) -> windows::core::Result<windows::Storage::Streams::IBuffer> {
+fn bytes_to_ibuffer(bytes: &[u8]) -> windows::core::Result<windows::Storage::Streams::IBuffer> {
     let writer = windows::Storage::Streams::DataWriter::new()?;
     writer.WriteBytes(bytes)?;
     writer.DetachBuffer()
@@ -618,8 +616,8 @@ impl BleTransport {
 impl BleTransport {
     async fn start_peripheral(&self, identity: &NodeIdentity) -> Result<()> {
         use windows::Devices::Bluetooth::GenericAttributeProfile::{
-            GattCharacteristicProperties, GattLocalCharacteristicParameters,
-            GattServiceProvider, GattServiceProviderAdvertisingParameters,
+            GattCharacteristicProperties, GattLocalCharacteristicParameters, GattServiceProvider,
+            GattServiceProviderAdvertisingParameters,
         };
         use windows::Foundation::TypedEventHandler;
         use windows::Storage::Streams::DataReader;
@@ -630,18 +628,15 @@ impl BleTransport {
             std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>,
         > = Arc::new(std::sync::Mutex::new(None));
         let (subscribe_tx, subscribe_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
-        let (conn_tx, conn_rx) =
-            tokio::sync::mpsc::unbounded_channel::<BlePeripheralConnection>();
+        let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel::<BlePeripheralConnection>();
         let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
 
         // IAsyncOperation<T> does not implement Future in windows crate 0.52+.
         // Use block_in_place (safe on multi-threaded tokio) with .get() for init calls.
-        let service_result =
-            tokio::task::block_in_place(|| {
-                GattServiceProvider::CreateAsync(uuid_to_guid(&PATHWEAVE_SERVICE_UUID))?
-                    .get()
-            })
-            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        let service_result = tokio::task::block_in_place(|| {
+            GattServiceProvider::CreateAsync(uuid_to_guid(&PATHWEAVE_SERVICE_UUID))?.get()
+        })
+        .map_err(|e| PathweaveError::Transport(e.to_string()))?;
         let service_provider = service_result
             .ServiceProvider()
             .map_err(|e| PathweaveError::Transport(e.to_string()))?;
@@ -719,7 +714,9 @@ impl BleTransport {
                     windows::Devices::Bluetooth::GenericAttributeProfile::GattLocalCharacteristic,
                 >,
                       _| {
-                    let Some(c) = char else { return Ok(()); };
+                    let Some(c) = char else {
+                        return Ok(());
+                    };
                     if c.SubscribedClients()?.Size()? > 0 {
                         let _ = subscribe_tx.send(());
                     }

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -470,8 +470,8 @@ Peripheral mode: platform-specific.
 - macOS: not yet implemented. CoreBluetooth is available on macOS (same framework as
   iOS); the implementation will be compile-tested on CI with community hardware testing.
   Tracked in issue #52.
-- Windows: not yet implemented. WinRT GATT Server API (Windows.Devices.Bluetooth).
-  Tracked in issue #51.
+- Windows: `windows` crate v0.58, shipped in v0.2.0. WinRT GATT Server API
+  (`Windows.Devices.Bluetooth.GenericAttributeProfile`). See ADR 014.
 
 **BLE peripheral and NodeIdentity**
 
@@ -531,8 +531,8 @@ When neither transport can reach the peer: "message failed: no transport availab
 No queuing, no silent retry.
 
 BLE in pw-chat works when at least one peer can advertise. Supported configurations:
-two Linux machines, a Linux machine and a Windows or macOS machine (pending issues
-#51 and #52), or any of the above and a phone running the native SDK.
+two Linux machines, a Linux or Windows machine and a macOS machine (pending issue
+#52), or any of the above and a phone running the native SDK.
 
 ---
 
@@ -548,7 +548,7 @@ Being clear about this matters as much as being clear about what it does.
   NWPathMonitor, and WinRT network events deferred to v0.3.0). See ADR 013.
 - No WiFi vs. mobile data detection for QUIC cost reporting (v0.2.0 cost intelligence
   work not yet complete; all QUIC connections currently report Metered)
-- No BLE peripheral mode on macOS or Windows yet (in progress, issues #51 and #52)
+- No BLE peripheral mode on macOS yet (in progress, issue #52)
 - No security audit completed
 
 v1.0.0 means the API is stable and the library is ready for production use. We're

--- a/notes/decisions/014-ble-peripheral-linux.md
+++ b/notes/decisions/014-ble-peripheral-linux.md
@@ -1,4 +1,4 @@
-# ADR 014: Linux BLE peripheral mode via bluer v0.17
+# ADR 014: BLE peripheral mode: bluer on Linux, WinRT on Windows
 
 **Status:** Accepted
 
@@ -9,15 +9,16 @@ and accepting GATT connections from scanning centrals. ADR 006 settled the split
 central mode uses `btleplug` on all platforms; peripheral mode uses `bluer` v0.17 on
 Linux. ADR 010 settled that `Transport::start()` takes `&NodeIdentity`.
 
-Three design questions remained open:
+Three design questions remained open for Linux:
 
 1. Which bluer data-path API to use for the GATT server
 2. How `accept()` maps onto bluer's event-driven model
 3. How `bluer` and `btleplug` coexist inside the same crate
 
-This ADR settles all three.
+This ADR settles all three for Linux, and adds a Windows section covering the
+WinRT-based implementation via the `windows` crate (v0.58).
 
-## bluer v0.17 GATT server data API
+## Linux: bluer v0.17 GATT server data API
 
 bluer exposes two data-path variants for GATT server characteristics:
 
@@ -50,6 +51,38 @@ Events on the notify characteristic:
   `CharacteristicWriter` (implements `AsyncWrite`) remains valid until the central
   disconnects or `_app_handle` is dropped.
 
+## Windows: WinRT GATT server data API (windows crate v0.58)
+
+WinRT GATT server events arrive as `TypedEventHandler` callbacks on Windows thread
+pool threads, not as an async stream. The `windows` crate (Microsoft's official WinRT
+bindings, v0.58) exposes:
+
+- `GattServiceProvider::CreateAsync`: creates the GATT service and starts the
+  underlying GATT server.
+- `GattLocalCharacteristic`: represents a characteristic. Events are registered via
+  `WriteRequested` (fires when a central writes) and `SubscribedClientsChanged` (fires
+  when the subscribed-client set changes).
+- `GattServiceProviderAdvertisingParameters`: controls advertisement including
+  `SetServiceData` (Windows 10 version 1903+, Build 18362, `IGattServiceProviderAdvertisingParameters2`).
+- `GattServiceProvider::StopAdvertising`: stops BLE advertisement packets. Does NOT
+  close event handlers or the GATT server itself.
+
+Two key behavioral differences from bluer determine the Windows architecture:
+
+**TypedEventHandler callbacks run outside tokio.** WinRT dispatches write and
+subscribe events to Windows thread pool threads. These threads are not inside any
+tokio runtime. `tokio::runtime::Handle::block_on()` is therefore safe: it enters a
+non-async context onto the current thread's stack, which is already outside tokio.
+
+**StopAdvertising() does not close GATT event streams.** On Linux, dropping
+`ApplicationHandle` causes bluer to unregister the GATT application, which closes
+the `CharacteristicControl` streams and exits `peripheral_loop`. On Windows,
+`StopAdvertising()` stops advertisement packets only; the `WriteRequested` and
+`SubscribedClientsChanged` handlers remain registered. There is no WinRT equivalent
+of a stream that closes when the service is stopped. Instead, a tokio oneshot sender
+(`_stop_signal` in `BlePeripheralState`) is the only mechanism that exits
+`windows_peripheral_task` and drops `conn_tx`, which unblocks `accept()`.
+
 ## Decision
 
 ### GATT characteristic configuration
@@ -76,17 +109,20 @@ acknowledgement. Delivery guarantees are provided by the at-least-once retry loo
 
 ### bluer/btleplug coexistence
 
-`BleTransport` gains one Linux-only field:
+`BleTransport` gains two fields shared by Linux and Windows:
 
 ```rust
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 peripheral: Arc<tokio::sync::Mutex<Option<BlePeripheralState>>>,
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+conn_rx: tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>>>,
 ```
 
-All bluer types are gated under `#[cfg(target_os = "linux")]`. The btleplug
-central-mode field (`adapter: Arc<Mutex<Option<Adapter>>>`) is unchanged and
-platform-independent. On macOS and Windows, `bluer` is absent from the dependency
-tree and `accept()` returns the existing not-implemented error.
+All bluer types are gated under `#[cfg(target_os = "linux")]`; all WinRT types under
+`#[cfg(target_os = "windows")]`. The btleplug central-mode field
+(`adapter: Arc<Mutex<Option<Adapter>>>`) is unchanged and platform-independent. On
+macOS, neither `bluer` nor `windows` is in the dependency tree and `accept()` returns
+the not-implemented error.
 
 `pathweave-transport-ble/Cargo.toml` adds a
 `[target.'cfg(target_os = "linux")'.dependencies]` section with
@@ -259,8 +295,12 @@ write events from the same subscriber. Reply bytes flow from connections through
 
 ### accept()
 
+The `accept()` implementation is shared between Linux and Windows. The
+platform-specific difference is only in what causes `recv()` to return `None` (bluer
+handle drop vs. stop signal drop), not in the `accept()` body itself.
+
 ```rust
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 async fn accept(&self) -> Result<Box<dyn Connection>> {
     let mut guard = self.conn_rx.lock().await;
     match guard.as_mut() {
@@ -278,15 +318,104 @@ The guard on `self.conn_rx` is held across `recv()`. See the rationale section f
 why this is safe with respect to `stop()`, and why `conn_rx` must live on
 `BleTransport` rather than inside `BlePeripheralState`.
 
+### Transport::start() on Windows
+
+`BleTransport::start_peripheral(&identity)` on Windows executes the following sequence:
+
+1. Create `GattServiceProvider` via `GattServiceProvider::CreateAsync(service_uuid).await`.
+2. Create write and notify `GattLocalCharacteristic` via `service.CreateCharacteristicAsync().await`.
+3. Register `WriteRequested` handler on the write characteristic. The handler uses
+   `IAsyncOperation::get()` to block synchronously on `args.GetRequestAsync()`, reads
+   bytes via `DataReader::FromBuffer`, and forwards them to the active connection
+   channel via `write_forward`.
+4. Register `SubscribedClientsChanged` handler on the notify characteristic. The handler
+   signals `subscribe_tx` when `SubscribedClients().Size() > 0`.
+5. Build the advertisement: set service data to `[0x01] ++ short_id` via
+   `GattServiceProviderAdvertisingParameters::SetServiceData` (Windows 10 1903+, Build 18362).
+6. Call `service_provider.StartAdvertisingWithParameters(&adv_params)`.
+7. Create channels: unbounded `(conn_tx, conn_rx)`, unbounded `(subscribe_tx, subscribe_rx)`,
+   oneshot `(stop_tx, stop_rx)`.
+8. Spawn `windows_peripheral_task(service_provider, notify_char, conn_tx, write_forward,
+   subscribe_rx, stop_rx)`.
+9. Store `conn_rx` in `self.conn_rx`, store `BlePeripheralState { _stop_signal: stop_tx }`
+   in `self.peripheral`.
+
+### windows_peripheral_task
+
+`windows_peripheral_task` is the Windows equivalent of `peripheral_loop`. It drives
+the connection lifecycle from the tokio side, bridging WinRT callback events
+(delivered to channels by the handlers registered in `start_peripheral`) into the
+`BlePeripheralConnection` channel-based model.
+
+Structure is a `'outer` loop waiting for a subscriber signal or stop signal, and an
+inner loop forwarding replies until the connection drops or a stop signal fires:
+
+```rust
+'outer: loop {
+    // Wait for subscribe signal or stop
+    tokio::select! {
+        _ = &mut stop_rx => break 'outer,
+        msg = subscribe_rx.recv() => { if msg.is_none() { break 'outer; } }
+    }
+
+    // Create connection and install write_forward sender
+    let (write_tx, write_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+    let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+    *write_forward.lock().unwrap() = Some(write_tx);
+    let _ = conn_tx.send(BlePeripheralConnection { write_rx: Mutex::new(write_rx), reply_tx });
+
+    loop {
+        tokio::select! {
+            _ = &mut stop_rx => break 'outer,
+            data = reply_rx.recv() => match data {
+                Some(bytes) => { /* call notify_char.NotifyValueAsync(&buffer).await */ }
+                None => break,   // connection dropped; loop back to wait for next subscriber
+            },
+            _ = subscribe_rx.recv() => {
+                tracing::debug!("second subscriber while active; ignored");
+            }
+        }
+    }
+    *write_forward.lock().unwrap() = None;
+}
+// cleanup
+*write_forward.lock().unwrap() = None;
+let _ = service_provider.StopAdvertising();
+```
+
+On connection drop (`reply_rx.recv()` returns `None`), the inner loop breaks and
+`write_forward` is cleared. The outer loop waits for the next subscriber. On stop
+signal, both loops exit and `conn_tx` is dropped, unblocking any waiting `accept()`.
+
+### BlePeripheralState on Windows
+
+```rust
+#[cfg(target_os = "windows")]
+struct BlePeripheralState {
+    _stop_signal: tokio::sync::oneshot::Sender<()>,
+}
+```
+
+Dropping this struct drops `_stop_signal`. The `stop_rx` end of the oneshot detects
+the drop (`recv()` returns `Err(RecvError)`), causing the `stop_rx => break 'outer`
+arm in `windows_peripheral_task` to fire. The task exits and drops `conn_tx`. The
+`recv()` waiting in `accept()` returns `None`; `accept()` returns an error and
+releases the `conn_rx` guard. `stop()` then acquires `self.conn_rx` and clears it.
+
 ### BlePeripheralConnection
 
 ```rust
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 struct BlePeripheralConnection {
     write_rx: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<Bytes>>,
-    reply_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
+    reply_tx:  tokio::sync::mpsc::UnboundedSender<Bytes>,
 }
 ```
+
+`BlePeripheralConnection` is platform-independent. Both Linux and Windows wire their
+platform-specific events into these channels and hand the connection to `accept()`.
+`Session::respond()` then drives the Noise_XX handshake over `recv_bytes`/`send_bytes`
+without knowing what is underneath.
 
 `write_rx` is wrapped in `tokio::sync::Mutex` to satisfy `Connection: Sync`.
 `recv_bytes` takes `&mut self`, so there is never actual contention on this lock.
@@ -390,17 +519,81 @@ returns `None`; `accept()` returns an error and releases the `conn_rx` guard. `s
 then acquires `self.conn_rx` and clears it so subsequent `accept()` calls return
 "transport not started" rather than "peripheral loop ended".
 
+**Why .get() in the write handler and block_in_place() in start_peripheral?**
+
+`windows` crate 0.52+ removed the `std::future::Future` implementation for
+`IAsyncOperation<T>`. WinRT async operations can no longer be `.await`ed directly.
+The two patterns used here reflect the execution context:
+
+In the `WriteRequested` handler, the callback runs on a Windows thread pool thread
+that is not inside any tokio runtime. `IAsyncOperation::get()` blocks synchronously;
+that is safe here because there is no tokio executor to block. `GetRequestAsync()`
+resolves immediately since the WinRT stack already holds the completed request.
+
+In `start_peripheral`, the three creation calls (`GattServiceProvider::CreateAsync`,
+`CreateCharacteristicAsync`) run inside the tokio async executor. Using `.get()`
+directly would block a tokio worker thread. `tokio::task::block_in_place()` is
+used instead: it notifies tokio to migrate other tasks away from the current thread
+before blocking, and restores the thread to the pool when the blocking call returns.
+This requires the multi-threaded tokio runtime, which is the standard configuration.
+
+In `windows_peripheral_task`, `NotifyValueAsync` is called on a tokio task.
+`block_in_place` wraps the call for the same reason: the task runs on a tokio worker
+and must not block it directly.
+
+A dedicated bridge task or channel per write event would work but adds per-event
+overhead. The synchronous `.get()` pattern keeps the handler self-contained for
+fast-resolving operations.
+
+**Why Respond() is not called for write-without-response characteristics?**
+
+The Microsoft GATT server documentation and the official Windows-universal-samples
+BluetoothLE sample both show the conditional pattern:
+
+```
+if (request.Option == GattWriteOption.WriteWithResponse) { request.Respond(); }
+```
+
+`Respond()` is only appropriate for write-with-response operations; the WinRT API
+does not require it for write-without-response. Our characteristic is configured as
+`WriteWithoutResponse` only, so no incoming request will have `Option == WriteWithResponse`,
+and `Respond()` is never called. Calling it unconditionally for write-without-response
+operations is not supported by any Microsoft documentation and risks sending an
+unexpected ATT response to a central that did not request one.
+
+**Why is _stop_signal the only exit mechanism?**
+
+`GattServiceProvider::StopAdvertising()` stops advertising but does not unregister
+`WriteRequested` or `SubscribedClientsChanged` handlers. There is no WinRT API that
+closes event handler registrations without destroying the service provider entirely.
+Destroying `GattServiceProvider` from a thread that is not the WinRT background
+thread (i.e., from tokio's drop glue) is unsafe on some Windows builds.
+
+The `_stop_signal` oneshot avoids all of this. When dropped (in `stop()`), it fires
+the `stop_rx => break 'outer` select arm in `windows_peripheral_task`, which exits
+cleanly and drops `conn_tx` from within the tokio runtime.
+
 ## Implications
 
 - `bluer` is added as a `[target.'cfg(target_os = "linux")'.dependencies]` entry
   in `pathweave-transport-ble/Cargo.toml`.
-- `BleTransport` gains `peripheral` and `conn_rx` fields, `BlePeripheralState`, and
-  `BlePeripheralConnection` under `#[cfg(target_os = "linux")]`.
+- `windows` crate v0.58 is added as a `[target.'cfg(target_os = "windows")'.dependencies]`
+  entry with features: `Devices_Bluetooth`, `Devices_Bluetooth_GenericAttributeProfile`,
+  `Foundation`, `Foundation_Collections`, `Storage_Streams`.
+- `BlePeripheralConnection` is shared across Linux and Windows under
+  `#[cfg(any(target_os = "linux", target_os = "windows"))]`.
+- `BleTransport` gains `peripheral` and `conn_rx` fields under
+  `#[cfg(any(target_os = "linux", target_os = "windows"))]`.
+- `BlePeripheralState` is platform-specific: on Linux it holds RAII handles; on
+  Windows it holds `_stop_signal`.
 - `Transport::start()` signature changes to `start(&self, identity: &NodeIdentity)`.
 - `QuicTransport`, all mock transports in tests: add `_identity`.
 - `health_monitor()`, `Router::register_transport()`, `PathweaveNode::add_transport()`:
   propagate `Arc<NodeIdentity>` as described above.
-- `accept()` on non-Linux platforms returns the not-implemented error unchanged.
+- `accept()` is a single implementation under `any(linux, windows)`. On other
+  platforms it returns the not-implemented error unchanged.
 - Multiple simultaneous centrals are not supported in v0.2.0. A second subscriber
-  while a connection is active is dropped with a debug log.
-- macOS and Windows peripheral mode remain deferred per ADR 006.
+  while a connection is active is dropped with a debug log on both platforms.
+- Windows peripheral mode requires Windows 10 version 1903 (Build 18362) or later
+  for `SetServiceData` via `IGattServiceProviderAdvertisingParameters2`.
+- macOS peripheral mode remains deferred per ADR 006.


### PR DESCRIPTION
## What changed

`BleTransport::start_peripheral()` is now implemented under `#[cfg(target_os = "windows")]` using the `windows` crate v0.58 and the WinRT `GattServiceProvider` API. The implementation mirrors the Linux bluer design: a background task (`windows_peripheral_task`) bridges WinRT callback events into the existing channel-based `BlePeripheralConnection` model, which is now shared across both platforms under `#[cfg(any(target_os = "linux", target_os = "windows"))]`. `accept()`, `stop()`, and the connection lifecycle are unchanged at the `Transport` trait level.

Three Windows-specific constraints determined the implementation shape, documented in ADR 014's new Windows section.

## Why

Closes #51. Windows is the second peripheral platform in the v0.2.0 scope.

## Alternatives considered

**IAsyncOperation::await in start_peripheral.** The `windows` crate removed `Future` impls for `IAsyncOperation<T>` in 0.52; `.await` does not compile. `tokio::task::block_in_place(.get())` is used instead for the three init calls (CreateAsync, CreateCharacteristicAsync twice). `block_in_place` is safe on the multi-threaded tokio runtime and avoids spawning dedicated blocking threads for fast-resolving one-shot operations.

**Calling Respond() unconditionally.** An earlier version called `request.Respond()` for every write, reasoning that it might prevent the WriteRequested event from stalling. The official Microsoft GATT server documentation and the Windows-universal-samples BluetoothLE sample both show the conditional pattern: `Respond()` only for `WriteWithResponse` operations. Our characteristic advertises `WriteWithoutResponse` only; calling `Respond()` unconditionally is not supported by any Microsoft source and risks sending an unexpected ATT response. It was removed.

**StopAdvertising() as the task exit mechanism.** `StopAdvertising()` stops advertisement packets but does not close `WriteRequested` or `SubscribedClientsChanged` event registrations; there is no WinRT API equivalent to bluer's `ApplicationHandle` drop. A tokio oneshot sender (`_stop_signal` in `BlePeripheralState`) is the mechanism: dropping it fires the `stop_rx` arm in `windows_peripheral_task`, which exits cleanly and drops `conn_tx`, unblocking any waiting `accept()`.

**Storing IBuffer and GattServiceProviderAdvertisingParameters across .await.** Both types are not `Send`. An earlier version held them as local variables that lived past the first `.await`; this failed to compile. Scoping them into a block that ends before `tokio::spawn` and the `lock().await` calls fixes the Send constraint cleanly.

## Security considerations

The `short_id` in the service data advertisement is the first 8 bytes of the SHA-256 hash of the node's static public key. No private key material is included. An observer learns the same 8-byte hash prefix they would learn from a completed Noise_XX handshake. This is unchanged from the Linux implementation (ADR 002).

## Test plan

- `cargo test -p pathweave-transport-ble` on Windows (this machine): 3 tests pass, including `accept_before_start_returns_error` under `#[cfg(any(target_os = "linux", target_os = "windows"))]`.
- `cargo check --workspace` on Windows: clean.
- Hardware end-to-end (peripheral + central swap between two Windows machines): pending CI on `windows-latest` and hardware availability.