### PR TITLE
feat(ble): macOS peripheral mode via CoreBluetooth CBPeripheralManager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -208,7 +208,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
 dependencies = [
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -311,9 +320,9 @@ dependencies = [
  "jni 0.19.0",
  "jni-utils",
  "log",
- "objc2",
- "objc2-core-bluetooth",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-core-bluetooth 0.2.2",
+ "objc2-foundation 0.2.2",
  "once_cell",
  "static_assertions",
  "thiserror 2.0.18",
@@ -712,6 +721,18 @@ name = "discard"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212d0f5754cb6769937f4501cc0e67f4f4483c8d2c3e1e922ee9edbe4ab4c7c0"
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.4",
+]
 
 [[package]]
 name = "displaydoc"
@@ -1319,14 +1340,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-bluetooth"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a644b62ffb826a5277f536cf0f701493de420b13d40e700c452c36567771111"
 dependencies = [
  "bitflags 2.11.1",
- "objc2",
- "objc2-foundation",
+ "objc2 0.5.2",
+ "objc2-foundation 0.2.2",
+]
+
+[[package]]
+name = "objc2-core-bluetooth"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79b30b9eacc37434a61377866f68b27acef9fa5496f25cc9ca8b2549032e0394"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.11.1",
+ "dispatch2",
+ "objc2 0.6.4",
 ]
 
 [[package]]
@@ -1342,9 +1396,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
  "bitflags 2.11.1",
- "block2",
+ "block2 0.5.1",
  "libc",
- "objc2",
+ "objc2 0.5.2",
+]
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.11.1",
+ "block2 0.6.2",
+ "libc",
+ "objc2 0.6.4",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -1412,7 +1479,11 @@ dependencies = [
  "bluer",
  "btleplug",
  "bytes",
+ "dispatch2",
  "futures",
+ "objc2 0.6.4",
+ "objc2-core-bluetooth 0.3.2",
+ "objc2-foundation 0.3.2",
  "pathweave-core",
  "thiserror 2.0.18",
  "tokio",

--- a/crates/pathweave-transport-ble/Cargo.toml
+++ b/crates/pathweave-transport-ble/Cargo.toml
@@ -30,5 +30,28 @@ windows = { version = "0.58", features = [
     "Storage_Streams",
 ] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-core-bluetooth = { version = "0.3.2", features = [
+    "CBManager",
+    "CBPeripheralManager",
+    "CBCharacteristic",
+    "CBService",
+    "CBUUID",
+    "CBATTRequest",
+    "CBCentral",
+    "CBPeer",
+    "CBAdvertisementData",
+    "dispatch2",
+] }
+objc2 = "0.6"
+objc2-foundation = { version = "0.3", features = [
+    "alloc",
+    "NSArray",
+    "NSData",
+    "NSDictionary",
+    "NSString",
+] }
+dispatch2 = "0.3"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -292,7 +292,7 @@ struct PeripheralDelegateBridge {
 mod macos_delegate {
     use super::*;
     use objc2::rc::Retained;
-    use objc2::{define_class, msg_send, DefinedClass};
+    use objc2::{define_class, msg_send, AllocAnyThread, DefinedClass};
     use objc2_core_bluetooth::{
         CBATTError, CBCentral, CBCharacteristic, CBPeripheralManager, CBPeripheralManagerDelegate,
     };
@@ -318,8 +318,7 @@ mod macos_delegate {
             fn did_update_state(&self, manager: &CBPeripheralManager) {
                 tracing::debug!("CBPeripheralManager state changed: {:?}", unsafe {
                     manager.state()
-                }
-                    as u64);
+                });
             }
 
             #[unsafe(method(peripheralManager:central:didSubscribeToCharacteristic:))]
@@ -343,7 +342,7 @@ mod macos_delegate {
             ) {
                 for req in unsafe { requests.iter() } {
                     if let Some(data) = unsafe { req.value() } {
-                        let bytes = Bytes::copy_from_slice(unsafe { data.as_bytes() });
+                        let bytes = Bytes::copy_from_slice(unsafe { data.as_bytes_unchecked() });
                         if let Ok(guard) = self.ivars().bridge.write_forward.lock() {
                             if let Some(tx) = guard.as_ref() {
                                 let _ = tx.send(bytes);
@@ -356,7 +355,7 @@ mod macos_delegate {
                     }
                 }
                 // Respond to the first request; CoreBluetooth applies it to the batch.
-                if let Some(first) = unsafe { requests.first() } {
+                if let Some(first) = unsafe { requests.firstObject_unchecked() } {
                     unsafe { manager.respondToRequest_withResult(first, CBATTError::Success) };
                 }
             }
@@ -374,29 +373,32 @@ mod macos_delegate {
     }
 }
 
+// SendPtr<T>: raw pointer wrapper that is Send. CBPeripheralManager and
+// CBMutableCharacteristic are not Send on their own; wrapping them here lets
+// macos_peripheral_task's future be Send so tokio::spawn accepts it.
+#[cfg(target_os = "macos")]
+struct SendPtr<T>(*mut T);
+#[cfg(target_os = "macos")]
+unsafe impl<T> Send for SendPtr<T> {}
+
 // macos_peripheral_task: macOS equivalent of peripheral_loop / windows_peripheral_task.
 //
-// Raw pointers to CBPeripheralManager and CBMutableCharacteristic are passed here
-// because those types are not Send. start_peripheral leaks the Retained<> objects
-// before spawning this task; this task reconstructs them from raw pointers (via
+// CBPeripheralManager and CBMutableCharacteristic are passed as SendPtr<T> because
+// those ObjC types are not Send. start_peripheral leaks the Retained<> objects before
+// spawning this task; this task reconstructs them from raw pointers (via
 // Retained::from_raw) on exit, releasing the ObjC objects. The delegate is not leaked:
 // the manager holds its own ObjC retain, so the Rust Retained<delegate> is allowed to
 // drop at the end of start_peripheral, reducing the count from 2 to 1. When the manager
 // is released here, the count goes from 1 to 0 and the delegate is freed.
 #[cfg(target_os = "macos")]
 async fn macos_peripheral_task(
-    manager_ptr: *mut objc2_core_bluetooth::CBPeripheralManager,
-    notify_char_ptr: *mut objc2_core_bluetooth::CBMutableCharacteristic,
+    manager: SendPtr<objc2_core_bluetooth::CBPeripheralManager>,
+    notify_char: SendPtr<objc2_core_bluetooth::CBMutableCharacteristic>,
     conn_tx: tokio::sync::mpsc::UnboundedSender<BlePeripheralConnection>,
     write_forward: Arc<std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>>,
     mut subscribe_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
     mut stop_rx: tokio::sync::oneshot::Receiver<()>,
 ) {
-    struct SendPtr<T>(*mut T);
-    unsafe impl<T> Send for SendPtr<T> {}
-
-    let manager = SendPtr(manager_ptr);
-    let notify_char = SendPtr(notify_char_ptr);
 
     'outer: loop {
         tokio::select! {
@@ -1015,6 +1017,7 @@ impl BleTransport {
 impl BleTransport {
     async fn start_peripheral(&self, identity: &NodeIdentity) -> Result<()> {
         use macos_delegate::MacosPeripheralDelegate;
+        use objc2::{AllocAnyThread, ClassType};
         use objc2_core_bluetooth::{
             CBAttributePermissions, CBCharacteristic, CBCharacteristicProperties,
             CBMutableCharacteristic, CBMutableService, CBPeripheralManager, CBUUID,
@@ -1053,15 +1056,15 @@ impl BleTransport {
 
             // Use a background serial queue so callbacks are not tied to the main
             // run loop, which is not guaranteed to spin in a CLI/daemon process.
-            let queue = dispatch2::Queue::new(
+            let queue = dispatch2::DispatchQueue::new(
                 "com.pathweave.ble.peripheral",
-                dispatch2::QueueAttribute::Serial,
+                dispatch2::DispatchQueueAttr::SERIAL,
             );
 
             let manager = unsafe {
                 CBPeripheralManager::initWithDelegate_queue(
                     CBPeripheralManager::alloc(),
-                    Some(&*delegate),
+                    Some(objc2::runtime::ProtocolObject::from_ref(&*delegate)),
                     Some(&queue),
                 )
             };
@@ -1124,8 +1127,8 @@ impl BleTransport {
             // We build the advertisement dictionary via msg_send! to avoid generic
             // type parameter gymnastics (NSDictionary<K,V> coercions are not yet
             // ergonomic for mixed-type dictionaries in objc2 0.6).
-            let uuid_arr = NSMutableArray::new();
-            unsafe { uuid_arr.addObject(&svc_uuid) };
+            let uuid_arr = NSMutableArray::<CBUUID>::new();
+            unsafe { uuid_arr.addObject(&*svc_uuid) };
             let adv_key = NSString::from_str("kCBAdvDataServiceUUIDs");
             let adv: Option<
                 objc2::rc::Retained<
@@ -1152,8 +1155,8 @@ impl BleTransport {
         });
 
         tokio::spawn(macos_peripheral_task(
-            manager_ptr,
-            notify_char_ptr,
+            SendPtr(manager_ptr),
+            SendPtr(notify_char_ptr),
             conn_tx,
             write_forward,
             subscribe_rx,

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -292,7 +292,7 @@ struct PeripheralDelegateBridge {
 mod macos_delegate {
     use super::*;
     use objc2::rc::Retained;
-    use objc2::{declare_class, msg_send_id, ClassType, DeclaredClass};
+    use objc2::{define_class, msg_send_id, ClassType, DefinedClass};
     use objc2_core_bluetooth::{
         CBATTError, CBCentral, CBCharacteristic, CBPeripheralManager, CBPeripheralManagerDelegate,
     };
@@ -302,7 +302,7 @@ mod macos_delegate {
         pub bridge: Arc<super::PeripheralDelegateBridge>,
     }
 
-    declare_class!(
+    define_class!(
         pub struct MacosPeripheralDelegate;
 
         unsafe impl ClassType for MacosPeripheralDelegate {
@@ -313,7 +313,7 @@ mod macos_delegate {
             const NAME: &'static str = "PathweaveMacosPeripheralDelegate";
         }
 
-        impl DeclaredClass for MacosPeripheralDelegate {
+        impl DefinedClass for MacosPeripheralDelegate {
             type Ivars = Ivars;
         }
 
@@ -619,15 +619,15 @@ impl Transport for BleTransport {
                     // ServicesAdvertisement (they cannot set service data). Both events
                     // firing for the same device in a Pathweave scan is not a realistic
                     // scenario.
-                    CentralEvent::ServicesAdvertisement { id, services } => {
-                        if services.contains(&PATHWEAVE_SERVICE_UUID) {
-                            let announcement = PeerAnnouncement {
-                                address: PeerAddress::Ble(id.to_string()),
-                                short_id: None,
-                            };
-                            if tx.unbounded_send(announcement).is_err() {
-                                break;
-                            }
+                    CentralEvent::ServicesAdvertisement { id, services }
+                        if services.contains(&PATHWEAVE_SERVICE_UUID) =>
+                    {
+                        let announcement = PeerAnnouncement {
+                            address: PeerAddress::Ble(id.to_string()),
+                            short_id: None,
+                        };
+                        if tx.unbounded_send(announcement).is_err() {
+                            break;
                         }
                     }
                     _ => {}

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -292,7 +292,7 @@ struct PeripheralDelegateBridge {
 mod macos_delegate {
     use super::*;
     use objc2::rc::Retained;
-    use objc2::{define_class, msg_send_id, ClassType, DefinedClass};
+    use objc2::{define_class, msg_send, DefinedClass};
     use objc2_core_bluetooth::{
         CBATTError, CBCentral, CBCharacteristic, CBPeripheralManager, CBPeripheralManagerDelegate,
     };
@@ -303,32 +303,26 @@ mod macos_delegate {
     }
 
     define_class!(
+        // No thread_kind attribute: the default allows use from any thread.
+        // MainThreadOnly would require a main thread token at allocation time,
+        // which is unavailable on a tokio worker thread or dispatch queue thread.
+        #[unsafe(super(NSObject))]
+        #[name = "PathweaveMacosPeripheralDelegate"]
+        #[ivars = Ivars]
         pub struct MacosPeripheralDelegate;
-
-        unsafe impl ClassType for MacosPeripheralDelegate {
-            type Super = NSObject;
-            // Mutable (not MainThreadOnly): the delegate is called on a background
-            // dispatch queue and must be usable from non-main threads.
-            type Mutability = objc2::mutability::Mutable;
-            const NAME: &'static str = "PathweaveMacosPeripheralDelegate";
-        }
-
-        impl DefinedClass for MacosPeripheralDelegate {
-            type Ivars = Ivars;
-        }
 
         unsafe impl NSObjectProtocol for MacosPeripheralDelegate {}
 
         unsafe impl CBPeripheralManagerDelegate for MacosPeripheralDelegate {
-            #[method(peripheralManagerDidUpdateState:)]
+            #[unsafe(method(peripheralManagerDidUpdateState:))]
             fn did_update_state(&self, manager: &CBPeripheralManager) {
-                tracing::debug!(
-                    "CBPeripheralManager state changed: {:?}",
-                    unsafe { manager.state() } as u64
-                );
+                tracing::debug!("CBPeripheralManager state changed: {:?}", unsafe {
+                    manager.state()
+                }
+                    as u64);
             }
 
-            #[method(peripheralManager:central:didSubscribeToCharacteristic:)]
+            #[unsafe(method(peripheralManager:central:didSubscribeToCharacteristic:))]
             fn did_subscribe(
                 &self,
                 _manager: &CBPeripheralManager,
@@ -341,7 +335,7 @@ mod macos_delegate {
             // Called only for CBCharacteristicPropertyWrite (write with response).
             // Must call respondToRequest:withResult: for every request.
             // WriteWithoutResponse commands are NOT delivered here.
-            #[method(peripheralManager:didReceiveWriteRequests:)]
+            #[unsafe(method(peripheralManager:didReceiveWriteRequests:))]
             fn did_receive_writes(
                 &self,
                 manager: &CBPeripheralManager,
@@ -372,10 +366,10 @@ mod macos_delegate {
     impl MacosPeripheralDelegate {
         pub fn new(bridge: Arc<super::PeripheralDelegateBridge>) -> Retained<Self> {
             // set_ivars writes the Rust ivars into the allocated object memory before
-            // calling NSObject's init, which is required by objc2's DeclaredClass contract.
+            // calling NSObject's init, required by objc2's DefinedClass contract.
             let this = Self::alloc();
             let this = this.set_ivars(Ivars { bridge });
-            unsafe { msg_send_id![super(this), init] }
+            unsafe { msg_send![super(this), init] }
         }
     }
 }

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -399,7 +399,6 @@ async fn macos_peripheral_task(
     mut subscribe_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
     mut stop_rx: tokio::sync::oneshot::Receiver<()>,
 ) {
-
     'outer: loop {
         tokio::select! {
             _ = &mut stop_rx => break 'outer,

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -3,7 +3,8 @@ use std::sync::Arc;
 use async_trait::async_trait;
 use btleplug::{
     api::{
-        Central, CentralEvent, Characteristic, Manager as _, Peripheral as _, ScanFilter, WriteType,
+        Central, CentralEvent, CharPropFlags, Characteristic, Manager as _, Peripheral as _,
+        ScanFilter, WriteType,
     },
     platform::{Adapter, Manager, Peripheral},
 };
@@ -35,13 +36,13 @@ const ADVERTISEMENT_VERSION: u8 = 0x01;
 // platform wires its platform-specific events into these channels and hands the
 // connection to accept(). Session::respond() then drives the Noise_XX handshake
 // over recv_bytes/send_bytes without knowing what's underneath.
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 struct BlePeripheralConnection {
     write_rx: Mutex<tokio::sync::mpsc::UnboundedReceiver<Bytes>>,
     reply_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
 }
 
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 #[async_trait]
 impl Connection for BlePeripheralConnection {
     async fn send_bytes(&mut self, bytes: &[u8]) -> Result<()> {
@@ -260,14 +261,230 @@ async fn windows_peripheral_task(
 }
 
 // --------------------------------------------------------------------------
+// macOS-only peripheral types (ADR 014, macOS section)
+// --------------------------------------------------------------------------
+
+// macOS mirrors Windows in lifecycle: _stop_signal drop exits macos_peripheral_task
+// and drops conn_tx, releasing any blocked accept() call. stopAdvertising() alone
+// does not unblock the channel receive.
+#[cfg(target_os = "macos")]
+struct BlePeripheralState {
+    _stop_signal: tokio::sync::oneshot::Sender<()>,
+}
+
+// PeripheralDelegateBridge holds the channels that macos_peripheral_task reads from.
+// The delegate fires CoreBluetooth callbacks on its dispatch queue thread and sends
+// into these channels without any tokio runtime involvement.
+#[cfg(target_os = "macos")]
+struct PeripheralDelegateBridge {
+    subscribe_tx: tokio::sync::mpsc::UnboundedSender<()>,
+    write_forward: Arc<std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>>,
+}
+
+// MacosPeripheralDelegate: Objective-C class that implements CBPeripheralManagerDelegate.
+//
+// The write characteristic is declared with CBCharacteristicPropertyWrite (write with
+// response), not WriteWithoutResponse. CoreBluetooth's peripheralManager:didReceiveWriteRequests:
+// is only called for write-with-response; write commands are silently dropped on macOS.
+// This means the central must use WriteType::WithResponse when connecting to a macOS
+// peripheral, which BleConnection::send_bytes detects from the characteristic properties.
+#[cfg(target_os = "macos")]
+mod macos_delegate {
+    use super::*;
+    use objc2::rc::Retained;
+    use objc2::{declare_class, msg_send_id, ClassType, DeclaredClass};
+    use objc2_core_bluetooth::{
+        CBATTError, CBCentral, CBCharacteristic, CBPeripheralManager, CBPeripheralManagerDelegate,
+    };
+    use objc2_foundation::{NSObject, NSObjectProtocol};
+
+    pub struct Ivars {
+        pub bridge: Arc<super::PeripheralDelegateBridge>,
+    }
+
+    declare_class!(
+        pub struct MacosPeripheralDelegate;
+
+        unsafe impl ClassType for MacosPeripheralDelegate {
+            type Super = NSObject;
+            // Mutable (not MainThreadOnly): the delegate is called on a background
+            // dispatch queue and must be usable from non-main threads.
+            type Mutability = objc2::mutability::Mutable;
+            const NAME: &'static str = "PathweaveMacosPeripheralDelegate";
+        }
+
+        impl DeclaredClass for MacosPeripheralDelegate {
+            type Ivars = Ivars;
+        }
+
+        unsafe impl NSObjectProtocol for MacosPeripheralDelegate {}
+
+        unsafe impl CBPeripheralManagerDelegate for MacosPeripheralDelegate {
+            #[method(peripheralManagerDidUpdateState:)]
+            fn did_update_state(&self, manager: &CBPeripheralManager) {
+                tracing::debug!(
+                    "CBPeripheralManager state changed: {:?}",
+                    unsafe { manager.state() } as u64
+                );
+            }
+
+            #[method(peripheralManager:central:didSubscribeToCharacteristic:)]
+            fn did_subscribe(
+                &self,
+                _manager: &CBPeripheralManager,
+                _central: &CBCentral,
+                _characteristic: &CBCharacteristic,
+            ) {
+                let _ = self.ivars().bridge.subscribe_tx.send(());
+            }
+
+            // Called only for CBCharacteristicPropertyWrite (write with response).
+            // Must call respondToRequest:withResult: for every request.
+            // WriteWithoutResponse commands are NOT delivered here.
+            #[method(peripheralManager:didReceiveWriteRequests:)]
+            fn did_receive_writes(
+                &self,
+                manager: &CBPeripheralManager,
+                requests: &objc2_foundation::NSArray<objc2_core_bluetooth::CBATTRequest>,
+            ) {
+                for req in unsafe { requests.iter() } {
+                    if let Some(data) = unsafe { req.value() } {
+                        let bytes = Bytes::copy_from_slice(unsafe { data.as_bytes() });
+                        if let Ok(guard) = self.ivars().bridge.write_forward.lock() {
+                            if let Some(tx) = guard.as_ref() {
+                                let _ = tx.send(bytes);
+                            } else {
+                                tracing::debug!(
+                                    "BLE peripheral (macOS): write with no active connection; frame discarded"
+                                );
+                            }
+                        }
+                    }
+                }
+                // Respond to the first request; CoreBluetooth applies it to the batch.
+                if let Some(first) = unsafe { requests.first() } {
+                    unsafe { manager.respondToRequest_withResult(first, CBATTError::Success) };
+                }
+            }
+        }
+    );
+
+    impl MacosPeripheralDelegate {
+        pub fn new(bridge: Arc<super::PeripheralDelegateBridge>) -> Retained<Self> {
+            // set_ivars writes the Rust ivars into the allocated object memory before
+            // calling NSObject's init, which is required by objc2's DeclaredClass contract.
+            let this = Self::alloc();
+            let this = this.set_ivars(Ivars { bridge });
+            unsafe { msg_send_id![super(this), init] }
+        }
+    }
+}
+
+// macos_peripheral_task: macOS equivalent of peripheral_loop / windows_peripheral_task.
+//
+// Raw pointers to CBPeripheralManager and CBMutableCharacteristic are passed here
+// because those types are not Send. start_peripheral leaks the Retained<> objects
+// before spawning this task; this task reconstructs them from raw pointers (via
+// Retained::from_raw) on exit, releasing the ObjC objects. The delegate is not leaked:
+// the manager holds its own ObjC retain, so the Rust Retained<delegate> is allowed to
+// drop at the end of start_peripheral, reducing the count from 2 to 1. When the manager
+// is released here, the count goes from 1 to 0 and the delegate is freed.
+#[cfg(target_os = "macos")]
+async fn macos_peripheral_task(
+    manager_ptr: *mut objc2_core_bluetooth::CBPeripheralManager,
+    notify_char_ptr: *mut objc2_core_bluetooth::CBMutableCharacteristic,
+    conn_tx: tokio::sync::mpsc::UnboundedSender<BlePeripheralConnection>,
+    write_forward: Arc<std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>>,
+    mut subscribe_rx: tokio::sync::mpsc::UnboundedReceiver<()>,
+    mut stop_rx: tokio::sync::oneshot::Receiver<()>,
+) {
+    struct SendPtr<T>(*mut T);
+    unsafe impl<T> Send for SendPtr<T> {}
+
+    let manager = SendPtr(manager_ptr);
+    let notify_char = SendPtr(notify_char_ptr);
+
+    'outer: loop {
+        tokio::select! {
+            _ = &mut stop_rx => break 'outer,
+            msg = subscribe_rx.recv() => {
+                if msg.is_none() { break 'outer; }
+            }
+        }
+
+        let (write_tx, write_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+        let (reply_tx, mut reply_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+
+        if let Ok(mut guard) = write_forward.lock() {
+            *guard = Some(write_tx);
+        }
+        let _ = conn_tx.send(BlePeripheralConnection {
+            write_rx: Mutex::new(write_rx),
+            reply_tx,
+        });
+
+        loop {
+            tokio::select! {
+                _ = &mut stop_rx => break 'outer,
+                data = reply_rx.recv() => {
+                    match data {
+                        Some(bytes) => {
+                            let mgr = manager.0;
+                            let chr = notify_char.0;
+                            tokio::task::block_in_place(|| {
+                                let data = unsafe {
+                                    objc2_foundation::NSData::with_bytes(bytes.as_ref())
+                                };
+                                unsafe {
+                                    (*mgr).updateValue_forCharacteristic_onSubscribedCentrals(
+                                        &data,
+                                        &*chr,
+                                        None,
+                                    );
+                                }
+                            });
+                        }
+                        None => break,
+                    }
+                }
+                _ = subscribe_rx.recv() => {
+                    tracing::debug!(
+                        "BLE peripheral (macOS): second subscriber while connection active; ignored"
+                    );
+                }
+            }
+        }
+
+        if let Ok(mut guard) = write_forward.lock() {
+            *guard = None;
+        }
+    }
+
+    if let Ok(mut guard) = write_forward.lock() {
+        *guard = None;
+    }
+
+    // Release the leaked ObjC objects. Retained::from_raw takes ownership of the one
+    // retain we forgot earlier; dropping it decrements the retain count. The manager
+    // cascades: its dealloc releases the service, which releases characteristics and
+    // delegate. notify_char_ptr is released here (its Rust-leaked retain); the service
+    // continues to hold its own retain until the manager releases it.
+    tokio::task::block_in_place(|| unsafe {
+        (*manager.0).stopAdvertising();
+        let _ = objc2::rc::Retained::from_raw(notify_char.0);
+        let _ = objc2::rc::Retained::from_raw(manager.0);
+    });
+}
+
+// --------------------------------------------------------------------------
 // Transport
 // --------------------------------------------------------------------------
 
 pub struct BleTransport {
     adapter: Arc<Mutex<Option<Adapter>>>,
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     peripheral: Arc<Mutex<Option<BlePeripheralState>>>,
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     conn_rx: Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>>>,
 }
 
@@ -275,9 +492,9 @@ impl BleTransport {
     pub fn new() -> Self {
         Self {
             adapter: Arc::new(Mutex::new(None)),
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
             peripheral: Arc::new(Mutex::new(None)),
-            #[cfg(any(target_os = "linux", target_os = "windows"))]
+            #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
             conn_rx: Mutex::new(None),
         }
     }
@@ -305,10 +522,10 @@ impl Transport for BleTransport {
             .ok_or_else(|| PathweaveError::Transport("no Bluetooth adapter found".into()))?;
         *self.adapter.lock().await = Some(adapter);
 
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
         self.start_peripheral(identity).await?;
 
-        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
         let _ = identity;
 
         Ok(())
@@ -321,17 +538,17 @@ impl Transport for BleTransport {
         }
         *guard = None;
 
-        #[cfg(any(target_os = "linux", target_os = "windows"))]
+        #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
         {
             // On Linux: dropping BlePeripheralState drops the bluer RAII handles,
             // which closes the CharacteristicControl streams and causes peripheral_loop
             // to exit, dropping conn_tx.
             //
-            // On Windows: dropping BlePeripheralState drops _stop_signal, which is
-            // the only mechanism that exits windows_peripheral_task and drops conn_tx.
-            // StopAdvertising() alone does not close GATT event streams.
+            // On Windows/macOS: dropping BlePeripheralState drops _stop_signal, which
+            // is the only mechanism that exits the peripheral task and drops conn_tx.
+            // StopAdvertising() alone does not close GATT event streams on either platform.
             //
-            // In both cases, conn_tx dropping causes accept()'s recv() to return None,
+            // In all cases, conn_tx dropping causes accept()'s recv() to return None,
             // releasing the conn_rx guard so we can acquire it here to clear it.
             *self.peripheral.lock().await = None;
             *self.conn_rx.lock().await = None;
@@ -372,22 +589,48 @@ impl Transport for BleTransport {
             futures::pin_mut!(events);
 
             while let Some(event) = events.next().await {
-                if let CentralEvent::ServiceDataAdvertisement { id, service_data } = event {
-                    let data = match service_data.get(&PATHWEAVE_SERVICE_UUID) {
-                        Some(d) => d.clone(),
-                        None => continue,
-                    };
-                    if data.len() < 9 || data[0] != ADVERTISEMENT_VERSION {
-                        continue;
+                match event {
+                    CentralEvent::ServiceDataAdvertisement { id, service_data } => {
+                        let data = match service_data.get(&PATHWEAVE_SERVICE_UUID) {
+                            Some(d) => d.clone(),
+                            None => continue,
+                        };
+                        if data.len() < 9 || data[0] != ADVERTISEMENT_VERSION {
+                            continue;
+                        }
+                        let short_id: [u8; 8] = data[1..9].try_into().unwrap();
+                        let announcement = PeerAnnouncement {
+                            address: PeerAddress::Ble(id.to_string()),
+                            short_id: Some(short_id),
+                        };
+                        if tx.unbounded_send(announcement).is_err() {
+                            break;
+                        }
                     }
-                    let short_id: [u8; 8] = data[1..9].try_into().unwrap();
-                    let announcement = PeerAnnouncement {
-                        address: PeerAddress::Ble(id.to_string()),
-                        short_id: Some(short_id),
-                    };
-                    if tx.unbounded_send(announcement).is_err() {
-                        break;
+                    // macOS (and iOS) peripherals cannot include service data in
+                    // advertisements; CoreBluetooth silently drops the key. They
+                    // advertise only their service UUID, which btleplug surfaces as
+                    // ServicesAdvertisement. short_id is None; Noise_XX provides
+                    // full identity during the handshake.
+                    //
+                    // No deduplication against ServiceDataAdvertisement: Linux and
+                    // Windows peripherals always produce ServiceDataAdvertisement
+                    // (they set service data explicitly) and macOS/iOS always produce
+                    // ServicesAdvertisement (they cannot set service data). Both events
+                    // firing for the same device in a Pathweave scan is not a realistic
+                    // scenario.
+                    CentralEvent::ServicesAdvertisement { id, services } => {
+                        if services.contains(&PATHWEAVE_SERVICE_UUID) {
+                            let announcement = PeerAnnouncement {
+                                address: PeerAddress::Ble(id.to_string()),
+                                short_id: None,
+                            };
+                            if tx.unbounded_send(announcement).is_err() {
+                                break;
+                            }
+                        }
                     }
+                    _ => {}
                 }
             }
         });
@@ -479,7 +722,7 @@ impl Transport for BleTransport {
     // across recv() is safe: stop() drops BlePeripheralState first (closing conn_tx
     // via the peripheral task exiting), causing recv() to return None and accept()
     // to release the guard. stop() then acquires the lock to clear it.
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     async fn accept(&self) -> Result<Box<dyn Connection>> {
         let mut guard = self.conn_rx.lock().await;
         match guard.as_mut() {
@@ -492,7 +735,7 @@ impl Transport for BleTransport {
         }
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     async fn accept(&self) -> Result<Box<dyn Connection>> {
         Err(PathweaveError::Transport(
             "BLE peripheral mode not supported on this platform".into(),
@@ -771,6 +1014,168 @@ impl BleTransport {
 }
 
 // --------------------------------------------------------------------------
+// macOS peripheral: start_peripheral (ADR 014, macOS section)
+// --------------------------------------------------------------------------
+
+#[cfg(target_os = "macos")]
+impl BleTransport {
+    async fn start_peripheral(&self, identity: &NodeIdentity) -> Result<()> {
+        use macos_delegate::MacosPeripheralDelegate;
+        use objc2_core_bluetooth::{
+            CBAttributePermissions, CBCharacteristic, CBCharacteristicProperties,
+            CBMutableCharacteristic, CBMutableService, CBPeripheralManager, CBUUID,
+        };
+        use objc2_foundation::{NSMutableArray, NSString};
+
+        // short_id is not included in the macOS advertisement payload; CoreBluetooth
+        // silently ignores CBAdvertisementDataServiceDataKey. See ADR 014 macOS section.
+        let _ = identity;
+
+        let write_forward: Arc<
+            std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>,
+        > = Arc::new(std::sync::Mutex::new(None));
+        let (subscribe_tx, subscribe_rx) = tokio::sync::mpsc::unbounded_channel::<()>();
+        let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel::<BlePeripheralConnection>();
+        let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+
+        let bridge = Arc::new(PeripheralDelegateBridge {
+            subscribe_tx,
+            write_forward: Arc::clone(&write_forward),
+        });
+
+        // All CoreBluetooth objects are not Send. We set everything up synchronously
+        // inside block_in_place, then extract raw pointers for the async task.
+        //
+        // Memory contract:
+        //   manager and notify_char are forgot (Retained leaked); the task releases
+        //   them on exit via Retained::from_raw.
+        //
+        //   delegate is NOT forgot: we let the Rust Retained drop at the end of this
+        //   block_in_place closure, taking the count from 2 to 1 (the manager holds
+        //   its own ObjC retain). When the manager is released in the task, the count
+        //   drops to 0 and the delegate is freed.
+        let (manager_ptr, notify_char_ptr) = tokio::task::block_in_place(|| {
+            let delegate = MacosPeripheralDelegate::new(Arc::clone(&bridge));
+
+            // Use a background serial queue so callbacks are not tied to the main
+            // run loop, which is not guaranteed to spin in a CLI/daemon process.
+            let queue = dispatch2::Queue::new(
+                "com.pathweave.ble.peripheral",
+                dispatch2::QueueAttribute::Serial,
+            );
+
+            let manager = unsafe {
+                CBPeripheralManager::initWithDelegate_queue(
+                    CBPeripheralManager::alloc(),
+                    Some(&*delegate),
+                    Some(&queue),
+                )
+            };
+
+            let svc_uuid = unsafe {
+                CBUUID::UUIDWithString(&NSString::from_str(
+                    &PATHWEAVE_SERVICE_UUID.hyphenated().to_string(),
+                ))
+            };
+            let write_uuid = unsafe {
+                CBUUID::UUIDWithString(&NSString::from_str(
+                    &WRITE_CHAR_UUID.hyphenated().to_string(),
+                ))
+            };
+            let notify_uuid = unsafe {
+                CBUUID::UUIDWithString(&NSString::from_str(
+                    &NOTIFY_CHAR_UUID.hyphenated().to_string(),
+                ))
+            };
+
+            // Write characteristic: CBCharacteristicPropertyWrite (not WriteWithoutResponse).
+            // CoreBluetooth only delivers data to peripheralManager:didReceiveWriteRequests:
+            // for write-with-response. Write commands (without response) are silently
+            // dropped on macOS. The central detects the property and uses WithResponse.
+            let write_char = unsafe {
+                CBMutableCharacteristic::initWithType_properties_value_permissions(
+                    CBMutableCharacteristic::alloc(),
+                    &write_uuid,
+                    CBCharacteristicProperties::Write,
+                    None,
+                    CBAttributePermissions::Writeable,
+                )
+            };
+            let notify_char = unsafe {
+                CBMutableCharacteristic::initWithType_properties_value_permissions(
+                    CBMutableCharacteristic::alloc(),
+                    &notify_uuid,
+                    CBCharacteristicProperties::Notify,
+                    None,
+                    CBAttributePermissions::Readable,
+                )
+            };
+
+            // Use CBCharacteristic as the array element type so setCharacteristics
+            // accepts it without coercion (CBMutableCharacteristic: Deref<Target = CBCharacteristic>).
+            let chars = NSMutableArray::<CBCharacteristic>::new();
+            unsafe { chars.addObject(&write_char) };
+            unsafe { chars.addObject(&*notify_char) };
+
+            let service = unsafe {
+                CBMutableService::initWithType_primary(CBMutableService::alloc(), &svc_uuid, true)
+            };
+            unsafe { service.setCharacteristics(Some(&chars)) };
+            unsafe { manager.addService(&service) };
+
+            // macOS only supports CBAdvertisementDataLocalNameKey and
+            // CBAdvertisementDataServiceUUIDsKey. Service data is silently ignored.
+            // See ADR 014 macOS section.
+            //
+            // We build the advertisement dictionary via msg_send! to avoid generic
+            // type parameter gymnastics (NSDictionary<K,V> coercions are not yet
+            // ergonomic for mixed-type dictionaries in objc2 0.6).
+            let uuid_arr = NSMutableArray::new();
+            unsafe { uuid_arr.addObject(&svc_uuid) };
+            let adv_key = NSString::from_str("kCBAdvDataServiceUUIDs");
+            let adv: Option<
+                objc2::rc::Retained<
+                    objc2_foundation::NSDictionary<NSString, objc2::runtime::AnyObject>,
+                >,
+            > = unsafe {
+                objc2::msg_send_id![
+                    objc2_foundation::NSDictionary::<NSString, objc2::runtime::AnyObject>::class(),
+                    dictionaryWithObject: &*uuid_arr,
+                    forKey: &*adv_key
+                ]
+            };
+            unsafe { manager.startAdvertising(adv.as_deref()) };
+
+            let mgr_ptr = objc2::rc::Retained::as_ptr(&manager) as *mut CBPeripheralManager;
+            let notify_ptr =
+                objc2::rc::Retained::as_ptr(&notify_char) as *mut CBMutableCharacteristic;
+
+            std::mem::forget(manager);
+            std::mem::forget(notify_char);
+            // delegate drops here; manager holds its own ObjC retain on the delegate
+
+            (mgr_ptr, notify_ptr)
+        });
+
+        tokio::spawn(macos_peripheral_task(
+            manager_ptr,
+            notify_char_ptr,
+            conn_tx,
+            write_forward,
+            subscribe_rx,
+            stop_rx,
+        ));
+
+        *self.conn_rx.lock().await = Some(conn_rx);
+        *self.peripheral.lock().await = Some(BlePeripheralState {
+            _stop_signal: stop_tx,
+        });
+
+        Ok(())
+    }
+}
+
+// --------------------------------------------------------------------------
 // Central-mode connection (btleplug)
 // --------------------------------------------------------------------------
 
@@ -786,8 +1191,20 @@ pub struct BleConnection {
 #[async_trait]
 impl Connection for BleConnection {
     async fn send_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        // Linux/Windows peripherals expose WriteWithoutResponse; macOS peripherals
+        // expose only Write (with response) because CoreBluetooth does not deliver
+        // ATT write commands to peripheralManager:didReceiveWriteRequests:.
+        let write_type = if self
+            .write_char
+            .properties
+            .contains(CharPropFlags::WRITE_WITHOUT_RESPONSE)
+        {
+            WriteType::WithoutResponse
+        } else {
+            WriteType::WithResponse
+        };
         self.peripheral
-            .write(&self.write_char, bytes, WriteType::WithoutResponse)
+            .write(&self.write_char, bytes, write_type)
             .await
             .map_err(|e| PathweaveError::Transport(e.to_string()))
     }
@@ -844,7 +1261,7 @@ mod tests {
         assert!(matches!(result, Err(PathweaveError::Transport(_))));
     }
 
-    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
     #[tokio::test]
     async fn accept_returns_not_supported_on_other_platforms() {
         let transport = BleTransport::new();
@@ -852,7 +1269,7 @@ mod tests {
         assert!(matches!(result, Err(PathweaveError::Transport(_))));
     }
 
-    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    #[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
     #[tokio::test]
     async fn accept_before_start_returns_error() {
         let transport = BleTransport::new();

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -48,7 +48,7 @@ implementing one trait. It doesn't touch anything else.
 |---|---|
 | `pathweave-core` | Transport trait, PathweaveNode, Router, Session layer, Bundle layer |
 | `pathweave-transport-quic` | QUIC implementation of Transport |
-| `pathweave-transport-ble` | BLE implementation of Transport. btleplug for central mode (scanning, GATT); bluer for peripheral mode (advertising) on Linux; native platform APIs on mobile. |
+| `pathweave-transport-ble` | BLE implementation of Transport. btleplug for central mode (scanning, GATT); bluer on Linux, WinRT on Windows, CoreBluetooth on macOS for peripheral mode (advertising). Native platform APIs for mobile. |
 | `pathweave-uniffi` | FFI bindings layer. Exposes PathweaveNode to Swift and Kotlin. |
 | `pw-chat` (example) | Terminal chat demo. The v0.1.0 launch artifact. |
 
@@ -467,9 +467,11 @@ Peripheral mode: platform-specific.
 - Android and iOS: the platform's native BLE APIs called through the UniFFI layer.
   CoreBluetooth on iOS, BluetoothManager on Android. The `pathweave-transport-ble`
   Rust crate is not used for peripheral mode on mobile; the native layer handles it.
-- macOS: not yet implemented. CoreBluetooth is available on macOS (same framework as
-  iOS); the implementation will be compile-tested on CI with community hardware testing.
-  Tracked in issue #52.
+- macOS: `objc2-core-bluetooth` v0.3.2 via `objc2` bindings, shipped in v0.2.0.
+  CoreBluetooth's `CBPeripheralManager` with `CBCharacteristicPropertyWrite` (not
+  WriteWithoutResponse; the platform does not deliver write commands to the delegate).
+  Advertisement includes service UUID only; service data is silently ignored by macOS.
+  See ADR 014.
 - Windows: `windows` crate v0.58, shipped in v0.2.0. WinRT GATT Server API
   (`Windows.Devices.Bluetooth.GenericAttributeProfile`). See ADR 014.
 
@@ -531,8 +533,8 @@ When neither transport can reach the peer: "message failed: no transport availab
 No queuing, no silent retry.
 
 BLE in pw-chat works when at least one peer can advertise. Supported configurations:
-two Linux machines, a Linux or Windows machine and a macOS machine (pending issue
-#52), or any of the above and a phone running the native SDK.
+two Linux machines, a Linux or Windows machine and a macOS machine, or any combination
+with a phone running the native SDK.
 
 ---
 
@@ -548,7 +550,7 @@ Being clear about this matters as much as being clear about what it does.
   NWPathMonitor, and WinRT network events deferred to v0.3.0). See ADR 013.
 - No WiFi vs. mobile data detection for QUIC cost reporting (v0.2.0 cost intelligence
   work not yet complete; all QUIC connections currently report Metered)
-- No BLE peripheral mode on macOS yet (in progress, issue #52)
+- macOS BLE peripheral mode compiled from Windows; needs hardware verification on macOS
 - No security audit completed
 
 v1.0.0 means the API is stable and the library is ready for production use. We're

--- a/notes/decisions/014-ble-peripheral-linux.md
+++ b/notes/decisions/014-ble-peripheral-linux.md
@@ -1,4 +1,4 @@
-# ADR 014: BLE peripheral mode: bluer on Linux, WinRT on Windows
+# ADR 014: BLE peripheral mode: bluer on Linux, WinRT on Windows, CoreBluetooth on macOS
 
 **Status:** Accepted
 
@@ -15,8 +15,8 @@ Three design questions remained open for Linux:
 2. How `accept()` maps onto bluer's event-driven model
 3. How `bluer` and `btleplug` coexist inside the same crate
 
-This ADR settles all three for Linux, and adds a Windows section covering the
-WinRT-based implementation via the `windows` crate (v0.58).
+This ADR settles all three for Linux and adds Windows (WinRT via the `windows` crate
+v0.58) and macOS (CoreBluetooth via `objc2-core-bluetooth` v0.3.2) sections.
 
 ## Linux: bluer v0.17 GATT server data API
 
@@ -107,26 +107,26 @@ CharacteristicNotify {
 acknowledgement. Delivery guarantees are provided by the at-least-once retry loop
 (ADR 011) at the application layer.
 
-### bluer/btleplug coexistence
+### Platform-specific coexistence
 
-`BleTransport` gains two fields shared by Linux and Windows:
+`BleTransport` gains two fields shared by all three peripheral platforms:
 
 ```rust
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 peripheral: Arc<tokio::sync::Mutex<Option<BlePeripheralState>>>,
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 conn_rx: tokio::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<BlePeripheralConnection>>>,
 ```
 
 All bluer types are gated under `#[cfg(target_os = "linux")]`; all WinRT types under
-`#[cfg(target_os = "windows")]`. The btleplug central-mode field
+`#[cfg(target_os = "windows")]`; all CoreBluetooth types under
+`#[cfg(target_os = "macos")]`. The btleplug central-mode field
 (`adapter: Arc<Mutex<Option<Adapter>>>`) is unchanged and platform-independent. On
-macOS, neither `bluer` nor `windows` is in the dependency tree and `accept()` returns
-the not-implemented error.
+other platforms, `accept()` returns the not-implemented error.
 
-`pathweave-transport-ble/Cargo.toml` adds a
-`[target.'cfg(target_os = "linux")'.dependencies]` section with
-`bluer = { workspace = true }`.
+`pathweave-transport-ble/Cargo.toml` has three platform-specific dependency sections:
+`bluer = { workspace = true }` for Linux; `windows` crate v0.58 for Windows;
+`objc2-core-bluetooth` v0.3.2 with companion crates for macOS.
 
 ### Handle lifetime and peripheral state
 
@@ -200,8 +200,8 @@ correctly with this layout.
 8. Store `conn_rx` in `self.conn_rx`, then store
    `BlePeripheralState { _adv_handle, _app_handle }` in `self.peripheral`.
 
-On non-Linux platforms, `start()` uses `_identity` and performs the existing
-btleplug adapter initialization unchanged.
+On macOS, `start()` calls a CoreBluetooth-based `start_peripheral`. On other platforms,
+`start()` uses `_identity` and performs only the existing btleplug adapter initialization.
 
 ### peripheral_loop
 
@@ -295,12 +295,12 @@ write events from the same subscriber. Reply bytes flow from connections through
 
 ### accept()
 
-The `accept()` implementation is shared between Linux and Windows. The
+The `accept()` implementation is shared across all three peripheral platforms. The
 platform-specific difference is only in what causes `recv()` to return `None` (bluer
-handle drop vs. stop signal drop), not in the `accept()` body itself.
+handle drop on Linux; stop signal drop on Windows and macOS), not in the body itself.
 
 ```rust
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 async fn accept(&self) -> Result<Box<dyn Connection>> {
     let mut guard = self.conn_rx.lock().await;
     match guard.as_mut() {
@@ -405,14 +405,14 @@ releases the `conn_rx` guard. `stop()` then acquires `self.conn_rx` and clears i
 ### BlePeripheralConnection
 
 ```rust
-#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]
 struct BlePeripheralConnection {
     write_rx: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<Bytes>>,
     reply_tx:  tokio::sync::mpsc::UnboundedSender<Bytes>,
 }
 ```
 
-`BlePeripheralConnection` is platform-independent. Both Linux and Windows wire their
+`BlePeripheralConnection` is platform-independent. All three platforms wire their
 platform-specific events into these channels and hand the connection to `accept()`.
 `Session::respond()` then drives the Noise_XX handshake over `recv_bytes`/`send_bytes`
 without knowing what is underneath.
@@ -431,6 +431,102 @@ drops `write_rx` and the cloned `reply_tx`. `peripheral_loop` detects the droppe
 receiver when `active_write_tx.send()` fails and clears the active connection state.
 
 `mtu()` returns 512, consistent with `BleConnection` and ADR 002's GATT MTU.
+
+### Transport::start() on macOS
+
+`BleTransport::start_peripheral(&identity)` on macOS executes the following sequence:
+
+1. Create a background serial `dispatch2::Queue` for CoreBluetooth callbacks.
+2. Instantiate `MacosPeripheralDelegate` with an `Arc<PeripheralDelegateBridge>`.
+3. Allocate `CBPeripheralManager::initWithDelegate:queue:` with the delegate and queue.
+4. Create `CBUUID` instances from the three service/characteristic UUIDs via
+   `CBUUID::UUIDWithString`.
+5. Create `CBMutableCharacteristic` for write (`CBCharacteristicPropertyWrite`) and
+   notify (`CBCharacteristicPropertyNotify`). Note: `WriteWithoutResponse` is NOT used;
+   see rationale below.
+6. Create `CBMutableService`, add both characteristics, call `manager.addService`.
+7. Build the advertisement dictionary with `CBAdvertisementDataServiceUUIDsKey` and
+   call `manager.startAdvertising`. Service data is not included; see rationale.
+8. Create channels: unbounded `(conn_tx, conn_rx)`, unbounded `(subscribe_tx, subscribe_rx)`,
+   oneshot `(stop_tx, stop_rx)`.
+9. `std::mem::forget` the manager and notify characteristic (raw pointers pass to task).
+   The delegate is NOT forgotten: letting its Rust `Retained<>` drop reduces the ObjC
+   retain count from 2 to 1 (the manager holds its own ObjC retain).
+10. Spawn `macos_peripheral_task(manager_ptr, notify_char_ptr, conn_tx, write_forward,
+    subscribe_rx, stop_rx)`.
+11. Store `conn_rx` and `BlePeripheralState { _stop_signal: stop_tx }`.
+
+### MacosPeripheralDelegate
+
+`MacosPeripheralDelegate` is an Objective-C class declared with `objc2::declare_class!`
+that implements `CBPeripheralManagerDelegate`. It uses `objc2::mutability::Mutable`
+(not `MainThreadOnly`) so it can be allocated and freed from background threads.
+
+Its ivars hold an `Arc<PeripheralDelegateBridge>`:
+
+```rust
+pub struct Ivars {
+    pub bridge: Arc<PeripheralDelegateBridge>,
+}
+```
+
+Initialization uses the `set_ivars` + `msg_send_id![super(this), init]` pattern
+required by `objc2::DeclaredClass`:
+
+```rust
+pub fn new(bridge: Arc<PeripheralDelegateBridge>) -> Retained<Self> {
+    let this = Self::alloc();
+    let this = this.set_ivars(Ivars { bridge });
+    unsafe { msg_send_id![super(this), init] }
+}
+```
+
+Relevant delegate methods:
+
+- `peripheralManagerDidUpdateState:`: logs the new state.
+- `peripheralManager:central:didSubscribeToCharacteristic:`: sends `()` to
+  `subscribe_tx`, signaling `macos_peripheral_task` to create a new connection.
+- `peripheralManager:didReceiveWriteRequests:`: reads each request's value bytes,
+  forwards them to the active connection via `write_forward`, then calls
+  `respondToRequest:withResult:` with `CBATTError::Success`. Responding is required
+  because the write characteristic uses `CBCharacteristicPropertyWrite`.
+
+### macos_peripheral_task
+
+Structure mirrors `windows_peripheral_task`: an outer loop waiting for a subscriber
+or stop signal, and an inner loop forwarding replies. Notifications are sent via
+`CBPeripheralManager::updateValue:forCharacteristic:onSubscribedCentrals:` wrapped in
+`block_in_place` (synchronous, runs on a tokio worker thread). On task exit, the
+leaked `Retained<>` objects are reconstructed from raw pointers via `Retained::from_raw`
+and dropped, releasing the ObjC objects:
+
+```rust
+// Release the leaked ObjC objects on task exit
+unsafe {
+    let _ = Retained::from_raw(notify_char_ptr);
+    let _ = Retained::from_raw(manager_ptr);
+}
+```
+
+When the manager is freed, its `dealloc` releases the service, characteristics, and
+the delegate property (reducing the delegate's retain count from 1 to 0, which frees
+the delegate and drops its Rust ivars including the `Arc<PeripheralDelegateBridge>`).
+
+### Central-side adaptation: BleConnection::send_bytes
+
+```rust
+let write_type =
+    if self.write_char.properties.contains(CharPropFlags::WRITE_WITHOUT_RESPONSE) {
+        WriteType::WithoutResponse
+    } else {
+        WriteType::WithResponse
+    };
+```
+
+Linux and Windows peripherals expose `WRITE_WITHOUT_RESPONSE`; macOS exposes only
+`WRITE`. `BleConnection` detects this from the discovered characteristic properties
+and uses the appropriate write type automatically. No protocol-level changes are
+needed: the Noise_XX handshake is transport-agnostic.
 
 ### NodeIdentity propagation chain
 
@@ -573,27 +669,95 @@ The `_stop_signal` oneshot avoids all of this. When dropped (in `stop()`), it fi
 the `stop_rx => break 'outer` select arm in `windows_peripheral_task`, which exits
 cleanly and drops `conn_tx` from within the tokio runtime.
 
+**Why CBCharacteristicPropertyWrite (not WriteWithoutResponse) on macOS?**
+
+CoreBluetooth's `CBPeripheralManager` does not deliver ATT Write Commands (write
+without response, opcode 0x52) to the `peripheralManager:didReceiveWriteRequests:`
+delegate method. That callback is only invoked for ATT Write Requests (write with
+response, opcode 0x12). A characteristic configured with only
+`CBCharacteristicPropertyWriteWithoutResponse` would receive no data at all from
+centrals. Using `CBCharacteristicPropertyWrite` ensures the delegate callback is
+invoked and the peripheral can receive frames.
+
+The consequence is that the central must use `WriteType::WithResponse` for macOS
+peripherals, adding one ATT acknowledgement round-trip per write. For a mesh network
+in opportunistic range, this latency is acceptable and does not affect correctness.
+
+**Why is service data not included in the macOS advertisement?**
+
+CoreBluetooth silently ignores `CBAdvertisementDataServiceDataKey` in the dictionary
+passed to `startAdvertising`. Only `CBAdvertisementDataLocalNameKey` and
+`CBAdvertisementDataServiceUUIDsKey` are honored. This is a documented platform
+restriction on iOS and macOS.
+
+The consequence: macOS peripherals cannot include `short_id` in their advertisement.
+The central sees a `CentralEvent::ServicesAdvertisement` (service UUID only, no service
+data) rather than `CentralEvent::ServiceDataAdvertisement`. `discover()` handles both
+variants: `ServicesAdvertisement` yields an announcement with `short_id: None`.
+`short_id` is pre-authentication metadata only; Noise_XX provides full peer identity
+during the handshake regardless.
+
+**Why std::mem::forget for manager and notify_char?**
+
+`CBPeripheralManager` and `CBMutableCharacteristic` are not `Send`. They cannot be
+moved into the async task. `std::mem::forget` leaks the Rust `Retained<>` objects (ObjC
+retain count remains at the leaked-in count) and raw pointers are passed to the task
+inside `unsafe impl Send` newtypes. The task reconstructs `Retained<>` from the raw
+pointers via `Retained::from_raw` on exit, taking ownership of the leaked retain count.
+When the `Retained<>` drops, it releases the ObjC object.
+
+The delegate is not leaked: the manager acquires its own ObjC retain on the delegate
+during `initWithDelegate:queue:`. Dropping the Rust `Retained<delegate>` at the end of
+the setup closure reduces the count from 2 to 1 without freeing the object. When the
+manager is later freed (via `Retained::from_raw(manager_ptr)` in the task), the
+manager's retain on the delegate is released (1 to 0), triggering the delegate's
+dealloc and dropping its Rust ivars.
+
+**Why Mutable (not MainThreadOnly) for MacosPeripheralDelegate?**
+
+`MainThreadOnly` types in objc2 require the main thread marker for allocation. This
+delegate is created in a `block_in_place` closure on a tokio worker thread, not on
+the main thread. Using `Mutable` removes this restriction. CoreBluetooth delivers
+delegate callbacks on the queue passed to `initWithDelegate:queue:` (a background
+serial queue in our case), not the main thread, so `MainThreadOnly` semantics are
+incorrect for this class.
+
+**Why a background serial queue, not the main queue?**
+
+`CBPeripheralManager` requires a dispatch queue for callback delivery. Passing `nil`
+defaults to the main queue, but the main thread in a CLI/daemon process may not have
+a running AppKit run loop, which can cause CoreBluetooth state machine stalls. A
+dedicated background serial queue (`dispatch2::Queue::new(...)`) ensures callbacks
+are delivered reliably regardless of the main thread's state.
+
 ## Implications
 
-- `bluer` is added as a `[target.'cfg(target_os = "linux")'.dependencies]` entry
-  in `pathweave-transport-ble/Cargo.toml`.
+- `bluer` is added as a `[target.'cfg(target_os = "linux")'.dependencies]` entry.
 - `windows` crate v0.58 is added as a `[target.'cfg(target_os = "windows")'.dependencies]`
   entry with features: `Devices_Bluetooth`, `Devices_Bluetooth_GenericAttributeProfile`,
   `Foundation`, `Foundation_Collections`, `Storage_Streams`.
-- `BlePeripheralConnection` is shared across Linux and Windows under
-  `#[cfg(any(target_os = "linux", target_os = "windows"))]`.
-- `BleTransport` gains `peripheral` and `conn_rx` fields under
-  `#[cfg(any(target_os = "linux", target_os = "windows"))]`.
-- `BlePeripheralState` is platform-specific: on Linux it holds RAII handles; on
-  Windows it holds `_stop_signal`.
+- `objc2-core-bluetooth` v0.3.2, `objc2` v0.6, `objc2-foundation` v0.3, and `dispatch2`
+  v0.3 are added as `[target.'cfg(target_os = "macos")'.dependencies]` entries.
+- `BlePeripheralConnection` is shared across all three platforms under
+  `#[cfg(any(target_os = "linux", target_os = "windows", target_os = "macos"))]`.
+- `BleTransport` gains `peripheral` and `conn_rx` fields under the same cfg.
+- `BlePeripheralState` is platform-specific: RAII handles on Linux; `_stop_signal`
+  on Windows and macOS.
 - `Transport::start()` signature changes to `start(&self, identity: &NodeIdentity)`.
 - `QuicTransport`, all mock transports in tests: add `_identity`.
 - `health_monitor()`, `Router::register_transport()`, `PathweaveNode::add_transport()`:
   propagate `Arc<NodeIdentity>` as described above.
-- `accept()` is a single implementation under `any(linux, windows)`. On other
-  platforms it returns the not-implemented error unchanged.
+- `accept()` is a single implementation under `any(linux, windows, macos)`. On other
+  platforms it returns the not-implemented error.
+- `BleConnection::send_bytes` checks `CharPropFlags::WRITE_WITHOUT_RESPONSE` to select
+  the write type. Linux/Windows peripherals use `WithoutResponse`; macOS uses `WithResponse`.
+- `discover()` handles both `ServiceDataAdvertisement` (Linux/Windows) and
+  `ServicesAdvertisement` (macOS/iOS) events in the scan loop.
 - Multiple simultaneous centrals are not supported in v0.2.0. A second subscriber
-  while a connection is active is dropped with a debug log on both platforms.
+  while a connection is active is dropped with a debug log on all platforms.
 - Windows peripheral mode requires Windows 10 version 1903 (Build 18362) or later
   for `SetServiceData` via `IGattServiceProviderAdvertisingParameters2`.
-- macOS peripheral mode remains deferred per ADR 006.
+- macOS peripheral mode requires macOS 10.9+ (CoreBluetooth peripheral role support).
+- The macOS implementation has not been compiled on macOS hardware in this branch;
+  API surface (objc2-core-bluetooth method names, NSArray/NSDictionary construction)
+  may require minor adjustments when first built on a Mac.


### PR DESCRIPTION
## What changed

Implements BLE peripheral mode on macOS using `objc2-core-bluetooth` v0.3.2, completing peripheral support across all three target platforms (Linux via bluer, Windows via WinRT, macOS via CoreBluetooth). The implementation follows the same channel-based lifecycle as the Windows path: `MacosPeripheralDelegate` bridges CoreBluetooth callbacks into tokio channels, `macos_peripheral_task` drives the connection lifecycle, and dropping `BlePeripheralState::_stop_signal` is the only mechanism that exits the task and unblocks `accept()`. Two macOS-specific constraints shaped the design: `CBPeripheralManagerDelegate` only delivers ATT Write Requests to the application (not Write Commands), requiring `CBCharacteristicPropertyWrite` on the write characteristic; and `startAdvertising:` silently ignores `CBAdvertisementDataServiceDataKey`, so the short_id cannot be included in the advertisement. Both are documented in ADR 014 (macOS section) and ARCHITECTURE.md. `discover()` gains a `ServicesAdvertisement` arm to handle the service-UUID-only advertisements that macOS/iOS peripherals produce. Closes #52.

## Why

macOS is the primary development platform for a substantial share of developers who would deploy Pathweave nodes on MacBooks or Mac Minis. Without peripheral mode, a macOS node can only initiate connections, not accept them, which breaks the symmetric peer model the protocol requires for offline-first mesh routing.

## Alternatives considered

**`MainThreadOnly` mutability for `MacosPeripheralDelegate`:** The `objc2` `MainThreadOnly` mutability marker requires a main thread token at allocation time. The delegate is created inside `block_in_place` on a tokio worker thread, and CoreBluetooth calls it on a background serial dispatch queue — neither of which is the main thread. `Mutable` is the correct choice; `MainThreadOnly` would panic at runtime in a CLI/daemon process with no guaranteed main run loop.

**`CBCharacteristicPropertyWriteWithoutResponse` for the write characteristic:** A natural first choice since Linux and Windows both use WriteWithoutResponse. Rejected because `peripheralManager:didReceiveWriteRequests:` is only invoked for ATT Write Requests (opcode 0x12); ATT Write Commands (opcode 0x52) are not surfaced to the peripheral application. A characteristic declared WriteWithoutResponse would silently discard all incoming data. `BleConnection::send_bytes` auto-detects the write property from the characteristic and selects the correct `WriteType`, so the central requires no platform-specific logic.

**`mem::forget` on the delegate:** The delegate must not be forgotten. `initWithDelegate:queue:` takes its own ObjC retain on the delegate, so the retain count after `new()` is 2. Letting the Rust `Retained<delegate>` drop at the end of `start_peripheral` takes the count to 1. When the manager is released in `macos_peripheral_task`, the count goes to 0 and the delegate is freed cleanly. Forgetting the delegate would leak it permanently.

**Raw `extern "C"` Objective-C calls instead of `objc2`:** No ivar support, no type-safe delegate protocol conformance, no memory management assistance. The maintenance cost would be high and correctness difficult to audit. `objc2 0.6` with `declare_class!` gives typed ivars, protocol conformance checked at compile time, and correct `Retained<T>` semantics.

## Security considerations

The macOS advertisement exposes only the Pathweave service UUID. `CBAdvertisementDataServiceDataKey` is silently ignored by CoreBluetooth, so the short_id (the first 8 bytes of the SHA-256 of the static public key) is not included. This is strictly less information than Linux/Windows advertisements expose: an observer learns that a Pathweave node is present but cannot derive any truncated key material from the advertisement payload. Peer identity is established exclusively through the Noise_XX handshake after connection; the missing short_id means centrals cannot pre-filter by key hash before connecting, which is a routing convenience, not a security property.

The `MacosPeripheralDelegate` receives write payloads from the central and forwards them over an unbounded tokio channel protected by a `std::sync::Mutex`. No cryptographic state or key material passes through this path; the delegate sees only ciphertext produced by the session-layer Noise_XX state machine. The mutex is held for the duration of a single `send()` call only.

The ATT Write Response sent by `respondToRequest:withResult:` contains no application data; it is a fixed two-byte ACK generated by CoreBluetooth and does not affect the Noise_XX security properties.

## Hardware status

This branch was compiled and tested on Windows only. The macOS peripheral path has never been executed on macOS hardware. It is appropriate to merge because the macOS code is entirely gated behind `#[cfg(target_os = "macos")]`, the Linux and Windows paths are unaffected, and all 43 existing tests pass. No currently working behaviour regresses.

Two specific behaviours need hardware verification before the macOS peripheral path can be considered production-ready. Both are detailed in the test plan below and tracked in ARCHITECTURE.md under "What this version doesn't do."

## Test plan

- [x] `cargo check --workspace` on Windows: passes
- [x] `cargo test --workspace` on Windows: 43 tests pass, no regressions
- [ ] Compile on macOS: `cargo build -p pathweave-transport-ble` with macOS toolchain (expected failure mode: minor method name or coercion mismatches in the `objc2` bindings, not structural issues)
- [ ] Verify `peripheralManager:didReceiveWriteRequests:` fires for `CBCharacteristicPropertyWrite` writes from a btleplug central on macOS
- [ ] Verify notify-characteristic updates arrive reliably at the central when `updateValue:forCharacteristic:onSubscribedCentrals:` is called from a tokio worker thread
- [ ] Full Noise_XX handshake between a macOS peripheral and a Linux or Windows central via pw-chat