### PR TITLE
feat(quic): WiFi vs mobile data detection for TransportCost

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,6 +481,16 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
@@ -1500,13 +1510,16 @@ dependencies = [
  "bytes",
  "futures",
  "getrandom 0.2.17",
+ "if-addrs",
  "mdns-sd",
  "pathweave-core",
  "quinn",
  "rcgen",
+ "system-configuration",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "windows 0.58.0",
 ]
 
 [[package]]
@@ -1924,7 +1937,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni 0.21.1",
  "log",
@@ -2005,7 +2018,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.11.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -2344,6 +2357,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]

--- a/crates/pathweave-transport-quic/Cargo.toml
+++ b/crates/pathweave-transport-quic/Cargo.toml
@@ -20,5 +20,12 @@ rcgen = { workspace = true }
 mdns-sd = { workspace = true }
 getrandom = { workspace = true }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = ["Networking_Connectivity"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+if-addrs = { workspace = true }
+system-configuration = "0.7"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -1,6 +1,9 @@
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
-    sync::Arc,
+    sync::{
+        atomic::{AtomicU8, Ordering},
+        Arc,
+    },
 };
 
 use async_trait::async_trait;
@@ -46,6 +49,8 @@ pub struct QuicTransport {
     endpoint: Mutex<Option<Endpoint>>,
     mdns: std::sync::Mutex<Option<MdnsState>>,
     instance_name: String,
+    // Detected at start() time; read lock-free by cost(). Encoding: 0=Free, 1=Metered, 2=Unknown.
+    cost: AtomicU8,
 }
 
 impl QuicTransport {
@@ -58,6 +63,7 @@ impl QuicTransport {
             endpoint: Mutex::new(None),
             mdns: std::sync::Mutex::new(None),
             instance_name,
+            cost: AtomicU8::new(2), // Unknown until start() detects the interface type
         }
     }
 
@@ -85,6 +91,119 @@ fn local_ipv4() -> Ipv4Addr {
             }
         })
         .unwrap_or(Ipv4Addr::LOCALHOST)
+}
+
+// --------------------------------------------------------------------------
+// Network cost detection (ADR 015)
+// --------------------------------------------------------------------------
+
+// Linux: parse /proc/net/route to find the default-route interface, then
+// classify by interface name prefix. No new dependencies required.
+#[cfg(target_os = "linux")]
+fn detect_network_cost() -> TransportCost {
+    let content = match std::fs::read_to_string("/proc/net/route") {
+        Ok(c) => c,
+        Err(_) => return TransportCost::Unknown,
+    };
+    let iface = content.lines().skip(1).find_map(|line| {
+        let mut fields = line.split_whitespace();
+        let iface = fields.next()?;
+        let dest = fields.next()?;
+        if dest == "00000000" {
+            Some(iface.to_string())
+        } else {
+            None
+        }
+    });
+    match iface.as_deref() {
+        Some(n) if n.starts_with("wlan") || n.starts_with("wlp") || n.starts_with("wlx") => {
+            TransportCost::Free
+        }
+        Some(n)
+            if n.starts_with("eth")
+                || n.starts_with("enp")
+                || n.starts_with("eno")
+                || n.starts_with("ens")
+                || n.starts_with("enx") =>
+        {
+            TransportCost::Free
+        }
+        Some(n)
+            if n.starts_with("wwan") || n.starts_with("rmnet") || n.starts_with("ppp") =>
+        {
+            TransportCost::Metered
+        }
+        _ => TransportCost::Unknown,
+    }
+}
+
+// Windows: ask the OS directly via WinRT NetworkInformation. Unrestricted maps
+// to Free; Fixed and Variable are metered plans with data caps.
+#[cfg(target_os = "windows")]
+fn detect_network_cost() -> TransportCost {
+    use windows::Networking::Connectivity::{NetworkCostType, NetworkInformation};
+    let result = (|| -> windows::core::Result<TransportCost> {
+        let profile = NetworkInformation::GetInternetConnectionProfile()?;
+        let cost_type = profile.GetConnectionCost()?.NetworkCostType()?;
+        if cost_type == NetworkCostType::Unrestricted {
+            Ok(TransportCost::Free)
+        } else if cost_type == NetworkCostType::Unknown {
+            Ok(TransportCost::Unknown)
+        } else {
+            Ok(TransportCost::Metered)
+        }
+    })();
+    result.unwrap_or(TransportCost::Unknown)
+}
+
+// macOS: match active interface BSD names (from if_addrs) against the
+// SystemConfiguration interface list to get the interface type. Free wins
+// over Metered if multiple active interfaces are found.
+#[cfg(target_os = "macos")]
+fn detect_network_cost() -> TransportCost {
+    use std::collections::HashSet;
+    use system_configuration::network_configuration::{get_interfaces, SCNetworkInterfaceType};
+
+    let active: HashSet<String> = if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter(|i| !i.is_loopback())
+        .map(|i| i.name)
+        .collect();
+
+    let mut found_free = false;
+    let mut found_metered = false;
+
+    for iface in get_interfaces().iter() {
+        let Some(bsd) = iface.bsd_name() else {
+            continue;
+        };
+        if !active.contains(bsd.to_string().as_str()) {
+            continue;
+        }
+        match iface.interface_type() {
+            Some(SCNetworkInterfaceType::IEEE80211) | Some(SCNetworkInterfaceType::Ethernet) => {
+                found_free = true;
+            }
+            Some(SCNetworkInterfaceType::WWAN) => {
+                found_metered = true;
+            }
+            _ => {}
+        }
+    }
+
+    if found_free {
+        TransportCost::Free
+    } else if found_metered {
+        TransportCost::Metered
+    } else {
+        TransportCost::Unknown
+    }
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows", target_os = "macos")))]
+fn detect_network_cost() -> TransportCost {
+    TransportCost::Unknown
 }
 
 fn make_server_config() -> Result<ServerConfig> {
@@ -236,6 +355,17 @@ impl Transport for QuicTransport {
             bridge,
         });
 
+        let detected = detect_network_cost();
+        self.cost.store(
+            match detected {
+                TransportCost::Free => 0,
+                TransportCost::Metered => 1,
+                TransportCost::Unknown => 2,
+            },
+            Ordering::Relaxed,
+        );
+        tracing::debug!("QUIC transport cost detected: {:?}", detected);
+
         Ok(())
     }
 
@@ -324,7 +454,11 @@ impl Transport for QuicTransport {
     }
 
     fn cost(&self) -> TransportCost {
-        TransportCost::Metered
+        match self.cost.load(Ordering::Relaxed) {
+            0 => TransportCost::Free,
+            1 => TransportCost::Metered,
+            _ => TransportCost::Unknown,
+        }
     }
 
     fn kind(&self) -> TransportKind {

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -128,9 +128,7 @@ fn detect_network_cost() -> TransportCost {
         {
             TransportCost::Free
         }
-        Some(n)
-            if n.starts_with("wwan") || n.starts_with("rmnet") || n.starts_with("ppp") =>
-        {
+        Some(n) if n.starts_with("wwan") || n.starts_with("rmnet") || n.starts_with("ppp") => {
             TransportCost::Metered
         }
         _ => TransportCost::Unknown,

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -233,11 +233,12 @@ pub enum TransportCost {
 ```
 
 `Metered` covers two situations that are not the same: QUIC over WiFi (flat monthly fee,
-functionally free) and QUIC over mobile data (per-megabyte, genuinely metered). Detecting
-which one you're on requires platform-specific OS APIs. Currently, all QUIC connections
-report `Metered` as the conservative default. The v0.2.0 cost intelligence work will
-replace this with WiFi vs. mobile data detection. Battery level, signal quality, and
-payload-size routing are deferred beyond v0.2.0.
+functionally free) and QUIC over mobile data (per-megabyte, genuinely metered). Detection
+uses platform-specific OS APIs: `/proc/net/route` + interface name heuristics on Linux,
+`NetworkInformation::GetConnectionCost()` on Windows, and `SCNetworkInterfaceType` via
+the SystemConfiguration framework on macOS. The detected cost is cached at `start()` time
+and refreshed by `health_monitor` on every network topology change (ADR 015). Battery
+level, signal quality, and payload-size routing are deferred beyond v0.2.0.
 
 ---
 
@@ -548,8 +549,8 @@ Being clear about this matters as much as being clear about what it does.
 - No contact or key registry (Noise_XK upgrade deferred to v0.3.0)
 - No OS network event integration for health monitoring (polling via if-addrs; rtnetlink,
   NWPathMonitor, and WinRT network events deferred to v0.3.0). See ADR 013.
-- No WiFi vs. mobile data detection for QUIC cost reporting (v0.2.0 cost intelligence
-  work not yet complete; all QUIC connections currently report Metered)
+- No real-time cost change notifications via OS events (health_monitor restart provides
+  cost refresh on topology change; OS event integration deferred to v0.3.0)
 - macOS BLE peripheral mode compiled from Windows; needs hardware verification on macOS
 - No security audit completed
 

--- a/notes/decisions/015-quic-cost-detection.md
+++ b/notes/decisions/015-quic-cost-detection.md
@@ -1,0 +1,135 @@
+# ADR 015: Per-platform network cost detection for QuicTransport
+
+**Status:** Accepted
+
+## Context
+
+`QuicTransport::cost()` returns `TransportCost::Metered` unconditionally. That is a
+correct conservative default, but it is wrong in the common case: a laptop on WiFi
+should report `Free` so the router treats it at the same priority as BLE. The gap is
+documented in ARCHITECTURE.md and designated for closure in v0.2.0.
+
+Two constraints shape the design:
+
+1. `Transport::cost()` is a synchronous `fn(&self)`. It cannot perform async or
+   blocking I/O on every call; the router calls it on every routing decision.
+
+2. There is no cross-platform Rust crate that answers "is the default route over WiFi
+   or cellular?" with acceptable stability and a small dependency footprint. Each OS
+   exposes a different API surface (see table below).
+
+The `health_monitor` task in the router already calls `stop()` and `start()` whenever
+the non-loopback IPv4 address set changes (ADR 013). `start()` is therefore called on
+every meaningful network topology change, making it the right place to refresh the
+detected cost. Caching the result in the struct and reading it from `cost()` is both
+correct and zero-overhead at read time.
+
+## Decision
+
+Add a `cost: std::sync::atomic::AtomicU8` field to `QuicTransport`. Values are:
+`0 = Free`, `1 = Metered`, `2 = Unknown`. `start()` calls the platform-specific
+`detect_network_cost()` function and stores the result with `Relaxed` ordering.
+`cost()` loads with `Relaxed` ordering and decodes.
+
+`Unknown` is the default and the fallback on detection failure. It is more honest than
+hard-coding `Metered`, and the router already handles it: `Unknown` transports are
+used last, but they are still used when nothing else is available.
+
+### Per-platform approach
+
+| Platform | API | New dependency |
+|---|---|---|
+| Linux | `/proc/net/route` default route interface + name prefix classification | none |
+| Windows | `NetworkInformation::GetInternetConnectionProfile()` → `GetConnectionCost()` → `NetworkCostType()` | `windows = "0.58"` with `Networking_Connectivity` feature |
+| macOS | `if_addrs` active interface names cross-referenced with `system-configuration`'s `get_interfaces()` by BSD name; `SCNetworkInterfaceType` determines cost | `if-addrs` (workspace) + `system-configuration = "0.7"` |
+| other | returns `Unknown` | none |
+
+**Linux detail:** Parse `/proc/net/route`. Find the line where the Destination field is
+`00000000` (the default route). Extract the interface name. Classify:
+- `wlan*`, `wlp*`, `wlx*` → `Free` (WiFi)
+- `eth*`, `enp*`, `eno*`, `ens*`, `enx*` → `Free` (Ethernet, including Ethernet-over-USB)
+- `wwan*`, `rmnet*`, `ppp*` → `Metered` (cellular)
+- unrecognized or parse failure → `Unknown`
+
+The `en*` prefixes cover both the legacy scheme (`eth0`) and all systemd predictable
+names: slot-based (`enp*`), on-board (`eno*`), hotplug slot (`ens*`), and MAC-based
+(`enx*`, common on Raspberry Pi and USB Ethernet adapters).
+
+`/proc/net/route` is always present on Linux kernels that support networking. Parsing it
+requires only `std::fs` and string splitting. No new dependency.
+
+**Windows detail:** `NetworkInformation::GetInternetConnectionProfile()` returns the
+profile for the connection most likely used for internet traffic. Its
+`GetConnectionCost()` returns a `ConnectionCost` whose `NetworkCostType()` exposes the
+OS-level cost classification. `Unrestricted` maps to `Free`; `Fixed` and `Variable`
+map to `Metered`; `Unknown` (the WinRT variant) maps to `TransportCost::Unknown`. Any
+error returns `Unknown`. `GetInternetConnectionProfile()` is a static synchronous
+method that returns cached OS state immediately; it is not an `IAsyncOperation` and
+does not require `block_in_place`.
+
+**macOS detail:** `system_configuration::network_configuration::get_interfaces()` returns
+all configured network interfaces with their BSD names and interface types. Active
+interfaces (those currently assigned an IP) are identified by cross-referencing with
+`if_addrs::get_if_addrs()`. For each active interface, `SCNetworkInterface::interface_type()`
+returns a `SCNetworkInterfaceType` variant: `IEEE80211` and `Ethernet` map to `Free`;
+`WWAN` maps to `Metered`. If multiple active interfaces are found, `Free` takes priority
+over `Metered`. Unrecognized or absent types fall through to `Unknown`.
+
+This approach finds the "best" active interface rather than strictly the default route's
+interface. In practice these are the same: a machine with active WiFi uses WiFi as the
+default route. The edge case (WiFi up but default route via cellular) is rare on desktop
+macOS and acceptable for v0.2.0.
+
+## Rationale
+
+**Why not re-query on every `cost()` call?**
+
+`cost()` is called synchronously on the hot routing path. A syscall or framework call on
+every invocation would add latency that compounds across multiple transports. Caching at
+`start()` gives correct behavior at zero marginal cost per routing decision, and
+`health_monitor` ensures the cache is refreshed on every real topology change.
+
+**Why `AtomicU8` and not `Mutex<TransportCost>`?**
+
+`AtomicU8` with `Relaxed` ordering gives lock-free reads. There is no correctness
+requirement for sequential consistency here: a slightly stale cost value on the routing
+path (in the window between `start()` writing and `cost()` reading) is indistinguishable
+in effect from the existing always-`Metered` behavior. `Mutex` would serialize all
+routing decisions on the same lock and is unnecessary.
+
+**Why `Unknown` as fallback and not `Metered`?**
+
+`Metered` carries a false precision: it claims we know the connection is metered when we
+do not. `Unknown` is honest. The router handles it correctly: `Unknown` transports are
+tried after `Free` and `Metered`, but they are not excluded. In a two-transport
+deployment (BLE + QUIC), an `Unknown` QUIC transport still provides connectivity when
+BLE is unavailable.
+
+**Why interface name heuristics on Linux instead of netlink?**
+
+`rtnetlink` events give the correct default route interface with zero ambiguity, but
+they require an async stream and a new crate dependency. The procfs approach requires
+only `std::fs::read_to_string` and is correct on any Linux machine with a network
+stack. The heuristic covers all systemd predictable name prefixes (`enp*`, `eno*`,
+`ens*`, `enx*`), the legacy scheme (`eth*`, `wlan*`), and cellular modem names
+(`wwan*`, `rmnet*`, `ppp*`).
+
+**Why not a single cross-platform crate?**
+
+The available candidates (`network-interface`, `default-net`, `netdev`) either lack
+interface-type information (only IP addresses), have unstable APIs, or pull in async
+runtimes as dependencies. Using OS APIs directly keeps the dependency graph minimal and
+the behavior predictable.
+
+## Implications
+
+- `QuicTransport` gains a `cost: AtomicU8` field, initialized to `2` (Unknown).
+- `QuicTransport::start()` calls `detect_network_cost()` and stores the result.
+- `QuicTransport::cost()` reads and decodes the stored value.
+- `pathweave-transport-quic/Cargo.toml` gains:
+  - Windows-only: `windows = { version = "0.58", features = ["Networking_Connectivity"] }`
+  - macOS-only: `if-addrs = { workspace = true }` and `system-configuration = "0.7"`
+- ARCHITECTURE.md TransportCost section updated to remove the "gap" note.
+- Battery level, signal quality, and payload-size routing remain deferred beyond v0.2.0.
+- Real-time cost change notifications (OS events instead of polling) remain deferred
+  to v0.3.0, consistent with the health monitoring decision in ADR 013.


### PR DESCRIPTION
## What changed

`QuicTransport::cost()` previously returned `TransportCost::Metered` unconditionally. This PR implements per-platform detection so QUIC over WiFi or Ethernet correctly reports `Free`, making the router treat it at the same priority as BLE rather than as a more expensive fallback. Detection runs at `start()` time and is cached in an `AtomicU8` on `QuicTransport`, read lock-free by `cost()`. The `health_monitor` task (ADR 013) already calls `stop()+start()` on every network topology change, so the cached value is refreshed automatically without any new polling or event-subscription machinery.

Each platform uses its native API: Linux parses `/proc/net/route` to find the default-route interface and classifies by name prefix; Windows calls `NetworkInformation::GetInternetConnectionProfile()` and reads `NetworkCostType`; macOS cross-references active interface names from `if_addrs` against `SCNetworkInterfaceType` from the SystemConfiguration framework. `Unknown` is the fallback on detection failure — more honest than hard-coding `Metered`, and the router still uses `Unknown` transports as a last resort. ADR 015 documents the per-platform choice and the caching-at-start rationale.

## Why

Closes #56

The ARCHITECTURE.md TransportCost section documented this as a known gap since v0.1.0. A node on WiFi should not be routed identically to a node on mobile data. The router's cost ordering (`Free=0`, `Metered=1`, `Unknown=2`) already supports the distinction — this PR wires real detection to it.

## Alternatives considered

**Re-query on every `cost()` call:** `cost()` is on the hot routing path and synchronous. A syscall or framework call per routing decision adds compounding latency. Caching at `start()` gives correct behavior at zero marginal cost per decision, and `health_monitor` ensures freshness on topology change.

**Single cross-platform crate (`network-interface`, `default-net`, `netdev`):** The available candidates either lack interface-type information (they surface IP addresses but not WiFi vs Ethernet vs cellular), have unstable APIs, or pull in async runtimes as transitive dependencies. Using OS APIs directly keeps the dependency graph minimal and the behavior predictable per platform.

**`Mutex<TransportCost>` instead of `AtomicU8`:** Would serialize all routing decisions on the same lock for no correctness benefit. `Relaxed` ordering on an `AtomicU8` is sufficient: a briefly stale cost value in the window between `start()` writing and `cost()` reading has the same effect as the prior always-`Metered` implementation.

**`block_in_place` for Windows:** Not needed. `NetworkInformation::GetInternetConnectionProfile()` is a static synchronous method that returns cached OS state immediately. It is not an `IAsyncOperation` and does not block for I/O — unlike the WinRT GATT calls in the BLE crate that required `block_in_place`.

**`Metered` as fallback instead of `Unknown`:** `Metered` carries false precision — it claims we know the connection is metered when we do not. `Unknown` is honest. The routing behavior is equivalent in practice: with BLE and QUIC as the only two transports, an `Unknown` QUIC transport is still used when BLE is unavailable.

## Security considerations

`detect_network_cost()` reads interface metadata from the OS (a procfs file on Linux, a cached WinRT profile on Windows, SystemConfiguration data on macOS). None of these paths touch transport bytes, keys, PeerId derivation, or Noise state. The result influences routing priority only — a misdetected cost causes suboptimal transport selection, not a security failure. No private key material is involved at any point in this path.

## Test plan

- [ ] `cargo check -p pathweave-transport-quic` passes on Windows (the platform this was developed on)
- [ ] CI passes on Linux and macOS runners (covers compilation of all three platform branches)
- [ ] Existing router tests pass unchanged (they use mock transports with fixed cost values and are not affected by this change)
- [ ] Runtime detection on physical hardware with a real network interface: not yet tested outside CI