### PR TITLE
fix(core): generalise peer_stream to handle BLE announcements

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -181,10 +181,19 @@ pub struct PeerAnnouncement {
     pub short_id: Option<[u8; 8]>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum PeerAddress {
     Quic(std::net::SocketAddr),
     Ble(String),
+}
+
+impl std::fmt::Display for PeerAddress {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PeerAddress::Quic(addr) => write!(f, "{}", addr),
+            PeerAddress::Ble(id) => write!(f, "{}", id),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -1,5 +1,4 @@
 use std::collections::{HashMap, HashSet};
-use std::net::SocketAddr;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -79,7 +78,7 @@ pub struct PathweaveNode {
     // peers; it never removes. This invariant is what makes the concurrent
     // add_peer() edge case benign: even if known_addrs loses an entry, the
     // peers entry remains intact and send() continues to work.
-    known_addrs: Arc<Mutex<HashSet<SocketAddr>>>,
+    known_addrs: Arc<Mutex<HashSet<PeerAddress>>>,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
 }
@@ -141,9 +140,10 @@ impl PathweaveNode {
     /// Returns NoTransportAvailable if no registered transport is available or all fail.
     pub async fn connect(&mut self, announcement: PeerAnnouncement) -> Result<PeerId> {
         let peer_id = self.router.connect(&announcement, &self.identity).await?;
-        if let PeerAddress::Quic(addr) = &announcement.address {
-            self.known_addrs.lock().unwrap().insert(*addr);
-        }
+        self.known_addrs
+            .lock()
+            .unwrap()
+            .insert(announcement.address.clone());
         self.peers
             .lock()
             .unwrap()
@@ -156,9 +156,10 @@ impl PathweaveNode {
     /// Not part of the UniFFI boundary. Used by pw-chat to inject a QUIC peer
     /// address resolved from the command line, and by tests to set up known peers.
     pub fn add_peer(&mut self, peer_id: PeerId, announcement: PeerAnnouncement) {
-        if let PeerAddress::Quic(addr) = &announcement.address {
-            self.known_addrs.lock().unwrap().insert(*addr);
-        }
+        self.known_addrs
+            .lock()
+            .unwrap()
+            .insert(announcement.address.clone());
         self.peers.lock().unwrap().insert(peer_id, announcement);
     }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -1,5 +1,5 @@
 use std::collections::{HashMap, HashSet};
-use std::net::{Ipv4Addr, SocketAddr};
+use std::net::Ipv4Addr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -338,7 +338,7 @@ async fn try_send(
     }
 }
 
-/// Drives mDNS peer discovery for a single transport across restarts.
+/// Drives peer discovery for a single transport across restarts.
 ///
 /// Waits for the transport to start, then drains its discover() stream. For
 /// each announced address that is not already in `known_addrs`, performs a
@@ -356,7 +356,7 @@ pub(crate) async fn peer_stream(
     identity: NodeIdentity,
     mut started: watch::Receiver<bool>,
     peers: Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>,
-    known_addrs: Arc<Mutex<HashSet<SocketAddr>>>,
+    known_addrs: Arc<Mutex<HashSet<PeerAddress>>>,
     local_peer_id: PeerId,
     event_tx: broadcast::Sender<TransportEvent>,
 ) {
@@ -364,28 +364,25 @@ pub(crate) async fn peer_stream(
         let _ = started.wait_for(|v| *v).await;
         let mut discover = transport.discover();
         while let Some(announcement) = discover.next().await {
-            let addr = match &announcement.address {
-                PeerAddress::Quic(addr) => *addr,
-                _ => continue,
-            };
+            let addr = announcement.address.clone();
 
             // Skip re-announcements from already-connected addresses (O(1) check).
-            if !known_addrs.lock().unwrap().insert(addr) {
+            if !known_addrs.lock().unwrap().insert(addr.clone()) {
                 continue;
             }
 
             match try_connect(transport.as_ref(), &announcement, &identity).await {
                 Ok(peer_id) if peer_id == local_peer_id => {
                     // Self-discovery: keep addr in known_addrs so we don't retry.
-                    tracing::debug!(addr = %addr, "mDNS: discovered self; skipping");
+                    tracing::debug!(addr = %addr, "discovered self; skipping");
                 }
                 Ok(peer_id) => {
-                    tracing::debug!(addr = %addr, peer = %peer_id, "mDNS: peer connected");
+                    tracing::debug!(addr = %addr, peer = %peer_id, "peer connected");
                     peers.lock().unwrap().insert(peer_id.clone(), announcement);
                     let _ = event_tx.send(TransportEvent::PeerConnected(peer_id));
                 }
                 Err(e) => {
-                    tracing::debug!(addr = %addr, "mDNS: handshake failed: {}", e);
+                    tracing::debug!(addr = %addr, "handshake failed: {}", e);
                     // Remove so we retry on the next re-announcement.
                     known_addrs.lock().unwrap().remove(&addr);
                 }


### PR DESCRIPTION
## What changed

`peer_stream` in `router.rs` was filtering discovered peers by address type before doing anything with them. Because `known_addrs` was typed as `HashSet<SocketAddr>`, the loop extracted a QUIC socket address first and continued past every other variant with `_ => continue`. Every announcement `BleTransport::discover()` emitted was a `PeerAddress::Ble`, so all of them hit that arm. The handshake never ran, the peer table was never populated, and `PeerConnected` never fired for BLE peers.

The fix changes `known_addrs` to `HashSet<PeerAddress>` across `peer_stream`, `connect()`, and `add_peer()`, which eliminates the need for address extraction before the dedup check. This required adding `PartialEq, Eq, Hash` to `PeerAddress` and a `Display` impl for tracing output. The address extraction block is replaced with `announcement.address.clone()` as the key directly. The same fix applies to `connect()` and `add_peer()` in `node.rs`, both of which had an equivalent `if let PeerAddress::Quic` guard that left BLE addresses out of `known_addrs` when a caller manually injected a peer.

Closes #60

## Alternatives considered

**Keep the filter, add a separate BLE-specific discover loop.** This would have required a second spawned task per BLE transport and duplicated the dedup check, handshake, peer table insert, and event emit logic. The QUIC filter existed only because `known_addrs` required extracting a `SocketAddr` before the `HashSet::insert` call. Removing that type constraint collapsed both paths into the existing one. No duplication warranted.

**Use `HashMap<PeerAddress, ()>` instead of `HashSet<PeerAddress>`.** Same semantics, more verbose. `HashSet` is the right type.

## Security considerations

The dedup check uses `PeerAddress` as the `HashSet` key. The derived `Hash` and `PartialEq` incorporate the enum discriminant, so `PeerAddress::Ble("x")` and `PeerAddress::Quic(addr)` cannot hash-collide regardless of their inner values. A BLE address string and a QUIC socket address string that happen to be identical character sequences will not be treated as the same peer. No new data crosses a process boundary. BLE announcements go through the same `try_connect` call that QUIC announcements use, so the Noise_XX authentication properties are identical for both transports: the peer's static public key is authenticated during the handshake and the resulting PeerId is derived from it.

## Test plan

- [x] `cargo test -p pathweave-core`: 37/37 pass
- [x] `cargo fmt --check -p pathweave-core`: clean
- [ ] BLE hardware end-to-end: two machines, BLE transport only, auto-discovery confirms `PeerConnected` fires and chat works. Pending this PR landing and #62 (cross-transport routing) for a clean setup.