### PR TITLE
feat(core): multi-address peer routing with kind-matched candidates

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -187,6 +187,15 @@ pub enum PeerAddress {
     Ble(String),
 }
 
+impl PeerAddress {
+    pub fn kind(&self) -> TransportKind {
+        match self {
+            PeerAddress::Quic(_) => TransportKind::Quic,
+            PeerAddress::Ble(_) => TransportKind::Ble,
+        }
+    }
+}
+
 impl std::fmt::Display for PeerAddress {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -66,13 +66,14 @@ impl DeduplicationCache {
 /// Callers create a node, register transports, inject any known peer addresses, and
 /// then use the four documented API surfaces (send, on_message, events, new).
 ///
-/// The peer table maps PeerId -> PeerAnnouncement. The discover task (one per
-/// transport) populates it automatically via mDNS. add_peer() and connect() also
-/// insert into the table for manually-supplied addresses.
+/// The peer table maps PeerId -> Vec<PeerAnnouncement>. A peer reachable via multiple
+/// transports accumulates one address per transport. The peer_stream task (one per
+/// transport) populates it automatically via discovery. add_peer() and connect() also
+/// push addresses for manually-supplied peers. See ADR 016.
 pub struct PathweaveNode {
     router: Router,
     identity: NodeIdentity,
-    peers: Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>,
+    peers: Arc<Mutex<HashMap<PeerId, Vec<PeerAnnouncement>>>>,
     // Dedup-only: tracks addresses currently in-flight or already connected.
     // Not authoritative for routing — peers is. peer_stream only upserts to
     // peers; it never removes. This invariant is what makes the concurrent
@@ -139,15 +140,19 @@ impl PathweaveNode {
     ///
     /// Returns NoTransportAvailable if no registered transport is available or all fail.
     pub async fn connect(&mut self, announcement: PeerAnnouncement) -> Result<PeerId> {
-        let peer_id = self.router.connect(&announcement, &self.identity).await?;
+        let peer_id = self
+            .router
+            .connect(std::slice::from_ref(&announcement), &self.identity)
+            .await?;
         self.known_addrs
             .lock()
             .unwrap()
             .insert(announcement.address.clone());
-        self.peers
-            .lock()
-            .unwrap()
-            .insert(peer_id.clone(), announcement);
+        let mut peers = self.peers.lock().unwrap();
+        let addrs = peers.entry(peer_id.clone()).or_default();
+        if !addrs.iter().any(|a| a.address == announcement.address) {
+            addrs.push(announcement);
+        }
         Ok(peer_id)
     }
 
@@ -160,7 +165,11 @@ impl PathweaveNode {
             .lock()
             .unwrap()
             .insert(announcement.address.clone());
-        self.peers.lock().unwrap().insert(peer_id, announcement);
+        let mut peers = self.peers.lock().unwrap();
+        let addrs = peers.entry(peer_id).or_default();
+        if !addrs.iter().any(|a| a.address == announcement.address) {
+            addrs.push(announcement);
+        }
     }
 
     /// Sends `payload` to the peer identified by `peer_id`.
@@ -172,7 +181,7 @@ impl PathweaveNode {
     /// Returns NoTransportAvailable if the peer is not in the peer table or if
     /// no registered transport can reach the peer.
     pub async fn send(&self, peer_id: PeerId, payload: Vec<u8>) -> Result<()> {
-        let announcement = self
+        let announcements = self
             .peers
             .lock()
             .unwrap()
@@ -180,7 +189,7 @@ impl PathweaveNode {
             .cloned()
             .ok_or(PathweaveError::NoTransportAvailable)?;
         self.router
-            .send(&announcement, &self.identity, payload)
+            .send(&announcements, &self.identity, payload)
             .await
     }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -84,12 +84,16 @@ impl Router {
     /// retry attempts. The receiver's deduplication cache suppresses duplicate delivery
     /// when the same ID arrives more than once (ADR 011).
     ///
-    /// Returns NoTransportAvailable immediately if no transport is currently available.
-    /// Returns DeliveryFailed if all attempts across all available transports are
-    /// exhausted without receiving a delivery ACK.
+    /// Each attempt builds a candidate list of (transport, announcement) pairs where
+    /// the transport kind matches the announcement address kind, sorted by transport
+    /// cost (Free first). All pairs are tried before the attempt is counted as failed.
+    ///
+    /// Returns NoTransportAvailable if no transport is currently available or no
+    /// registered transport can handle any of the given addresses.
+    /// Returns DeliveryFailed if all attempts are exhausted without a delivery ACK.
     pub async fn send(
         &self,
-        peer: &PeerAnnouncement,
+        peers: &[PeerAnnouncement],
         identity: &NodeIdentity,
         payload: Vec<u8>,
     ) -> Result<()> {
@@ -104,22 +108,35 @@ impl Router {
         let message_id = new_message_id();
 
         for attempt in 0..MAX_SEND_ATTEMPTS {
-            let mut candidates: Vec<&TransportEntry> = self
+            let mut candidates: Vec<(&TransportEntry, &PeerAnnouncement)> = self
                 .transports
                 .iter()
                 .filter(|t| t.available.load(Ordering::Acquire))
+                .flat_map(|entry| {
+                    peers.iter().filter_map(move |ann| {
+                        if ann.address.kind() == entry.transport.kind() {
+                            Some((entry, ann))
+                        } else {
+                            None
+                        }
+                    })
+                })
                 .collect();
 
-            candidates.sort_by_key(|t| match t.transport.cost() {
+            if candidates.is_empty() {
+                return Err(PathweaveError::NoTransportAvailable);
+            }
+
+            candidates.sort_by_key(|(entry, _)| match entry.transport.cost() {
                 TransportCost::Free => 0u8,
                 TransportCost::Metered => 1,
                 TransportCost::Unknown => 2,
             });
 
-            for entry in candidates {
+            for (entry, ann) in &candidates {
                 if try_send(
                     entry.transport.as_ref(),
-                    peer,
+                    ann,
                     identity,
                     &payload,
                     message_id,
@@ -139,28 +156,40 @@ impl Router {
         Err(PathweaveError::DeliveryFailed)
     }
 
-    /// Dials `peer`, completes the Noise_XX handshake as the initiator, and returns
-    /// the remote PeerId. Tries transports in cost order (Free first). The session is
-    /// closed after the handshake; the caller is responsible for storing the mapping.
+    /// Dials each address in `peers` in transport-cost order, completes the
+    /// Noise_XX handshake as the initiator, and returns the remote PeerId on
+    /// the first success. Tries (transport, announcement) pairs where the
+    /// transport kind matches the announcement address kind. The session is
+    /// closed after the handshake; the caller is responsible for storing the
+    /// PeerId -> announcements mapping.
     pub async fn connect(
         &self,
-        peer: &PeerAnnouncement,
+        peers: &[PeerAnnouncement],
         identity: &NodeIdentity,
     ) -> Result<PeerId> {
-        let mut candidates: Vec<&TransportEntry> = self
+        let mut candidates: Vec<(&TransportEntry, &PeerAnnouncement)> = self
             .transports
             .iter()
             .filter(|t| t.available.load(Ordering::Acquire))
+            .flat_map(|entry| {
+                peers.iter().filter_map(move |ann| {
+                    if ann.address.kind() == entry.transport.kind() {
+                        Some((entry, ann))
+                    } else {
+                        None
+                    }
+                })
+            })
             .collect();
 
-        candidates.sort_by_key(|t| match t.transport.cost() {
+        candidates.sort_by_key(|(entry, _)| match entry.transport.cost() {
             TransportCost::Free => 0u8,
             TransportCost::Metered => 1,
             TransportCost::Unknown => 2,
         });
 
-        for entry in candidates {
-            if let Ok(peer_id) = try_connect(entry.transport.as_ref(), peer, identity).await {
+        for (entry, ann) in candidates {
+            if let Ok(peer_id) = try_connect(entry.transport.as_ref(), ann, identity).await {
                 return Ok(peer_id);
             }
         }
@@ -355,7 +384,7 @@ pub(crate) async fn peer_stream(
     transport: Arc<dyn Transport>,
     identity: NodeIdentity,
     mut started: watch::Receiver<bool>,
-    peers: Arc<Mutex<HashMap<PeerId, PeerAnnouncement>>>,
+    peers: Arc<Mutex<HashMap<PeerId, Vec<PeerAnnouncement>>>>,
     known_addrs: Arc<Mutex<HashSet<PeerAddress>>>,
     local_peer_id: PeerId,
     event_tx: broadcast::Sender<TransportEvent>,
@@ -378,7 +407,12 @@ pub(crate) async fn peer_stream(
                 }
                 Ok(peer_id) => {
                     tracing::debug!(addr = %addr, peer = %peer_id, "peer connected");
-                    peers.lock().unwrap().insert(peer_id.clone(), announcement);
+                    peers
+                        .lock()
+                        .unwrap()
+                        .entry(peer_id.clone())
+                        .or_default()
+                        .push(announcement);
                     let _ = event_tx.send(TransportEvent::PeerConnected(peer_id));
                 }
                 Err(e) => {
@@ -572,6 +606,20 @@ mod tests {
         }
     }
 
+    // Peer reachable via both BLE and QUIC: used to test cross-transport fallback.
+    fn dual_peer() -> Vec<PeerAnnouncement> {
+        vec![
+            PeerAnnouncement {
+                address: PeerAddress::Ble("aa:bb:cc:dd:ee:ff".into()),
+                short_id: None,
+            },
+            PeerAnnouncement {
+                address: PeerAddress::Quic("127.0.0.1:9001".parse().unwrap()),
+                short_id: None,
+            },
+        ]
+    }
+
     /// Runs a responder: completes the Noise_XX handshake, receives one message, and
     /// sends an empty ACK so try_send() can return before dropping the connection.
     async fn run_responder(conn: TestConn, identity: NodeIdentity) {
@@ -579,6 +627,43 @@ mod tests {
         let mut session = Session::respond(&identity, bundled).await.unwrap();
         let _ = session.recv().await;
         let _ = session.send(b"").await;
+    }
+
+    #[tokio::test]
+    async fn send_with_dual_address_peer_prefers_free_transport_and_skips_metered() {
+        // When the peer has both addresses and BLE succeeds, QUIC must not be attempted.
+        let (ble, mut ble_rx, ble_count) =
+            make_transport(TransportCost::Free, TransportKind::Ble, false);
+        let (quic, _quic_rx, quic_count) =
+            make_transport(TransportCost::Metered, TransportKind::Quic, false);
+
+        let identity = Arc::new(NodeIdentity::generate());
+        let mut router = Router::new();
+        router.register_transport(ble, Arc::clone(&identity));
+        router.register_transport(quic, Arc::clone(&identity));
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let sender_id = NodeIdentity::generate();
+        let responder_id = NodeIdentity::generate();
+
+        tokio::spawn(async move {
+            let conn = ble_rx.recv().await.unwrap();
+            run_responder(conn, responder_id).await;
+        });
+
+        router
+            .send(&dual_peer(), &sender_id, b"hello".to_vec())
+            .await
+            .unwrap();
+
+        assert_eq!(ble_count.load(Ordering::Relaxed), 1, "BLE should be used");
+        assert_eq!(
+            quic_count.load(Ordering::Relaxed),
+            0,
+            "QUIC must not be attempted when BLE succeeds"
+        );
     }
 
     #[tokio::test]
@@ -606,7 +691,7 @@ mod tests {
         });
 
         router
-            .send(&dummy_peer(), &sender_id, b"hello".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"hello".to_vec())
             .await
             .unwrap();
 
@@ -620,6 +705,8 @@ mod tests {
 
     #[tokio::test]
     async fn send_falls_back_on_connect_failure() {
+        // Peer has both a BLE address and a QUIC address. BLE transport fails;
+        // router should fall back to the QUIC address on the same attempt.
         let (ble, _ble_rx, ble_count) =
             make_transport(TransportCost::Free, TransportKind::Ble, true); // fail
         let (quic, mut quic_rx, quic_count) =
@@ -642,7 +729,7 @@ mod tests {
         });
 
         router
-            .send(&dummy_peer(), &sender_id, b"fallback".to_vec())
+            .send(&dual_peer(), &sender_id, b"fallback".to_vec())
             .await
             .unwrap();
 
@@ -660,6 +747,8 @@ mod tests {
 
     #[tokio::test(start_paused = true)]
     async fn send_returns_delivery_failed_when_all_transports_fail() {
+        // Peer has both addresses; both transports fail. Each attempt tries
+        // BLE first (Free) then QUIC (Metered) before backing off.
         let (ble, _ble_rx, ble_count) =
             make_transport(TransportCost::Free, TransportKind::Ble, true);
         let (quic, _quic_rx, quic_count) =
@@ -675,7 +764,7 @@ mod tests {
 
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&dummy_peer(), &sender_id, b"ignored".to_vec())
+            .send(&dual_peer(), &sender_id, b"ignored".to_vec())
             .await;
 
         assert!(
@@ -699,7 +788,7 @@ mod tests {
         let router = Router::new();
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&dummy_peer(), &sender_id, b"ignored".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec())
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }
@@ -726,7 +815,7 @@ mod tests {
         });
 
         router
-            .send(&dummy_peer(), &sender_id, b"hello".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"hello".to_vec())
             .await
             .unwrap();
 
@@ -748,7 +837,7 @@ mod tests {
         // No yield: monitoring task has not run, available = false.
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&dummy_peer(), &sender_id, b"ignored".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec())
             .await;
 
         assert!(
@@ -782,7 +871,10 @@ mod tests {
             run_responder(conn, responder_id).await;
         });
 
-        let peer_id = router.connect(&dummy_peer(), &initiator_id).await.unwrap();
+        let peer_id = router
+            .connect(&[dummy_peer()], &initiator_id)
+            .await
+            .unwrap();
         assert_eq!(peer_id, expected_peer_id);
     }
 
@@ -790,7 +882,7 @@ mod tests {
     async fn connect_returns_no_transport_when_none_registered() {
         let router = Router::new();
         let identity = NodeIdentity::generate();
-        let result = router.connect(&dummy_peer(), &identity).await;
+        let result = router.connect(&[dummy_peer()], &identity).await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }
 

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -84,7 +84,7 @@ let mut events = node.events(); // Stream<Item = TransportEvent>
 // register a transport before first use
 node.register_transport(Box::new(quic));
 
-// dial a peer, complete the Noise_XX handshake, store the PeerId -> address mapping
+// dial a peer, complete the Noise_XX handshake, push the address into the peer's list
 // the session closes immediately after the handshake; send() re-dials on each call
 node.connect(announcement).await?;
 
@@ -93,8 +93,10 @@ node.add_peer(peer_id, announcement);
 ```
 
 `connect()` tries transports in cost order (Free first). It returns the PeerId learned
-from the Noise_XX handshake. Subsequent `send()` calls look up the stored address and
-re-dial lazily.
+from the Noise_XX handshake. The address is pushed into `peers[peer_id]`, a
+`Vec<PeerAnnouncement>`. A peer can accumulate addresses from multiple transports (one
+QUIC address, one BLE address, or both). Subsequent `send()` calls retrieve the full
+list and route across all known addresses. See ADR 016.
 
 **MessageHandler** is a callback interface, not a closure. This is a UniFFI requirement --
 closures don't cross FFI boundaries cleanly. In Rust, you implement the trait. In Swift,
@@ -246,10 +248,23 @@ level, signal quality, and payload-size routing are deferred beyond v0.2.0.
 
 Static priority fallback. That's what it is and what we call it.
 
-1. If BLE is available and the peer is reachable over BLE, use BLE.
-2. Otherwise, use QUIC.
+**Peer table:** `HashMap<PeerId, Vec<PeerAnnouncement>>`. A peer discovered via both
+mDNS (QUIC address) and BLE scan (BLE address) accumulates both addresses in its Vec.
+`peer_stream` deduplicates upstream: the `known_addrs` HashSet prevents a given address
+from reaching the handshake or the Vec a second time. `connect()` and `add_peer()` check
+the Vec directly with an address-equality guard before pushing. The Vec is never pruned
+at runtime; stale address removal is deferred to v0.3.0. See ADR 016.
 
-The routing gets real cost intelligence later in v0.2.0. For now, free transport wins.
+**Candidate building:** `send()` and `connect()` build a candidate list of
+`(transport, announcement)` pairs where the transport kind matches the announcement
+address kind (`PeerAddress::Quic` with `TransportKind::Quic`, `PeerAddress::Ble` with
+`TransportKind::Ble`). Mismatched pairs are excluded at build time rather than failing
+at dial time. Candidates are sorted by transport cost (Free first). All pairs in the
+list are tried before an attempt is counted as failed.
+
+This means: if a peer is known by a BLE address and a QUIC address, and BLE fails, the
+router tries QUIC within the same attempt. No retry sleep is paid for a same-attempt
+cross-transport fallback.
 
 **How the switch works: health monitoring, lazy connections**
 
@@ -271,11 +286,11 @@ connection on the best available transport when `send()` is called.
 
 **Retry behavior**
 
-`send()` retries up to `MAX_SEND_ATTEMPTS` (3) times across available transports, with
-a 1-second back-off (`RETRY_BACKOFF`) between attempts. Each attempt dials the peer,
-completes the Noise_XX handshake, sends the framed payload, and waits for the delivery
-ACK. If all attempts fail, `send()` returns `PathweaveError::DeliveryFailed`. See the
-delivery guarantees section.
+`send()` retries up to `MAX_SEND_ATTEMPTS` (3) times. Each attempt builds the full
+candidate list (all matching transport-address pairs in cost order), tries every pair
+in the list, then backs off for 1 second (`RETRY_BACKOFF`) before the next attempt. If
+all attempts across all candidates fail, `send()` returns `PathweaveError::DeliveryFailed`.
+See the delivery guarantees section.
 
 ---
 

--- a/notes/decisions/016-multi-address-peer-routing.md
+++ b/notes/decisions/016-multi-address-peer-routing.md
@@ -1,0 +1,94 @@
+# ADR 016: Multi-address peer routing with kind-matched candidates
+
+**Status:** Accepted
+
+## Context
+
+The peer table was `HashMap<PeerId, PeerAnnouncement>`: one address per peer. A peer
+reachable via both QUIC (mDNS-discovered) and BLE (BLE-discovered) would only have the
+first-discovered address stored. `send()` looked up a single announcement, and the router
+tried transports in cost order against that one address. If the stored address was
+unreachable and the peer had a second address on a different transport, delivery failed
+instead of falling back.
+
+The "BLE fallback" story was also incomplete in a subtler way: the old candidate-building
+loop passed a single `PeerAnnouncement` to every available transport, including transports
+that cannot handle that address type (a QUIC transport receiving a BLE address). In
+production, `QuicTransport::connect()` would reject any non-QUIC address immediately.
+This was harmless but incorrect: it made `send()` appear to try more options than it
+actually had.
+
+Two constraints:
+
+1. The transport-address pairing must be strict: a transport should only be asked to
+   dial an address of the kind it handles. Mismatched pairs are not a recoverable
+   failure; they are a caller error.
+
+2. A peer discovered via multiple transports (BLE scan and mDNS at the same time) must
+   accumulate all known addresses without overwriting the ones already stored.
+
+## Decision
+
+Change the peer table to `HashMap<PeerId, Vec<PeerAnnouncement>>`. Every call site that
+previously overwrote the entry now pushes a new announcement onto the Vec, with an
+address-equality dedup check to prevent unbounded growth on repeated discovery cycles.
+
+Change `Router::send()` and `Router::connect()` to accept `&[PeerAnnouncement]`. The
+candidate list is built by pairing each available transport with each announcement where
+`announcement.address.kind() == transport.kind()`. Candidates are sorted by transport
+cost (Free first). All pairs are tried before an attempt is counted as failed. On
+`send()`, all `MAX_SEND_ATTEMPTS` retry attempts use this same per-attempt candidate
+list, rebuilding it each time to reflect any availability changes between retries.
+
+Add `PeerAddress::kind() -> TransportKind` to make the kind comparison explicit and
+exhaustive. A new `PeerAddress` variant must assign a kind here or the match will
+not compile, preventing silent omission from the routing path.
+
+If the candidate list is empty for a given attempt (no registered transport can handle
+any of the peer's known addresses), return `NoTransportAvailable` immediately rather
+than exhausting retries.
+
+## Rationale
+
+**Why `Vec<PeerAnnouncement>` and not `HashMap<PeerAddress, PeerAnnouncement>`?**
+
+Iteration order matters for routing: candidates must be sortable by transport cost.
+A `Vec` supports stable sort and preserves insertion order as a tiebreaker for equal-cost
+addresses. A `HashMap` would require collecting into a `Vec` for sorting anyway, and its
+dedup semantics would need the same address-equality check. The `Vec` is simpler and the
+access pattern (full iteration on every send, no random lookup by address) matches it
+well.
+
+**Why kind-matching instead of trying all (transport, announcement) pairs?**
+
+A QUIC transport calling `connect()` with a BLE address is not a recoverable situation:
+it is a logic error. Transports are not interchangeable address handlers; each transport
+only knows how to connect to addresses of its own kind. Filtering mismatched pairs at
+candidate-build time gives an accurate candidate count, makes the retry logic reflect
+actual options, and avoids misleading error logs from transports rejecting addresses they
+never should have received.
+
+**Why dedup by address rather than by the full `PeerAnnouncement`?**
+
+`short_id` in `PeerAnnouncement` is metadata derived from the remote PeerId and may
+differ across announcements for the same physical address if the remote re-derives it.
+Two announcements for the same address with different `short_id` values are not two
+distinct reachability options; they are the same address with stale metadata. Deduping
+on address alone keeps the routing path simple: `send()` already re-derives the remote
+PeerId via Noise_XX on every connection, so `short_id` in the stored announcement is
+never load-bearing for routing.
+
+## Implications
+
+- `PathweaveNode::peers` field type changes from `HashMap<PeerId, PeerAnnouncement>` to
+  `HashMap<PeerId, Vec<PeerAnnouncement>>`.
+- `peer_stream` uses `entry().or_default().push()` with no Vec-level dedup guard because
+  `known_addrs` (a `HashSet<PeerAddress>` shared across all peer_stream tasks) prevents
+  the same address from reaching the handshake or the Vec push a second time.
+- `connect()` and `add_peer()` check the Vec directly with an address-equality guard
+  before pushing, since those call sites have no upstream known_addrs gating.
+- `Router::send()` and `Router::connect()` signatures change; all call sites updated.
+- The `dual_peer()` test helper is added to the router test module to exercise the
+  cross-transport fallback path.
+- Removing stale addresses from the peer Vec when a transport goes down is deferred to
+  v0.3.0, consistent with the broader session lifecycle work planned for that milestone.


### PR DESCRIPTION
## What changed

The peer table was `HashMap<PeerId, PeerAnnouncement>`: one address per peer. A peer reachable via both BLE and QUIC accumulated only the first-discovered address. If that address became unreachable, delivery failed rather than trying the other transport. The old routing also passed a single announcement to every registered transport, including ones that cannot handle that address type: a QUIC transport receiving a BLE address would reject it immediately, making the candidate list appear larger than the real options.

The peer table is now `HashMap<PeerId, Vec<PeerAnnouncement>>`. `Router::send()` and `Router::connect()` take `&[PeerAnnouncement]` and build candidates by pairing each available transport with each announcement whose address kind matches the transport kind (`PeerAddress::Ble` with `TransportKind::Ble`, `PeerAddress::Quic` with `TransportKind::Quic`). Candidates are sorted by cost and all pairs are tried before an attempt counts as failed, so a same-attempt cross-transport fallback pays no retry sleep. `PeerAddress::kind()` makes the mapping explicit and exhaustive: a new address variant that omits a `kind()` arm will not compile.

Dedup: `peer_stream` relies on the upstream `known_addrs` HashSet to prevent the same address from reaching the handshake or the Vec a second time. `connect()` and `add_peer()` guard the Vec directly with an address-equality check before pushing.

ADR 016 filed. ARCHITECTURE.md routing layer and peer table sections updated to reflect the new model.

Closes #62

## Alternatives considered

**Keep single address, add address-rotation on failure.** This would have required the router to mutate the peer table on each failed send to cycle through addresses. The Vec approach is simpler: the router sees all addresses on every attempt and the caller never has to manage rotation state.

**Use `HashMap<PeerAddress, PeerAnnouncement>` instead of `Vec`.** HashMap dedup semantics would prevent address duplication without the explicit guard, but iteration order is non-deterministic, which breaks cost-ordered routing. Vec preserves insertion order as a stable tiebreaker and matches the access pattern (full iteration on every send, no lookup by address).

**Try all (transport, announcement) pairs regardless of kind.** This would preserve the old behavior where any transport attempts any address. It is incorrect: transports are not interchangeable address handlers. Kind-matching makes the candidate list accurate and eliminates misleading error logs from transports rejecting addresses they should never have received.

## Security considerations

No new data crosses a process boundary. The Noise_XX handshake is unchanged: each candidate pair opens a fresh connection, completes the handshake, and derives the remote PeerId from the static public key. A peer with multiple known addresses is still authenticated on every connection via the same handshake. Accumulating a BLE address alongside a QUIC address for the same PeerId does not weaken authentication: both paths authenticate to the same static key, and a PeerId mismatch on any path causes the session to be dropped.

## Test plan

- [x] `cargo test -p pathweave-core`: 38/38 pass
- [x] `cargo fmt --check -p pathweave-core`: clean
- [x] `send_falls_back_on_connect_failure`: dual-address peer, BLE fails, QUIC succeeds within the same attempt (no retry sleep paid)
- [x] `send_returns_delivery_failed_when_all_transports_fail`: dual-address peer, both fail, BLE and QUIC each tried MAX_SEND_ATTEMPTS times
- [x] `send_with_dual_address_peer_prefers_free_transport_and_skips_metered`: dual-address peer, BLE succeeds, QUIC count stays 0
- [ ] BLE + QUIC hardware end-to-end: two machines in both WiFi and BLE range, QUIC path blocked, verify delivery via BLE fallback. Pending BLE testing milestone.