### PR TITLE
feat(pw-chat): ratatui split-pane TUI replaces stdin/stdout REPL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,7 +266,7 @@ dependencies = [
  "dbus",
  "dbus-tokio",
  "futures",
- "itertools",
+ "itertools 0.14.0",
  "log",
  "serde",
  "serde-xml-rs",
@@ -344,6 +350,21 @@ name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "cassowary"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "cc"
@@ -465,6 +486,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "compact_str"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "static_assertions",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,6 +580,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.11.1",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,7 +665,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a707ceda8652f6c7624f2be725652e9524c815bf3b9d55a0b2320be2303f9c11"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -617,8 +678,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -636,12 +707,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -996,6 +1091,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -1058,6 +1155,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1067,10 +1173,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "instability"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
+dependencies = [
+ "darling 0.23.0",
+ "indoc",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -1207,6 +1335,12 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
+version = "0.4.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
@@ -1225,6 +1359,15 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "lru-slab"
@@ -1273,6 +1416,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -1449,6 +1593,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
 name = "parking_lot_core"
 version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1460,6 +1614,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pathweave-core"
@@ -1669,10 +1829,12 @@ name = "pw-chat"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "crossterm",
  "futures",
  "pathweave-core",
  "pathweave-transport-ble",
  "pathweave-transport-quic",
+ "ratatui",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1807,6 +1969,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "ratatui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+dependencies = [
+ "bitflags 2.11.1",
+ "cassowary",
+ "compact_str",
+ "crossterm",
+ "indoc",
+ "instability",
+ "itertools 0.13.0",
+ "lru",
+ "paste",
+ "strum",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "rcgen"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,6 +2068,19 @@ dependencies = [
 
 [[package]]
 name = "rustix"
+version = "0.38.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+dependencies = [
+ "bitflags 2.11.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
@@ -1892,7 +2088,7 @@ dependencies = [
  "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
@@ -1987,6 +2183,12 @@ dependencies = [
  "tempfile",
  "wait-timeout",
 ]
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -2171,6 +2373,37 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "siphasher"
@@ -2390,7 +2623,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -2609,6 +2842,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-truncate"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+dependencies = [
+ "itertools 0.13.0",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2802,6 +3064,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2809,6 +3087,12 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,5 +58,9 @@ getrandom = "0.2"
 mdns-sd = "0.11"
 if-addrs = "0.13"
 
+# tui
+ratatui = "0.29"
+crossterm = { version = "0.28", features = ["event-stream"] }
+
 # testing
 proptest = "1"

--- a/examples/pw-chat/Cargo.toml
+++ b/examples/pw-chat/Cargo.toml
@@ -11,8 +11,10 @@ rust-version.workspace = true
 pathweave-core = { path = "../../crates/pathweave-core" }
 pathweave-transport-quic = { path = "../../crates/pathweave-transport-quic" }
 pathweave-transport-ble = { path = "../../crates/pathweave-transport-ble" }
-tokio = { workspace = true, features = ["io-std"] }
+tokio = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { workspace = true }
+ratatui = { workspace = true }
+crossterm = { workspace = true }

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -9,8 +9,8 @@ use crossterm::{
 };
 use futures::StreamExt;
 use pathweave_core::{
-    MessageHandler, NodeConfig, NodeIdentity, PeerAddress, PeerAnnouncement, PeerId, TransportEvent,
-    TransportKind,
+    MessageHandler, NodeConfig, NodeIdentity, PeerAddress, PeerAnnouncement, PeerId,
+    TransportEvent, TransportKind,
 };
 use pathweave_transport_ble::BleTransport;
 use pathweave_transport_quic::QuicTransport;
@@ -67,7 +67,11 @@ struct App {
 }
 
 impl App {
-    fn new(local_short_id: String, peer_id: Option<PeerId>, initial_transport: TransportKind) -> Self {
+    fn new(
+        local_short_id: String,
+        peer_id: Option<PeerId>,
+        initial_transport: TransportKind,
+    ) -> Self {
         let peer_short_id = peer_id.as_ref().map(|id| id.to_base58()[..8].to_owned());
         Self {
             messages: Vec::new(),

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -151,16 +151,14 @@ async fn run_app(
                     KeyCode::Esc => {
                         return Ok(());
                     }
-                    KeyCode::Enter => {
-                        if !app.input.is_empty() {
-                            if let Some(peer_id) = app.peer_id.clone() {
-                                let text = std::mem::take(&mut app.input);
-                                app.messages.push(format!("me: {}", text));
-                                // Redraw before awaiting send so the message appears immediately.
-                                terminal.draw(|f| draw(f, &app))?;
-                                if let Err(e) = node.send(peer_id, text.into_bytes()).await {
-                                    app.messages.push(format!("[error] {}", e));
-                                }
+                    KeyCode::Enter if !app.input.is_empty() => {
+                        if let Some(peer_id) = app.peer_id.clone() {
+                            let text = std::mem::take(&mut app.input);
+                            app.messages.push(format!("me: {}", text));
+                            // Redraw before awaiting send so the message appears immediately.
+                            terminal.draw(|f| draw(f, &app))?;
+                            if let Err(e) = node.send(peer_id, text.into_bytes()).await {
+                                app.messages.push(format!("[error] {}", e));
                             }
                         }
                     }
@@ -209,7 +207,7 @@ async fn main() {
             tracing_subscriber::EnvFilter::try_from_default_env()
                 .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
         )
-        .with_writer(|| io::stderr())
+        .with_writer(io::stderr)
         .init();
 
     let args = Args::parse();

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -1,14 +1,28 @@
+use std::io;
 use std::net::SocketAddr;
-use std::sync::Arc;
 
 use clap::Parser;
+use crossterm::{
+    event::{Event, EventStream, KeyCode, KeyEventKind, KeyModifiers},
+    execute,
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
 use futures::StreamExt;
 use pathweave_core::{
     MessageHandler, NodeConfig, NodeIdentity, PeerAddress, PeerAnnouncement, PeerId, TransportEvent,
+    TransportKind,
 };
 use pathweave_transport_ble::BleTransport;
 use pathweave_transport_quic::QuicTransport;
-use tokio::io::AsyncBufReadExt;
+use ratatui::{
+    backend::CrosstermBackend,
+    layout::{Constraint, Direction, Layout},
+    style::{Color, Style},
+    text::Line,
+    widgets::{Block, Borders, Paragraph},
+    Frame, Terminal,
+};
+use tokio::sync::mpsc;
 
 const DEFAULT_LISTEN_PORT: u16 = 9001;
 
@@ -33,32 +47,175 @@ struct Args {
     port: u16,
 }
 
-struct PrintHandler {
-    label: Arc<str>,
+struct TuiHandler {
+    tx: mpsc::UnboundedSender<(PeerId, Vec<u8>)>,
 }
 
-impl PrintHandler {
-    fn new(label: &str) -> Self {
+impl MessageHandler for TuiHandler {
+    fn on_message(&self, peer_id: PeerId, payload: Vec<u8>) {
+        let _ = self.tx.send((peer_id, payload));
+    }
+}
+
+struct App {
+    messages: Vec<String>,
+    input: String,
+    peer_id: Option<PeerId>,
+    peer_short_id: Option<String>,
+    transport_name: Option<&'static str>,
+    local_short_id: String,
+}
+
+impl App {
+    fn new(local_short_id: String, peer_id: Option<PeerId>, initial_transport: TransportKind) -> Self {
+        let peer_short_id = peer_id.as_ref().map(|id| id.to_base58()[..8].to_owned());
         Self {
-            label: Arc::from(label),
+            messages: Vec::new(),
+            input: String::new(),
+            peer_id,
+            peer_short_id,
+            transport_name: Some(transport_kind_name(initial_transport)),
+            local_short_id,
         }
     }
 }
 
-impl MessageHandler for PrintHandler {
-    fn on_message(&self, _peer_id: PeerId, payload: Vec<u8>) {
-        let text = String::from_utf8_lossy(&payload);
-        println!("{}: {}", self.label, text);
+fn transport_kind_name(kind: TransportKind) -> &'static str {
+    match kind {
+        TransportKind::Quic => "QUIC",
+        TransportKind::Ble => "BLE",
+    }
+}
+
+fn draw(frame: &mut Frame, app: &App) {
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(3),
+        ])
+        .split(frame.area());
+
+    let peer_label = app.peer_short_id.as_deref().unwrap_or("waiting...");
+    let transport_label = app.transport_name.unwrap_or("none");
+    let status = Paragraph::new(format!(
+        " me: {}   peer: {}   transport: {}",
+        app.local_short_id, peer_label, transport_label
+    ))
+    .style(Style::default().bg(Color::Blue).fg(Color::White));
+    frame.render_widget(status, chunks[0]);
+
+    let inner_height = chunks[1].height.saturating_sub(2) as usize;
+    let start = app.messages.len().saturating_sub(inner_height);
+    let lines: Vec<Line> = app.messages[start..]
+        .iter()
+        .map(|m| Line::from(m.as_str()))
+        .collect();
+    let messages = Paragraph::new(lines).block(Block::default().borders(Borders::ALL));
+    frame.render_widget(messages, chunks[1]);
+
+    let input_text = format!("> {}", app.input);
+    let input_widget = Paragraph::new(input_text.as_str())
+        .block(Block::default().borders(Borders::ALL).title("input"));
+    frame.render_widget(input_widget, chunks[2]);
+
+    // Cursor: inside left border (x+1), past the "> " prompt (x+2), at end of input text.
+    let cursor_x = chunks[2].x + 1 + 2 + app.input.len() as u16;
+    let max_x = chunks[2].x + chunks[2].width.saturating_sub(2);
+    frame.set_cursor_position((cursor_x.min(max_x), chunks[2].y + 1));
+}
+
+async fn run_app(
+    terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
+    node: &pathweave_core::PathweaveNode,
+    mut node_events: futures::stream::BoxStream<'static, TransportEvent>,
+    mut msg_rx: mpsc::UnboundedReceiver<(PeerId, Vec<u8>)>,
+    mut app: App,
+) -> io::Result<()> {
+    let mut key_events = EventStream::new();
+
+    loop {
+        terminal.draw(|f| draw(f, &app))?;
+
+        tokio::select! {
+            maybe_key = key_events.next() => {
+                let Some(Ok(Event::Key(key))) = maybe_key else { continue };
+                if key.kind != KeyEventKind::Press {
+                    continue;
+                }
+                match key.code {
+                    KeyCode::Char('c') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                        return Ok(());
+                    }
+                    KeyCode::Esc => {
+                        return Ok(());
+                    }
+                    KeyCode::Enter => {
+                        if !app.input.is_empty() {
+                            if let Some(peer_id) = app.peer_id.clone() {
+                                let text = std::mem::take(&mut app.input);
+                                app.messages.push(format!("me: {}", text));
+                                // Redraw before awaiting send so the message appears immediately.
+                                terminal.draw(|f| draw(f, &app))?;
+                                if let Err(e) = node.send(peer_id, text.into_bytes()).await {
+                                    app.messages.push(format!("[error] {}", e));
+                                }
+                            }
+                        }
+                    }
+                    KeyCode::Backspace => {
+                        app.input.pop();
+                    }
+                    KeyCode::Char(c) => {
+                        app.input.push(c);
+                    }
+                    _ => {}
+                }
+            }
+            maybe_event = node_events.next() => {
+                match maybe_event {
+                    Some(TransportEvent::TransportChanged { to, .. }) => {
+                        app.transport_name = Some(transport_kind_name(to));
+                    }
+                    Some(TransportEvent::PeerConnected(peer_id)) => {
+                        let short_id = peer_id.to_base58()[..8].to_owned();
+                        app.messages.push(format!("[connected] peer: {}", short_id));
+                        app.peer_short_id = Some(short_id);
+                        app.peer_id = Some(peer_id);
+                    }
+                    Some(TransportEvent::PeerDisconnected(peer_id)) => {
+                        let short_id = peer_id.to_base58()[..8].to_owned();
+                        app.messages.push(format!("[disconnected] peer: {}", short_id));
+                    }
+                    None => {}
+                }
+            }
+            maybe_msg = msg_rx.recv() => {
+                if let Some((peer_id, payload)) = maybe_msg {
+                    let short_id = peer_id.to_base58()[..8].to_owned();
+                    let text = String::from_utf8_lossy(&payload);
+                    app.messages.push(format!("{}: {}", short_id, text));
+                }
+            }
+        }
     }
 }
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+        )
+        .with_writer(|| io::stderr())
+        .init();
+
     let args = Args::parse();
 
     let identity = NodeIdentity::generate();
-    println!("my peer id: {}", identity.peer_id());
+    let local_short_id = identity.peer_id().to_base58()[..8].to_owned();
 
     let listen_addr: SocketAddr = format!("0.0.0.0:{}", args.port).parse().unwrap();
 
@@ -66,34 +223,33 @@ async fn main() {
         .await
         .expect("failed to create node");
 
-    // Subscribe before registering transports: broadcast only delivers events sent
-    // after subscription. Registering first risks missing TransportChanged if a
-    // health_monitor task fires on another thread before events() is called.
+    // Subscribe before registering transports to avoid missing the first TransportChanged.
     let mut events = node.events();
 
-    let quic = QuicTransport::new(listen_addr);
-    node.register_transport(Box::new(quic));
+    node.register_transport(Box::new(QuicTransport::new(listen_addr)));
     node.register_transport(Box::new(BleTransport::new()));
-    loop {
+
+    let initial_transport = loop {
         match events.next().await {
-            Some(TransportEvent::TransportChanged { .. }) => break,
+            Some(TransportEvent::TransportChanged { to, .. }) => break to,
             None => {
                 eprintln!("error: event stream closed before any transport started");
                 std::process::exit(1);
             }
             _ => {}
         }
-    }
+    };
 
-    if let Some(peer_addr) = args.peer {
+    let (msg_tx, msg_rx) = mpsc::unbounded_channel();
+    node.on_message(Box::new(TuiHandler { tx: msg_tx }));
+
+    let initial_peer_id = if let Some(peer_addr) = args.peer {
         let announcement = PeerAnnouncement {
             address: PeerAddress::Quic(peer_addr),
             short_id: None,
         };
-
-        print!("connecting to {}...", peer_addr);
-        let peer_id = match node.connect(announcement).await {
-            Ok(id) => id,
+        match node.connect(announcement).await {
+            Ok(id) => Some(id),
             Err(e) => {
                 eprintln!("error: could not connect to {}: {}", peer_addr, e);
                 eprintln!(
@@ -102,43 +258,34 @@ async fn main() {
                 );
                 std::process::exit(1);
             }
-        };
-        let short_id = &peer_id.to_base58()[..8];
-        println!(" connected. peer: {}", short_id);
-
-        node.on_message(Box::new(PrintHandler::new(short_id)));
-        run_send_loop(&node, peer_id).await;
+        }
     } else {
-        println!("listening on {}. waiting for peer via mDNS...", listen_addr);
+        None
+    };
 
-        let peer_id = loop {
-            match events.next().await {
-                Some(TransportEvent::PeerConnected(peer_id)) => break peer_id,
-                None => {
-                    eprintln!("error: event stream closed before a peer was discovered");
-                    std::process::exit(1);
-                }
-                _ => {}
-            }
-        };
+    let app = App::new(local_short_id, initial_peer_id, initial_transport);
 
-        let short_id = &peer_id.to_base58()[..8];
-        println!("peer discovered: {}. starting chat.", short_id);
+    // Restore the terminal before printing any panic message, otherwise the
+    // shell is left in raw mode with the alternate screen active.
+    let original_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        let _ = disable_raw_mode();
+        let _ = execute!(io::stdout(), LeaveAlternateScreen);
+        original_hook(info);
+    }));
 
-        node.on_message(Box::new(PrintHandler::new(short_id)));
-        run_send_loop(&node, peer_id).await;
-    }
-}
+    enable_raw_mode().expect("failed to enable raw mode");
+    execute!(io::stdout(), EnterAlternateScreen).expect("failed to enter alternate screen");
+    let mut terminal =
+        Terminal::new(CrosstermBackend::new(io::stdout())).expect("failed to create terminal");
 
-async fn run_send_loop(node: &pathweave_core::PathweaveNode, peer_id: PeerId) {
-    let stdin = tokio::io::BufReader::new(tokio::io::stdin());
-    let mut lines = stdin.lines();
-    while let Some(line) = lines.next_line().await.expect("stdin error") {
-        if line.is_empty() {
-            continue;
-        }
-        if let Err(e) = node.send(peer_id.clone(), line.into_bytes()).await {
-            eprintln!("message failed: {}", e);
-        }
+    let result = run_app(&mut terminal, &node, events, msg_rx, app).await;
+
+    let _ = disable_raw_mode();
+    let _ = execute!(io::stdout(), LeaveAlternateScreen);
+
+    if let Err(e) = result {
+        eprintln!("terminal error: {}", e);
+        std::process::exit(1);
     }
 }


### PR DESCRIPTION
Closes #63

## What changed

Replaced the stdin line-reader with a three-pane ratatui TUI running in alternate screen mode.

- **Status bar** (1 line): local short-id, peer short-id, active transport name. Updates live as `TransportChanged` and `PeerConnected` events arrive.
- **Message panel**: bordered, shows the last N messages that fit without scrolling. Incoming messages appear as `short_id: text`; sent messages appear as `me: text`.
- **Input box**: bordered with title, shows `> {input}` with a live cursor clamped to the inner width.

`TuiHandler` implements `MessageHandler` and forwards received messages to the event loop via `mpsc::UnboundedSender`, bridging the synchronous `on_message` interface to the async draw loop.

A single `tokio::select!` loop drains key events (`EventStream`), node events, and the message channel concurrently. On Enter, the message is pushed to `app.messages` and a draw is issued before awaiting `node.send()`, so the sender sees their text immediately rather than after the ACK round-trip.

A panic hook set before `enable_raw_mode()` restores the terminal on unexpected panic so the shell is not left in raw mode. Tracing defaults to `warn` and is redirected to stderr to prevent log output from bleeding into the alternate screen buffer.

The startup sequence is unchanged: `events()` is subscribed before transport registration, the startup loop captures the initial `TransportKind`, `--peer` mode connects before the TUI starts, and auto-discovery mode sets `app.peer_id` when `PeerConnected` fires inside the event loop.

## Alternatives considered

**Spawning `node.send()` into a task instead of awaiting inline.** Would keep the event loop fully responsive during a send, but requires sharing `node` via `Arc` and routing errors back through a separate channel. For a two-person demo where sends complete in milliseconds, the added complexity is not justified. The inline await with a pre-draw is simpler and the UX difference is imperceptible on a local network.

**`ScrollView` or manual scroll offset for the message panel.** Deferred: the demo targets two-person sessions where the visible window is sufficient. Scroll support would require tracking a scroll offset and handling `PageUp`/`PageDown` keys; that is a good follow-on but not needed for the feature to be useful.

## Security considerations

No new trust boundaries. The TUI is a presentation layer over the existing `PathweaveNode` API. All encryption and authentication is handled by the Session layer (Noise_XX) as before; the TUI only reads and displays plaintext that has already been decrypted by the node.

## Test plan

- [ ] `cargo check -p pw-chat` passes with zero warnings
- [ ] `cargo build -p pw-chat` succeeds
- [ ] Manual: `pw-chat --peer <addr>` on one side, `pw-chat` on the other — status bar shows peer short-id and transport after connect; messages appear in the panel; input box accepts text and clears on Enter
- [ ] Manual: Ctrl-C and Esc both exit cleanly and restore the terminal
- [ ] Manual: CI green