### PR TITLE
fix: clean up TUI noise from BLE recovery and tracing

### DIFF
--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -294,7 +294,7 @@ pub(crate) async fn health_monitor(
                 "transport restarted after address change"
             );
         } else {
-            tracing::warn!(
+            tracing::debug!(
                 transport = transport.name(),
                 "transport restart failed; will retry"
             );

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -206,10 +206,12 @@ async fn run_app(
 
 #[tokio::main]
 async fn main() {
+    // Default to off: any write to stderr bleeds into the alternate screen on
+    // most terminals. Set RUST_LOG to enable tracing when debugging.
     tracing_subscriber::fmt()
         .with_env_filter(
             tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn")),
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("off")),
         )
         .with_writer(io::stderr)
         .init();


### PR DESCRIPTION
## What changed

Two fixes found during pw-chat localhost testing.

**Router: demote BLE recovery retry log from warn to debug**

A transport that fails to start enters recovery mode and retries every `NETWORK_POLL_INTERVAL`. Each retry was logged at `warn`, producing a message every 3 seconds indefinitely on any machine without a Bluetooth adapter. The initial failure (entering recovery mode) remains at `warn` since it marks a genuine state transition. Repeated retries are expected recovery behaviour and belong at `debug`.

**pw-chat: default tracing filter to off**

Any write to stderr appears inside the alternate screen on most terminals, including Windows Terminal. With the previous `warn` default, the single remaining initial BLE start failure still corrupted the input box on every launch on a machine without a Bluetooth adapter. Defaulting to `off` keeps the TUI completely clean. `RUST_LOG` can still be set explicitly when debugging.

## Alternatives considered

Writing logs to a file would keep them accessible without corrupting the TUI. Deferred: adds file lifecycle complexity (path, rotation, cleanup) that is disproportionate for a demo tool. The `off` default with explicit `RUST_LOG` override covers the debugging use case cleanly.

## Security considerations

No change to trust boundaries or data handling. Log level changes only.

## Test plan

- [ ] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [ ] Manual: `pw-chat --port 9001` and `pw-chat --port 9002` in two terminals — no log output in TUI, auto-discovery connects both sides, messages flow bidirectionally
- [ ] Manual: `RUST_LOG=debug ./pw-chat --port 9001` — debug output visible on stderr as expected
- [ ] CI green