### PR TITLE
fix(ble): resolve Windows BLE send failure from WinRT lifecycle and peripheral task bugs

### DIFF
--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -134,7 +134,13 @@ impl Router {
             });
 
             for (entry, ann) in &candidates {
-                if try_send(
+                tracing::debug!(
+                    attempt,
+                    transport = entry.transport.name(),
+                    addr = ?ann.address,
+                    "try_send attempt"
+                );
+                match try_send(
                     entry.transport.as_ref(),
                     ann,
                     identity,
@@ -142,9 +148,15 @@ impl Router {
                     message_id,
                 )
                 .await
-                .is_ok()
                 {
-                    return Ok(());
+                    Ok(()) => return Ok(()),
+                    Err(e) => tracing::debug!(
+                        attempt,
+                        transport = entry.transport.name(),
+                        addr = ?ann.address,
+                        error = %e,
+                        "try_send failed"
+                    ),
                 }
             }
 
@@ -348,21 +360,33 @@ async fn try_send(
     payload: &[u8],
     message_id: u64,
 ) -> Result<()> {
-    let raw = transport.connect(peer).await?;
+    let raw = transport.connect(peer).await.map_err(|e| {
+        tracing::debug!(addr = ?peer.address, error = %e, "try_send: connect failed");
+        e
+    })?;
     let bundled = Box::new(BundleLayer::new(raw));
-    let mut session = Session::initiate(identity, bundled).await?;
+    let mut session = Session::initiate(identity, bundled).await.map_err(|e| {
+        tracing::debug!(addr = ?peer.address, error = %e, "try_send: handshake failed");
+        e
+    })?;
 
     let mut framed = Vec::with_capacity(8 + payload.len());
     framed.extend_from_slice(&message_id.to_be_bytes());
     framed.extend_from_slice(payload);
 
-    session.send(&framed).await?;
+    session.send(&framed).await.map_err(|e| {
+        tracing::debug!(addr = ?peer.address, error = %e, "try_send: send failed");
+        e
+    })?;
     // Quinn's write_all() buffers internally; CONNECTION_CLOSE fires when the last
     // connection handle drops, which happens before the buffer is flushed. Waiting
     // for the receiver's ACK keeps the connection alive until the data is delivered.
     match tokio::time::timeout(Duration::from_secs(5), session.recv()).await {
         Ok(Ok(_)) => Ok(()),
-        Ok(Err(e)) => Err(e),
+        Ok(Err(e)) => {
+            tracing::debug!(addr = ?peer.address, error = %e, "try_send: ACK recv failed");
+            Err(e)
+        }
         Err(_) => Err(PathweaveError::Transport("delivery ACK timed out".into())),
     }
 }

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -328,7 +328,8 @@ fn current_ipv4_addrs() -> HashSet<Ipv4Addr> {
 }
 
 /// Dials the transport, completes the Noise_XX handshake, and returns the remote PeerId.
-/// The session is dropped after the handshake, closing the connection.
+/// The session is closed explicitly so transports that require an active teardown
+/// (e.g. BLE peripheral.disconnect()) release their resources before the next connect.
 async fn try_connect(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
@@ -336,8 +337,10 @@ async fn try_connect(
 ) -> Result<PeerId> {
     let raw = transport.connect(peer).await?;
     let bundled = Box::new(BundleLayer::new(raw));
-    let session = Session::initiate(identity, bundled).await?;
-    Ok(session.peer_id().clone())
+    let mut session = Session::initiate(identity, bundled).await?;
+    let peer_id = session.peer_id().clone();
+    let _ = session.close().await;
+    Ok(peer_id)
 }
 
 /// Generates a cryptographically random 64-bit message ID from OS entropy.

--- a/crates/pathweave-core/src/session.rs
+++ b/crates/pathweave-core/src/session.rs
@@ -134,6 +134,10 @@ impl Session {
     pub fn peer_id(&self) -> &PeerId {
         &self.peer_id
     }
+
+    pub async fn close(&mut self) -> Result<()> {
+        self.conn.close().await
+    }
 }
 
 #[cfg(test)]

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -956,8 +956,17 @@ impl BleTransport {
             ))
             .map_err(|e| PathweaveError::Transport(e.to_string()))?;
 
-        // Subscribe handler fires on subscribe and unsubscribe. Only signal
-        // peripheral_task when at least one client is currently subscribed.
+        // Subscribe handler fires on subscribe and unsubscribe.
+        //
+        // Size > 0: signal peripheral_task that a client is ready.
+        //
+        // Size == 0: the client disconnected. Drop write_tx by clearing
+        // write_forward so that BlePeripheralConnection.recv_bytes() returns
+        // an error, which unwinds handle_incoming, which drops reply_tx,
+        // which breaks the peripheral_task inner loop. Without this, the
+        // inner loop stays stuck and the next subscribe signal is silently
+        // consumed and ignored, making message delivery impossible.
+        let write_forward_for_unsub = Arc::clone(&write_forward);
         notify_char
             .SubscribedClientsChanged(&TypedEventHandler::new(
                 move |char: &Option<
@@ -969,6 +978,8 @@ impl BleTransport {
                     };
                     if c.SubscribedClients()?.Size()? > 0 {
                         let _ = subscribe_tx.send(());
+                    } else if let Ok(mut guard) = write_forward_for_unsub.lock() {
+                        *guard = None;
                     }
                     Ok(())
                 },

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -669,9 +669,14 @@ impl Transport for BleTransport {
         // drops the existing BLEDevice cleanly before the new one is created.
         let _ = peripheral.disconnect().await;
 
-        peripheral
-            .connect()
+        // Give the Windows BLE stack time to fully tear down the previous
+        // session before issuing GetGattServicesWithCacheModeAsync on the
+        // new one. Without this settling window the WinRT call hangs.
+        tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+
+        tokio::time::timeout(std::time::Duration::from_secs(10), peripheral.connect())
             .await
+            .map_err(|_| PathweaveError::Transport("BLE connect timed out".into()))?
             .map_err(|e| PathweaveError::Transport(e.to_string()))?;
 
         peripheral

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -662,6 +662,13 @@ impl Transport for BleTransport {
                 ))
             })?;
 
+        // Dropping a BleConnection without calling close() leaves the btleplug
+        // Peripheral's internal BLEDevice alive. When connect() creates a new
+        // BLEDevice for the same address while the old one is still open,
+        // Windows returns RO_E_CLOSED on the new handle. Disconnecting first
+        // drops the existing BLEDevice cleanly before the new one is created.
+        let _ = peripheral.disconnect().await;
+
         peripheral
             .connect()
             .await


### PR DESCRIPTION
## What changed

This PR fixes two interlocking bugs that made BLE message delivery impossible on Windows after the initial `peer_stream` handshake. Three changes land in `pathweave-transport-ble`: `disconnect()` is called before `connect()` in `BleTransport::connect()`, a 500ms settling delay is inserted between them, and `peripheral.connect()` is wrapped in a 10s timeout. A fourth change clears `write_forward` in the `SubscribedClientsChanged` handler when the subscriber count drops to zero, which unblocks the `windows_peripheral_task` inner loop so it is ready for the next `try_send`. Two supporting changes land in `pathweave-core`: `Session::close()` is added, and `try_connect` calls it explicitly after the discovery handshake so the underlying connection is torn down before the next `connect()` call. The branch also includes debug-level tracing in `Router::try_send` that makes the per-step failure sequence visible under `RUST_LOG=pathweave_core=debug`; this stays because it will be useful next time something breaks at the transport layer.

## Why

Closes #68.

The per-message reconnect model in `Router::try_send` assumes the peripheral can accept a fresh connection after the discovery handshake session drops. On Windows that assumption breaks in two places. See #68 for the full diagnosis.

## Alternatives considered

**Call `disconnect()` but skip the settling delay:** tried first. Windows BLE still returned `RO_E_CLOSED` intermittently when the new `GetGattServicesWithCacheModeAsync` call raced with the OS tearing down the previous GATT session. The 500ms delay is the minimum that made the hardware reliable across repeated test runs. It is not principled; it is the smallest value that stopped the flake.

**Use `BluetoothCacheMode::Cached` instead of `Uncached` for the GATT service lookup:** `Cached` would avoid the OTA round-trip and return immediately, but it can hand back stale service handles from a previous connection. `Uncached` is required to force a live connection for data transfer.

**Send a poison-pill value through `write_forward` instead of dropping the sender:** possible, but it introduces a sentinel value that every reader of `write_forward` must know to handle. Dropping the `UnboundedSender` is the idiomatic signal that there are no more writers; `recv()` returning `None` is already the teardown path used by every other channel in the stack.

**Clear `write_forward` in a dedicated disconnect event:** `GattServiceProvider` exposes no explicit client-disconnected event. `SubscribedClientsChanged` with `Size() == 0` is the only signal available from the WinRT peripheral API. A polling approach would work but burns power and adds latency; the event-driven path is both cheaper and faster.

**Restructure `windows_peripheral_task` to create `BlePeripheralConnection` in the outer loop instead of the inner:** this would avoid the stuck-loop problem by design, but it changes the ownership model of `reply_tx` and `write_rx` significantly. The outer/inner structure was chosen deliberately in #50 because it maps cleanly onto the peripheral state machine (waiting for subscriber vs. serving a subscriber). Fixing the teardown signal is a smaller and safer change.

## Security considerations

These changes affect connection teardown sequencing, settling timing, and error propagation paths. The Noise_XX handshake is unaffected: it executes freshly on every connection, and no session state is shared across reconnects. The `write_forward` clearing fires only when the subscriber count drops to zero, meaning the central has already disconnected and no application session is in flight. No application data is discarded by the clearing: the channel is empty at that point because `handle_incoming` has not received any transport payload. No key material, PeerId derivation, or ciphertext handling is changed.

## Test plan

- [x] Two Windows 11 laptops (10.0.26200), WiFi disabled, BLE enabled
- [x] Built `pw-chat` with `cargo build --release` on both laptops (separate builds, no binary copying)
- [x] Sent messages bidirectionally; both sides received under the ratatui TUI
- [x] Each message delivered in ~1-2s, consistent with the per-message reconnect model
- [x] `cargo test -p pathweave-transport-ble`
- [x] `cargo test -p pathweave-core`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo fmt --all --check`