### PR TITLE
fix(pw-chat): introduce MessageDelivered to track the send transport

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -226,6 +226,13 @@ pub enum TransportEvent {
     },
     PeerConnected(PeerId),
     PeerDisconnected(PeerId),
+    /// Fired after each successful send(), naming the transport that carried the message.
+    /// pw-chat uses this to show which transport actually delivered the last send, not
+    /// which transport started most recently.
+    MessageDelivered {
+        peer_id: PeerId,
+        transport: TransportKind,
+    },
 }
 
 pub trait MessageHandler: Send + Sync {

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -189,7 +189,7 @@ impl PathweaveNode {
             .cloned()
             .ok_or(PathweaveError::NoTransportAvailable)?;
         self.router
-            .send(&announcements, &self.identity, payload)
+            .send(&announcements, &self.identity, payload, &peer_id)
             .await
     }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -96,6 +96,7 @@ impl Router {
         peers: &[PeerAnnouncement],
         identity: &NodeIdentity,
         payload: Vec<u8>,
+        peer_id: &PeerId,
     ) -> Result<()> {
         let any_available = self
             .transports
@@ -149,7 +150,13 @@ impl Router {
                 )
                 .await
                 {
-                    Ok(()) => return Ok(()),
+                    Ok(()) => {
+                        let _ = self.event_tx.send(TransportEvent::MessageDelivered {
+                            peer_id: peer_id.clone(),
+                            transport: entry.transport.kind(),
+                        });
+                        return Ok(());
+                    }
                     Err(e) => tracing::debug!(
                         attempt,
                         transport = entry.transport.name(),
@@ -681,7 +688,7 @@ mod tests {
         });
 
         router
-            .send(&dual_peer(), &sender_id, b"hello".to_vec())
+            .send(&dual_peer(), &sender_id, b"hello".to_vec(), sender_id.peer_id())
             .await
             .unwrap();
 
@@ -718,7 +725,7 @@ mod tests {
         });
 
         router
-            .send(&[dummy_peer()], &sender_id, b"hello".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"hello".to_vec(), sender_id.peer_id())
             .await
             .unwrap();
 
@@ -756,7 +763,7 @@ mod tests {
         });
 
         router
-            .send(&dual_peer(), &sender_id, b"fallback".to_vec())
+            .send(&dual_peer(), &sender_id, b"fallback".to_vec(), sender_id.peer_id())
             .await
             .unwrap();
 
@@ -791,7 +798,7 @@ mod tests {
 
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&dual_peer(), &sender_id, b"ignored".to_vec())
+            .send(&dual_peer(), &sender_id, b"ignored".to_vec(), sender_id.peer_id())
             .await;
 
         assert!(
@@ -815,7 +822,7 @@ mod tests {
         let router = Router::new();
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec(), sender_id.peer_id())
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }
@@ -842,7 +849,7 @@ mod tests {
         });
 
         router
-            .send(&[dummy_peer()], &sender_id, b"hello".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"hello".to_vec(), sender_id.peer_id())
             .await
             .unwrap();
 
@@ -864,7 +871,7 @@ mod tests {
         // No yield: monitoring task has not run, available = false.
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec())
+            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec(), sender_id.peer_id())
             .await;
 
         assert!(

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -688,7 +688,12 @@ mod tests {
         });
 
         router
-            .send(&dual_peer(), &sender_id, b"hello".to_vec(), sender_id.peer_id())
+            .send(
+                &dual_peer(),
+                &sender_id,
+                b"hello".to_vec(),
+                sender_id.peer_id(),
+            )
             .await
             .unwrap();
 
@@ -725,7 +730,12 @@ mod tests {
         });
 
         router
-            .send(&[dummy_peer()], &sender_id, b"hello".to_vec(), sender_id.peer_id())
+            .send(
+                &[dummy_peer()],
+                &sender_id,
+                b"hello".to_vec(),
+                sender_id.peer_id(),
+            )
             .await
             .unwrap();
 
@@ -763,7 +773,12 @@ mod tests {
         });
 
         router
-            .send(&dual_peer(), &sender_id, b"fallback".to_vec(), sender_id.peer_id())
+            .send(
+                &dual_peer(),
+                &sender_id,
+                b"fallback".to_vec(),
+                sender_id.peer_id(),
+            )
             .await
             .unwrap();
 
@@ -798,7 +813,12 @@ mod tests {
 
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&dual_peer(), &sender_id, b"ignored".to_vec(), sender_id.peer_id())
+            .send(
+                &dual_peer(),
+                &sender_id,
+                b"ignored".to_vec(),
+                sender_id.peer_id(),
+            )
             .await;
 
         assert!(
@@ -822,7 +842,12 @@ mod tests {
         let router = Router::new();
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec(), sender_id.peer_id())
+            .send(
+                &[dummy_peer()],
+                &sender_id,
+                b"ignored".to_vec(),
+                sender_id.peer_id(),
+            )
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }
@@ -849,7 +874,12 @@ mod tests {
         });
 
         router
-            .send(&[dummy_peer()], &sender_id, b"hello".to_vec(), sender_id.peer_id())
+            .send(
+                &[dummy_peer()],
+                &sender_id,
+                b"hello".to_vec(),
+                sender_id.peer_id(),
+            )
             .await
             .unwrap();
 
@@ -871,7 +901,12 @@ mod tests {
         // No yield: monitoring task has not run, available = false.
         let sender_id = NodeIdentity::generate();
         let result = router
-            .send(&[dummy_peer()], &sender_id, b"ignored".to_vec(), sender_id.peer_id())
+            .send(
+                &[dummy_peer()],
+                &sender_id,
+                b"ignored".to_vec(),
+                sender_id.peer_id(),
+            )
             .await;
 
         assert!(

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -67,18 +67,14 @@ struct App {
 }
 
 impl App {
-    fn new(
-        local_short_id: String,
-        peer_id: Option<PeerId>,
-        initial_transport: TransportKind,
-    ) -> Self {
+    fn new(local_short_id: String, peer_id: Option<PeerId>) -> Self {
         let peer_short_id = peer_id.as_ref().map(|id| id.to_base58()[..8].to_owned());
         Self {
             messages: Vec::new(),
             input: String::new(),
             peer_id,
             peer_short_id,
-            transport_name: Some(transport_kind_name(initial_transport)),
+            transport_name: None,
             local_short_id,
         }
     }
@@ -177,8 +173,8 @@ async fn run_app(
             }
             maybe_event = node_events.next() => {
                 match maybe_event {
-                    Some(TransportEvent::TransportChanged { to, .. }) => {
-                        app.transport_name = Some(transport_kind_name(to));
+                    Some(TransportEvent::MessageDelivered { transport, .. }) => {
+                        app.transport_name = Some(transport_kind_name(transport));
                     }
                     Some(TransportEvent::PeerConnected(peer_id)) => {
                         let short_id = peer_id.to_base58()[..8].to_owned();
@@ -190,7 +186,7 @@ async fn run_app(
                         let short_id = peer_id.to_base58()[..8].to_owned();
                         app.messages.push(format!("[disconnected] peer: {}", short_id));
                     }
-                    None => {}
+                    Some(_) | None => {}
                 }
             }
             maybe_msg = msg_rx.recv() => {
@@ -237,21 +233,10 @@ async fn main() {
         .expect("failed to create node");
 
     // Subscribe before registering transports to avoid missing the first TransportChanged.
-    let mut events = node.events();
+    let events = node.events();
 
     node.register_transport(Box::new(QuicTransport::new(listen_addr)));
     node.register_transport(Box::new(BleTransport::new()));
-
-    let initial_transport = loop {
-        match events.next().await {
-            Some(TransportEvent::TransportChanged { to, .. }) => break to,
-            None => {
-                eprintln!("error: event stream closed before any transport started");
-                std::process::exit(1);
-            }
-            _ => {}
-        }
-    };
 
     let (msg_tx, msg_rx) = mpsc::unbounded_channel();
     node.on_message(Box::new(TuiHandler { tx: msg_tx }));
@@ -276,7 +261,7 @@ async fn main() {
         None
     };
 
-    let app = App::new(local_short_id, initial_peer_id, initial_transport);
+    let app = App::new(local_short_id, initial_peer_id);
 
     // Restore the terminal before printing any panic message, otherwise the
     // shell is left in raw mode with the alternate screen active.


### PR DESCRIPTION
## What this fixes

`TransportChanged` fires when `Transport::start()` succeeds. It marks that a transport is available, not that it delivered a specific message. With QUIC and BLE both registered, both fire at startup; the last one wins in the status bar regardless of which transport `router.send()` actually used.

## How it works

`MessageDelivered { peer_id, transport }` is a new `TransportEvent` variant. It fires inside the confirmed `try_send()` arm in `router.send()`, after the Noise handshake and ACK round-trip prove the peer received the payload. That is the earliest point where both the transport kind and peer identity are known with certainty.

`Router::send()` gains a `peer_id: &PeerId` parameter. `PathweaveNode::send()` passes the `peer_id` it already holds. pw-chat handles `MessageDelivered` to update the status bar; `TransportChanged` is swallowed by a wildcard arm.

The initial `TransportChanged` wait loop in `main()` is removed. The TUI opens immediately with transport showing "none" and updates on first delivery. If no transport starts, `send()` fails before reaching `try_send()`, so "none" is correct rather than showing a stale startup name.

## Alternatives considered

Returning `TransportKind` from `router.send()` and emitting the event in `PathweaveNode::send()` was considered. Rejected: `PathweaveNode` does not hold `event_tx` and wiring it there would scatter event emission across two layers. Emitting from the router keeps all transport events in one place.

## Files changed

- `pathweave-core/src/lib.rs`: new `MessageDelivered` variant on `TransportEvent`
- `pathweave-core/src/router.rs`: emit event on successful send; update all test call sites
- `pathweave-core/src/node.rs`: pass `&peer_id` to `router.send()`
- `examples/pw-chat/src/main.rs`: handle `MessageDelivered`; remove wait loop

## Test plan

- [ ] All 38 existing tests pass (`cargo test --workspace`)
- [ ] Run two pw-chat instances; confirm status bar shows "none" before first send, then the correct transport after sending
- [ ] If both QUIC and BLE are available, confirm the bar shows whichever transport actually carried the message, not the last one to start

Closes #75