### PR TITLE
feat(core): populate KeyRegistry from every Noise_XX handshake

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -1,6 +1,8 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
 
 pub mod bundle;
 pub use bundle::BundleLayer;
@@ -258,6 +260,15 @@ pub trait Connection: Send + Sync {
     async fn recv_bytes(&mut self) -> Result<Bytes>;
     async fn close(&mut self) -> Result<()>;
     fn mtu(&self) -> usize;
+}
+
+// -- key registry --------------------------------------------------------
+
+/// Key store for the Noise_XK upgrade path; populated after every handshake. See ADR 020.
+pub(crate) type KeyRegistry = Arc<Mutex<HashMap<PeerId, [u8; 32]>>>;
+
+pub(crate) fn new_key_registry() -> KeyRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
 }
 
 // -- node ----------------------------------------------------------------

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -7,8 +7,9 @@ use futures::stream::BoxStream;
 use tokio::sync::watch;
 
 use crate::{
-    BundleLayer, Connection, MessageHandler, NodeConfig, NodeIdentity, PathweaveError, PeerAddress,
-    PeerAnnouncement, PeerId, Result, Router, Session, Transport, TransportEvent,
+    new_key_registry, BundleLayer, Connection, KeyRegistry, MessageHandler, NodeConfig,
+    NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId, Result, Router, Session,
+    Transport, TransportEvent,
 };
 
 const DEDUP_TTL: Duration = Duration::from_secs(60);
@@ -82,6 +83,7 @@ pub struct PathweaveNode {
     known_addrs: Arc<Mutex<HashSet<PeerAddress>>>,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
+    key_registry: KeyRegistry,
 }
 
 impl PathweaveNode {
@@ -95,6 +97,7 @@ impl PathweaveNode {
             known_addrs: Arc::new(Mutex::new(HashSet::new())),
             handler: Arc::new(Mutex::new(None)),
             dedup: Arc::new(Mutex::new(DeduplicationCache::new())),
+            key_registry: new_key_registry(),
         })
     }
 
@@ -119,6 +122,7 @@ impl PathweaveNode {
             handler,
             dedup,
             started.clone(),
+            Arc::clone(&self.key_registry),
         ));
 
         tokio::spawn(crate::router::peer_stream(
@@ -129,6 +133,7 @@ impl PathweaveNode {
             Arc::clone(&self.known_addrs),
             self.identity.peer_id().clone(),
             self.router.event_tx(),
+            Arc::clone(&self.key_registry),
         ));
     }
 
@@ -142,7 +147,11 @@ impl PathweaveNode {
     pub async fn connect(&mut self, announcement: PeerAnnouncement) -> Result<PeerId> {
         let peer_id = self
             .router
-            .connect(std::slice::from_ref(&announcement), &self.identity)
+            .connect(
+                std::slice::from_ref(&announcement),
+                &self.identity,
+                &self.key_registry,
+            )
             .await?;
         self.known_addrs
             .lock()
@@ -189,7 +198,13 @@ impl PathweaveNode {
             .cloned()
             .ok_or(PathweaveError::NoTransportAvailable)?;
         self.router
-            .send(&announcements, &self.identity, payload, &peer_id)
+            .send(
+                &announcements,
+                &self.identity,
+                payload,
+                &peer_id,
+                &self.key_registry,
+            )
             .await
     }
 
@@ -218,6 +233,7 @@ async fn accept_loop(
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
     mut started: watch::Receiver<bool>,
+    key_registry: KeyRegistry,
 ) {
     let _ = started.wait_for(|v| *v).await;
     loop {
@@ -226,7 +242,14 @@ async fn accept_loop(
                 let identity = identity.clone();
                 let handler = Arc::clone(&handler);
                 let dedup = Arc::clone(&dedup);
-                tokio::spawn(handle_incoming(conn, identity, handler, dedup));
+                let key_registry = Arc::clone(&key_registry);
+                tokio::spawn(handle_incoming(
+                    conn,
+                    identity,
+                    handler,
+                    dedup,
+                    key_registry,
+                ));
             }
             Err(e) => {
                 tracing::debug!(transport = transport.name(), "accept error: {}", e);
@@ -248,6 +271,7 @@ async fn handle_incoming(
     identity: NodeIdentity,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
+    key_registry: KeyRegistry,
 ) {
     let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(conn));
     let mut session = match Session::respond(&identity, bundled).await {
@@ -258,6 +282,10 @@ async fn handle_incoming(
         }
     };
     let peer_id = session.peer_id().clone();
+    key_registry
+        .lock()
+        .unwrap()
+        .insert(peer_id.clone(), *session.remote_static_key());
     while let Ok(payload) = session.recv().await {
         if payload.len() < 8 {
             tracing::debug!(peer = %peer_id, "received payload shorter than 8 bytes; skipping");
@@ -638,6 +666,35 @@ mod tests {
         assert_eq!(peer_id, expected_peer_id);
         // Verify the mapping was stored so send() can now route to this peer.
         assert!(node.peers.lock().unwrap().contains_key(&peer_id));
+    }
+
+    #[tokio::test]
+    async fn connect_stores_peer_key_in_registry() {
+        let (mock, mut mock_rx, _) = make_transport(TransportCost::Free, TransportKind::Ble);
+
+        let initiator_id = NodeIdentity::generate();
+        let responder_id = NodeIdentity::generate();
+        let expected_key: [u8; 32] = responder_id.public_key().try_into().unwrap();
+
+        let mut node = PathweaveNode::new(NodeConfig::default(), initiator_id)
+            .await
+            .unwrap();
+        node.register_transport(Box::new(mock));
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        tokio::spawn(async move {
+            let conn = mock_rx.recv().await.unwrap();
+            run_responder(conn, responder_id).await;
+        });
+
+        let peer_id = node.connect(dummy_peer()).await.unwrap();
+        let registry = node.key_registry.lock().unwrap();
+        let stored = registry
+            .get(&peer_id)
+            .expect("key must be in registry after connect");
+        assert_eq!(stored, &expected_key);
     }
 
     #[tokio::test]

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -429,6 +429,7 @@ async fn try_send(
 /// back and waits for the next started -> stopped -> started cycle. The
 /// wait_for(false) step prevents a spin loop on transports whose discover()
 /// returns an empty stream immediately.
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn peer_stream(
     transport: Arc<dyn Transport>,
     identity: NodeIdentity,

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -9,8 +9,8 @@ use tokio::sync::{broadcast, watch};
 use tokio::task::JoinHandle;
 
 use crate::{
-    BundleLayer, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId, Result,
-    Session, Transport, TransportCost, TransportEvent, TransportKind,
+    BundleLayer, KeyRegistry, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId,
+    Result, Session, Transport, TransportCost, TransportEvent, TransportKind,
 };
 
 const MAX_SEND_ATTEMPTS: usize = 3;
@@ -97,6 +97,7 @@ impl Router {
         identity: &NodeIdentity,
         payload: Vec<u8>,
         peer_id: &PeerId,
+        key_registry: &KeyRegistry,
     ) -> Result<()> {
         let any_available = self
             .transports
@@ -147,6 +148,7 @@ impl Router {
                     identity,
                     &payload,
                     message_id,
+                    key_registry,
                 )
                 .await
                 {
@@ -185,6 +187,7 @@ impl Router {
         &self,
         peers: &[PeerAnnouncement],
         identity: &NodeIdentity,
+        key_registry: &KeyRegistry,
     ) -> Result<PeerId> {
         let mut candidates: Vec<(&TransportEntry, &PeerAnnouncement)> = self
             .transports
@@ -208,7 +211,9 @@ impl Router {
         });
 
         for (entry, ann) in candidates {
-            if let Ok(peer_id) = try_connect(entry.transport.as_ref(), ann, identity).await {
+            if let Ok(peer_id) =
+                try_connect(entry.transport.as_ref(), ann, identity, key_registry).await
+            {
                 return Ok(peer_id);
             }
         }
@@ -341,11 +346,16 @@ async fn try_connect(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
     identity: &NodeIdentity,
+    key_registry: &KeyRegistry,
 ) -> Result<PeerId> {
     let raw = transport.connect(peer).await?;
     let bundled = Box::new(BundleLayer::new(raw));
     let mut session = Session::initiate(identity, bundled).await?;
     let peer_id = session.peer_id().clone();
+    key_registry
+        .lock()
+        .unwrap()
+        .insert(peer_id.clone(), *session.remote_static_key());
     let _ = session.close().await;
     Ok(peer_id)
 }
@@ -369,6 +379,7 @@ async fn try_send(
     identity: &NodeIdentity,
     payload: &[u8],
     message_id: u64,
+    key_registry: &KeyRegistry,
 ) -> Result<()> {
     let raw = transport.connect(peer).await.map_err(|e| {
         tracing::debug!(addr = ?peer.address, error = %e, "try_send: connect failed");
@@ -379,6 +390,10 @@ async fn try_send(
         tracing::debug!(addr = ?peer.address, error = %e, "try_send: handshake failed");
         e
     })?;
+    key_registry
+        .lock()
+        .unwrap()
+        .insert(session.peer_id().clone(), *session.remote_static_key());
 
     let mut framed = Vec::with_capacity(8 + payload.len());
     framed.extend_from_slice(&message_id.to_be_bytes());
@@ -422,6 +437,7 @@ pub(crate) async fn peer_stream(
     known_addrs: Arc<Mutex<HashSet<PeerAddress>>>,
     local_peer_id: PeerId,
     event_tx: broadcast::Sender<TransportEvent>,
+    key_registry: KeyRegistry,
 ) {
     loop {
         let _ = started.wait_for(|v| *v).await;
@@ -434,7 +450,7 @@ pub(crate) async fn peer_stream(
                 continue;
             }
 
-            match try_connect(transport.as_ref(), &announcement, &identity).await {
+            match try_connect(transport.as_ref(), &announcement, &identity, &key_registry).await {
                 Ok(peer_id) if peer_id == local_peer_id => {
                     // Self-discovery: keep addr in known_addrs so we don't retry.
                     tracing::debug!(addr = %addr, "discovered self; skipping");
@@ -465,7 +481,7 @@ pub(crate) async fn peer_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{Connection, NodeIdentity, PeerAddress, Session, TransportKind};
+    use crate::{new_key_registry, Connection, NodeIdentity, PeerAddress, Session, TransportKind};
     use async_trait::async_trait;
     use bytes::Bytes;
     use std::sync::atomic::AtomicUsize;
@@ -693,6 +709,7 @@ mod tests {
                 &sender_id,
                 b"hello".to_vec(),
                 sender_id.peer_id(),
+                &new_key_registry(),
             )
             .await
             .unwrap();
@@ -735,6 +752,7 @@ mod tests {
                 &sender_id,
                 b"hello".to_vec(),
                 sender_id.peer_id(),
+                &new_key_registry(),
             )
             .await
             .unwrap();
@@ -778,6 +796,7 @@ mod tests {
                 &sender_id,
                 b"fallback".to_vec(),
                 sender_id.peer_id(),
+                &new_key_registry(),
             )
             .await
             .unwrap();
@@ -818,6 +837,7 @@ mod tests {
                 &sender_id,
                 b"ignored".to_vec(),
                 sender_id.peer_id(),
+                &new_key_registry(),
             )
             .await;
 
@@ -847,6 +867,7 @@ mod tests {
                 &sender_id,
                 b"ignored".to_vec(),
                 sender_id.peer_id(),
+                &new_key_registry(),
             )
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
@@ -879,6 +900,7 @@ mod tests {
                 &sender_id,
                 b"hello".to_vec(),
                 sender_id.peer_id(),
+                &new_key_registry(),
             )
             .await
             .unwrap();
@@ -906,6 +928,7 @@ mod tests {
                 &sender_id,
                 b"ignored".to_vec(),
                 sender_id.peer_id(),
+                &new_key_registry(),
             )
             .await;
 
@@ -941,7 +964,7 @@ mod tests {
         });
 
         let peer_id = router
-            .connect(&[dummy_peer()], &initiator_id)
+            .connect(&[dummy_peer()], &initiator_id, &new_key_registry())
             .await
             .unwrap();
         assert_eq!(peer_id, expected_peer_id);
@@ -951,7 +974,9 @@ mod tests {
     async fn connect_returns_no_transport_when_none_registered() {
         let router = Router::new();
         let identity = NodeIdentity::generate();
-        let result = router.connect(&[dummy_peer()], &identity).await;
+        let result = router
+            .connect(&[dummy_peer()], &identity, &new_key_registry())
+            .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }
 
@@ -1192,6 +1217,7 @@ mod tests {
             Arc::clone(&known_addrs),
             local_peer_id,
             event_tx,
+            new_key_registry(),
         ));
 
         // Start the transport: peer_stream calls discover() (first call, empty stream ends).

--- a/crates/pathweave-core/src/session.rs
+++ b/crates/pathweave-core/src/session.rs
@@ -13,6 +13,7 @@ const NOISE_MSG_MAX: usize = 65535;
 /// After construction the remote peer's identity is known and all traffic is encrypted.
 pub struct Session {
     peer_id: PeerId,
+    remote_static_key: [u8; 32],
     state: snow::TransportState,
     conn: Box<dyn Connection>,
 }
@@ -92,18 +93,18 @@ impl Session {
     }
 
     fn finish(state: snow::HandshakeState, conn: Box<dyn Connection>) -> Result<Self> {
-        let remote_static = state
-            .get_remote_static()
-            .ok_or_else(|| {
-                PathweaveError::Session("remote static key unavailable after handshake".into())
-            })?
-            .to_vec();
-        let peer_id = peer_id_from_public_key(&remote_static);
+        let raw = state.get_remote_static().ok_or_else(|| {
+            PathweaveError::Session("remote static key unavailable after handshake".into())
+        })?;
+        let remote_static_key: [u8; 32] =
+            raw.try_into().expect("Noise static key is always 32 bytes");
+        let peer_id = peer_id_from_public_key(&remote_static_key);
         let transport = state
             .into_transport_mode()
             .map_err(|e| PathweaveError::Session(e.to_string()))?;
         Ok(Self {
             peer_id,
+            remote_static_key,
             state: transport,
             conn,
         })
@@ -133,6 +134,10 @@ impl Session {
 
     pub fn peer_id(&self) -> &PeerId {
         &self.peer_id
+    }
+
+    pub fn remote_static_key(&self) -> &[u8; 32] {
+        &self.remote_static_key
     }
 
     pub async fn close(&mut self) -> Result<()> {
@@ -192,6 +197,21 @@ mod tests {
             Session::respond(&id_b, Box::new(conn_b)),
         );
         (a.unwrap(), b.unwrap())
+    }
+
+    #[tokio::test]
+    async fn handshake_reveals_correct_static_key() {
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let (conn_a, conn_b) = conn_pair();
+        let (session_a, session_b) = tokio::join!(
+            Session::initiate(&id_a, Box::new(conn_a)),
+            Session::respond(&id_b, Box::new(conn_b)),
+        );
+        let session_a = session_a.unwrap();
+        let session_b = session_b.unwrap();
+        assert_eq!(&session_a.remote_static_key()[..], id_b.public_key());
+        assert_eq!(&session_b.remote_static_key()[..], id_a.public_key());
     }
 
     #[tokio::test]

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -121,6 +121,10 @@ pub enum TransportEvent {
     },
     PeerConnected(PeerId),
     PeerDisconnected(PeerId),
+    MessageDelivered {
+        peer_id: PeerId,
+        transport: TransportKind,
+    },
 }
 
 pub enum TransportKind {
@@ -129,8 +133,12 @@ pub enum TransportKind {
 }
 ```
 
-`events()` is what powers the "switched to BLE" line in pw-chat. These enums must be
-defined before the UDL is written because they cross the UniFFI boundary.
+`events()` is what powers the status line in pw-chat. `MessageDelivered` fires after
+each confirmed send (after the receiver's ACK round-trip), naming the transport that
+actually carried the message. `TransportChanged` fires when a transport starts or
+restarts; it is not a reliable signal for which transport delivered a specific message.
+These enums must be defined before the UDL is written because they cross the UniFFI
+boundary.
 
 ---
 
@@ -374,10 +382,17 @@ before you connect. Noise_XK requires knowing the responder's key before initiat
 means you can't use it for unknown nearby peers. Noise_XX lets both sides reveal keys
 during the handshake, so you can connect to anyone you discover.
 
-Noise_XK is the v0.3.0 upgrade, once we have a contact and key registry. The pattern
-string changes; the crate doesn't.
+After the handshake, the peer's static public key is known. PeerId is derived here. The
+raw 32-byte Curve25519 key is retained in the session and stored in a key registry on
+`PathweaveNode` (`HashMap<PeerId, [u8; 32]>`). See ADR 020.
 
-After the handshake, the peer's static public key is known. PeerId is derived here.
+Noise_XK is the v0.3.0 upgrade for known peers. Once the key registry has a peer's key,
+subsequent connections use XK instead of XX. XK hides the responder's identity from
+passive observers during the handshake. A 1-byte protocol version prefix before the first
+handshake message signals which pattern is in use so both sides build the correct
+handshake state. The `snow` pattern string changes from
+`Noise_XX_25519_ChaChaPoly_BLAKE2s` to `Noise_XK_25519_ChaChaPoly_BLAKE2s`; nothing
+else in the session layer changes. See ADR 020.
 
 Crate: `snow` v0.10, RustCrypto backends. The underlying primitives (x25519-dalek,
 chacha20poly1305) are independently verified. The ring backend uses hand-optimized
@@ -561,7 +576,7 @@ Being clear about this matters as much as being clear about what it does.
 - No WiFi Direct, SMS, or USSD transports
 - No MLS group key exchange (Noise_XX is 1:1 only)
 - No multi-hop BLE routing (single-hop only)
-- No contact or key registry (Noise_XK upgrade deferred to v0.3.0)
+- No Noise_XK upgrade yet (key registry implemented in v0.3.0; XK handshake path follows)
 - No OS network event integration for health monitoring (polling via if-addrs; rtnetlink,
   NWPathMonitor, and WinRT network events deferred to v0.3.0). See ADR 013.
 - No real-time cost change notifications via OS events (health_monitor restart provides


### PR DESCRIPTION
## What changed

`Session` now stores the remote peer's 32-byte Curve25519 static public key after every Noise_XX handshake. A `KeyRegistry` (`Arc<Mutex<HashMap<PeerId, [u8; 32]>>>`) lives on `PathweaveNode` and is populated at three callsites: `handle_incoming` (responder path), `try_connect` (peer-stream discovery), and `try_send` (outbound message path). Two new tests verify the behavior end-to-end.

ARCHITECTURE.md is updated to describe the key registry structure and the Noise_XK upgrade path. See ADR 020.

## Why this is the right approach

PeerId is a one-way blake3 hash of the Curve25519 public key. Without storing the raw key bytes before the `HandshakeState` is consumed by `into_transport_mode()`, there is no way to recover them later. The XK handshake pattern requires knowing the responder's static key before initiating, so the registry must be populated during XX to unlock XK for subsequent connections.

The three-callsite approach mirrors how `PeerId` is already captured at the same three sites. Passing `&KeyRegistry` to async functions called inline (send, connect) and `KeyRegistry` (owned Arc clone) to spawned background tasks follows the same ownership split used for other shared state on `PathweaveNode`.

## Alternatives considered

**Return the key alongside PeerId from try_connect/try_send instead of threading the registry inward.** This would require changing the return type of two internal functions and rebuilding call chains at the PathweaveNode level. It also does not fit the `handle_incoming` path cleanly since `handle_incoming` has no return value. The registry-as-parameter approach is uniform across all three sites.

**Store the registry on Router instead of PathweaveNode.** ADR 020 places the registry on the node layer, and key lookup for Noise_XK will happen at the `send()` call site in `PathweaveNode`, not inside `Router`. Storing it on `PathweaveNode` keeps the lookup co-located with the decision point.

## Security considerations

The registry stores Curve25519 static **public** keys, not any secret material. Public keys are exchanged openly during the Noise_XX handshake; recording them does not expose anything an observer of the handshake could not already see. No private key material is stored anywhere in this PR. Registry writes are idempotent: if the same peer reconnects its key is overwritten with the same value (keys are deterministic per ADR 005). `Arc<Mutex<...>>` provides safe concurrent access from multiple transport tasks with no unsafe code.

## Test plan

- `session::tests::handshake_reveals_correct_static_key`: runs `Session::initiate` and `Session::respond` concurrently via `tokio::join!`, asserts both sides expose the correct 32-byte key for the other's identity.
- `node::tests::connect_stores_peer_key_in_registry`: full `PathweaveNode::connect()` round-trip using a mock transport and a live responder task; asserts registry contains the expected key after connect returns.
- All 46 existing tests continue to pass.
- `cargo fmt --check` clean.

Closes #78.