### PR TITLE
feat(core): upgrade directed sends to Noise_XK for known peers

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -41,6 +41,7 @@ pub enum PathweaveError {
 // -- identity ------------------------------------------------------------
 
 pub(crate) const NOISE_PARAMS: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
+pub(crate) const NOISE_XK_PARAMS: &str = "Noise_XK_25519_ChaChaPoly_BLAKE2s";
 
 pub(crate) fn peer_id_from_public_key(public_key: &[u8]) -> PeerId {
     PeerId(*blake3::hash(public_key).as_bytes())

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -221,6 +221,14 @@ impl PathweaveNode {
     pub fn events(&self) -> BoxStream<'static, TransportEvent> {
         self.router.events()
     }
+
+    /// Returns the stored Curve25519 static public key for `peer_id`, if known.
+    ///
+    /// Populated after every successful handshake. Used by the Noise_XK upgrade path
+    /// and future E2E hop encryption. See ADR 020.
+    pub fn lookup_key(&self, peer_id: &PeerId) -> Option<[u8; 32]> {
+        self.key_registry.lock().unwrap().get(peer_id).copied()
+    }
 }
 
 /// Loops calling transport.accept(). Waits for the transport's start() to complete
@@ -624,7 +632,7 @@ mod tests {
 
         tokio::spawn(async move {
             let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(Box::new(client_conn)));
-            let mut session = Session::initiate(&sender_id, bundled).await.unwrap();
+            let mut session = Session::initiate(&sender_id, bundled, None).await.unwrap();
             // Prepend the 8-byte message ID as handle_incoming now expects (ADR 011).
             let msg_id: u64 = 0x0102030405060708;
             let mut framed = Vec::with_capacity(8 + b"hello from peer".len());
@@ -804,7 +812,7 @@ mod tests {
             tokio::spawn(async move {
                 let bundled: Box<dyn Connection> =
                     Box::new(BundleLayer::new(Box::new(client_conn)));
-                let mut session = Session::initiate(&sender_id, bundled).await.unwrap();
+                let mut session = Session::initiate(&sender_id, bundled, None).await.unwrap();
                 session.send(&framed).await.unwrap();
                 // Wait for the ACK so handle_incoming has time to process.
                 let _ =

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -149,6 +149,7 @@ impl Router {
                     &payload,
                     message_id,
                     key_registry,
+                    peer_id,
                 )
                 .await
                 {
@@ -340,6 +341,7 @@ fn current_ipv4_addrs() -> HashSet<Ipv4Addr> {
 }
 
 /// Dials the transport, completes the Noise_XX handshake, and returns the remote PeerId.
+/// Always uses Noise_XX because the target identity is unknown before dialing.
 /// The session is closed explicitly so transports that require an active teardown
 /// (e.g. BLE peripheral.disconnect()) release their resources before the next connect.
 async fn try_connect(
@@ -350,7 +352,7 @@ async fn try_connect(
 ) -> Result<PeerId> {
     let raw = transport.connect(peer).await?;
     let bundled = Box::new(BundleLayer::new(raw));
-    let mut session = Session::initiate(identity, bundled).await?;
+    let mut session = Session::initiate(identity, bundled, None).await?;
     let peer_id = session.peer_id().clone();
     key_registry
         .lock()
@@ -373,6 +375,8 @@ fn new_message_id() -> u64 {
 /// Opens a connection through the given transport, wraps it in BundleLayer and
 /// Session, prepends the 8-byte message ID for receiver-side deduplication,
 /// sends the framed payload, waits for the receiver's delivery ACK, then closes.
+/// Uses Noise_XK when the key registry has an entry for peer_id; falls back to
+/// Noise_XX on XK failure and evicts the stale entry so the next retry uses XX.
 async fn try_send(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
@@ -380,16 +384,25 @@ async fn try_send(
     payload: &[u8],
     message_id: u64,
     key_registry: &KeyRegistry,
+    peer_id: &PeerId,
 ) -> Result<()> {
+    let remote_key = key_registry.lock().unwrap().get(peer_id).copied();
     let raw = transport.connect(peer).await.map_err(|e| {
         tracing::debug!(addr = ?peer.address, error = %e, "try_send: connect failed");
         e
     })?;
     let bundled = Box::new(BundleLayer::new(raw));
-    let mut session = Session::initiate(identity, bundled).await.map_err(|e| {
-        tracing::debug!(addr = ?peer.address, error = %e, "try_send: handshake failed");
-        e
-    })?;
+    let mut session = match Session::initiate(identity, bundled, remote_key.as_ref()).await {
+        Ok(s) => s,
+        Err(e) => {
+            if remote_key.is_some() {
+                // XK failed; evict the stale key so the next retry uses XX.
+                key_registry.lock().unwrap().remove(peer_id);
+            }
+            tracing::debug!(addr = ?peer.address, error = %e, "try_send: handshake failed");
+            return Err(e);
+        }
+    };
     key_registry
         .lock()
         .unwrap()

--- a/crates/pathweave-core/src/session.rs
+++ b/crates/pathweave-core/src/session.rs
@@ -1,13 +1,18 @@
 use bytes::Bytes;
 
 use crate::{
-    peer_id_from_public_key, Connection, NodeIdentity, PathweaveError, PeerId, Result, NOISE_PARAMS,
+    peer_id_from_public_key, Connection, NodeIdentity, PathweaveError, PeerId, Result,
+    NOISE_PARAMS, NOISE_XK_PARAMS,
 };
 
 // Maximum Noise protocol message size (spec limit).
 const NOISE_MSG_MAX: usize = 65535;
 
-/// An authenticated, encrypted channel established via Noise_XX_25519_ChaChaPoly_BLAKE2s.
+// Protocol version prefix sent before the first Noise handshake message.
+const PROTO_XX: u8 = 0x00;
+const PROTO_XK: u8 = 0x01;
+
+/// An authenticated, encrypted channel established via Noise_XX or Noise_XK.
 ///
 /// Callers obtain a Session by completing a handshake through `initiate` or `respond`.
 /// After construction the remote peer's identity is known and all traffic is encrypted.
@@ -19,36 +24,63 @@ pub struct Session {
 }
 
 impl Session {
-    /// Performs the Noise_XX handshake as the initiator over `conn`.
+    /// Performs the Noise handshake as the initiator over `conn`.
     ///
-    /// Sends three handshake messages. Panics only if the hardcoded Noise params
-    /// string is invalid (compile-time invariant, not a runtime condition).
-    pub async fn initiate(identity: &NodeIdentity, mut conn: Box<dyn Connection>) -> Result<Self> {
-        let mut state = snow::Builder::new(
-            NOISE_PARAMS
-                .parse()
-                .expect("hardcoded noise params are valid"),
-        )
-        .local_private_key(identity.private_key_bytes())
-        .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
-        .build_initiator()
-        .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
+    /// Pass `remote_key = Some(key)` to use Noise_XK when the peer's static public key
+    /// is already known (from the key registry). Pass `None` to use Noise_XX.
+    /// A 1-byte protocol version prefix is sent before the first handshake message so
+    /// the responder builds the matching HandshakeState. See ADR 020.
+    pub async fn initiate(
+        identity: &NodeIdentity,
+        mut conn: Box<dyn Connection>,
+        remote_key: Option<&[u8; 32]>,
+    ) -> Result<Self> {
+        let (prefix, mut state) = match remote_key {
+            Some(key) => {
+                let state = snow::Builder::new(
+                    NOISE_XK_PARAMS
+                        .parse()
+                        .expect("hardcoded noise params are valid"),
+                )
+                .local_private_key(identity.private_key_bytes())
+                .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
+                .remote_public_key(key)
+                .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
+                .build_initiator()
+                .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
+                (PROTO_XK, state)
+            }
+            None => {
+                let state = snow::Builder::new(
+                    NOISE_PARAMS
+                        .parse()
+                        .expect("hardcoded noise params are valid"),
+                )
+                .local_private_key(identity.private_key_bytes())
+                .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
+                .build_initiator()
+                .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
+                (PROTO_XX, state)
+            }
+        };
+
+        conn.send_bytes(&[prefix]).await?;
 
         let mut buf = vec![0u8; NOISE_MSG_MAX];
 
-        // Message 1: -> e
+        // Message 1: -> e (XX) or -> e, es (XK)
         let n = state
             .write_message(&[], &mut buf)
             .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
         conn.send_bytes(&buf[..n]).await?;
 
-        // Message 2: <- e, ee, s, es
+        // Message 2: <- e, ee, s, es (XX) or <- e, ee, se (XK)
         let msg = conn.recv_bytes().await?;
         state
             .read_message(&msg, &mut buf)
             .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
 
-        // Message 3: -> s, se
+        // Message 3: -> s, se (both XX and XK)
         let n = state
             .write_message(&[], &mut buf)
             .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
@@ -57,10 +89,30 @@ impl Session {
         Self::finish(state, conn)
     }
 
-    /// Performs the Noise_XX handshake as the responder over `conn`.
+    /// Performs the Noise handshake as the responder over `conn`.
+    ///
+    /// Reads the 1-byte protocol version prefix sent by the initiator and builds the
+    /// matching HandshakeState (XX or XK). The three-message exchange is identical
+    /// in both patterns. See ADR 020.
     pub async fn respond(identity: &NodeIdentity, mut conn: Box<dyn Connection>) -> Result<Self> {
+        let prefix_msg = conn.recv_bytes().await?;
+        let prefix = prefix_msg
+            .first()
+            .copied()
+            .ok_or_else(|| PathweaveError::Session("missing protocol prefix byte".into()))?;
+
+        let params_str = match prefix {
+            PROTO_XX => NOISE_PARAMS,
+            PROTO_XK => NOISE_XK_PARAMS,
+            other => {
+                return Err(PathweaveError::Session(format!(
+                    "unknown protocol prefix: {other:#04x}"
+                )));
+            }
+        };
+
         let mut state = snow::Builder::new(
-            NOISE_PARAMS
+            params_str
                 .parse()
                 .expect("hardcoded noise params are valid"),
         )
@@ -71,19 +123,19 @@ impl Session {
 
         let mut buf = vec![0u8; NOISE_MSG_MAX];
 
-        // Message 1: -> e
+        // Message 1: -> e (XX) or -> e, es (XK)
         let msg = conn.recv_bytes().await?;
         state
             .read_message(&msg, &mut buf)
             .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
 
-        // Message 2: <- e, ee, s, es
+        // Message 2: <- e, ee, s, es (XX) or <- e, ee, se (XK)
         let n = state
             .write_message(&[], &mut buf)
             .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
         conn.send_bytes(&buf[..n]).await?;
 
-        // Message 3: -> s, se
+        // Message 3: -> s, se (both XX and XK)
         let msg = conn.recv_bytes().await?;
         state
             .read_message(&msg, &mut buf)
@@ -193,7 +245,7 @@ mod tests {
         let id_b = NodeIdentity::generate();
         let (conn_a, conn_b) = conn_pair();
         let (a, b) = tokio::join!(
-            Session::initiate(&id_a, Box::new(conn_a)),
+            Session::initiate(&id_a, Box::new(conn_a), None),
             Session::respond(&id_b, Box::new(conn_b)),
         );
         (a.unwrap(), b.unwrap())
@@ -205,7 +257,7 @@ mod tests {
         let id_b = NodeIdentity::generate();
         let (conn_a, conn_b) = conn_pair();
         let (session_a, session_b) = tokio::join!(
-            Session::initiate(&id_a, Box::new(conn_a)),
+            Session::initiate(&id_a, Box::new(conn_a), None),
             Session::respond(&id_b, Box::new(conn_b)),
         );
         let session_a = session_a.unwrap();
@@ -220,13 +272,48 @@ mod tests {
         let id_b = NodeIdentity::generate();
         let (conn_a, conn_b) = conn_pair();
         let (session_a, session_b) = tokio::join!(
-            Session::initiate(&id_a, Box::new(conn_a)),
+            Session::initiate(&id_a, Box::new(conn_a), None),
             Session::respond(&id_b, Box::new(conn_b)),
         );
         let session_a = session_a.unwrap();
         let session_b = session_b.unwrap();
         assert_eq!(session_a.peer_id(), id_b.peer_id());
         assert_eq!(session_b.peer_id(), id_a.peer_id());
+    }
+
+    #[tokio::test]
+    async fn xk_handshake_succeeds_with_known_key() {
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let known_key: [u8; 32] = id_b.public_key().try_into().unwrap();
+        let (conn_a, conn_b) = conn_pair();
+        let (session_a, session_b) = tokio::join!(
+            Session::initiate(&id_a, Box::new(conn_a), Some(&known_key)),
+            Session::respond(&id_b, Box::new(conn_b)),
+        );
+        let session_a = session_a.unwrap();
+        let session_b = session_b.unwrap();
+        assert_eq!(session_a.peer_id(), id_b.peer_id());
+        assert_eq!(session_b.peer_id(), id_a.peer_id());
+        assert_eq!(&session_a.remote_static_key()[..], id_b.public_key());
+        assert_eq!(&session_b.remote_static_key()[..], id_a.public_key());
+    }
+
+    #[tokio::test]
+    async fn xk_with_wrong_key_returns_session_error() {
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let id_wrong = NodeIdentity::generate();
+        let wrong_key: [u8; 32] = id_wrong.public_key().try_into().unwrap();
+        let (conn_a, conn_b) = conn_pair();
+        let (result_a, result_b) = tokio::join!(
+            Session::initiate(&id_a, Box::new(conn_a), Some(&wrong_key)),
+            Session::respond(&id_b, Box::new(conn_b)),
+        );
+        assert!(
+            result_a.is_err() || result_b.is_err(),
+            "XK handshake with wrong key must fail on at least one side"
+        );
     }
 
     #[tokio::test]
@@ -268,12 +355,14 @@ mod tests {
         };
 
         // Forward all handshake messages unmodified, then tamper the first transport message.
+        // The initiator sends 3 messages before entering transport mode: the 1-byte protocol
+        // prefix, Noise msg1, and Noise msg3. Count <= 3 passes all three through.
         let relay = tokio::spawn(async move {
             let mut count = 0usize;
             while let Some(msg) = intercept_rx.recv().await {
                 count += 1;
-                if count <= 2 {
-                    // Messages 1 and 3 of XX handshake from initiator: pass through.
+                if count <= 3 {
+                    // Protocol prefix, msg1, and msg3 from initiator: pass through.
                     intercept_tx.send(msg).ok();
                 } else {
                     // First transport message: flip the first byte.
@@ -288,7 +377,7 @@ mod tests {
         });
 
         let (session_a, session_b) = tokio::join!(
-            Session::initiate(&id_a, Box::new(conn_a)),
+            Session::initiate(&id_a, Box::new(conn_a), None),
             Session::respond(&id_b, Box::new(conn_b)),
         );
         let mut session_a = session_a.unwrap();

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -570,7 +570,9 @@ mod tests {
         let client = QuicTransport::new(loopback(0));
         let conn = client.connect(&peer).await.unwrap();
         let bundled = Box::new(BundleLayer::new(conn));
-        let mut session = Session::initiate(&client_identity, bundled).await.unwrap();
+        let mut session = Session::initiate(&client_identity, bundled, None)
+            .await
+            .unwrap();
         session.send(b"hello from quic").await.unwrap();
 
         let received = server_task.await.unwrap();

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -386,13 +386,17 @@ After the handshake, the peer's static public key is known. PeerId is derived he
 raw 32-byte Curve25519 key is retained in the session and stored in a key registry on
 `PathweaveNode` (`HashMap<PeerId, [u8; 32]>`). See ADR 020.
 
-Noise_XK is the v0.3.0 upgrade for known peers. Once the key registry has a peer's key,
-subsequent connections use XK instead of XX. XK hides the responder's identity from
-passive observers during the handshake. A 1-byte protocol version prefix before the first
-handshake message signals which pattern is in use so both sides build the correct
-handshake state. The `snow` pattern string changes from
-`Noise_XX_25519_ChaChaPoly_BLAKE2s` to `Noise_XK_25519_ChaChaPoly_BLAKE2s`; nothing
-else in the session layer changes. See ADR 020.
+Noise_XK is used for directed sends to known peers (v0.3.0). When the key registry has
+an entry for the target PeerId, `Session::initiate` builds an XK initiator and passes the
+stored key as `remote_public_key`. XK hides the responder's identity from passive
+observers: the first handshake message is encrypted to the responder's static key, so an
+observer learns the initiator's identity (msg3) but not the responder's. Discovery probes
+(`try_connect`) always use XX because the target identity is not known before dialing.
+
+A 1-byte protocol version prefix is sent before the first Noise message: `0x00` for XX,
+`0x01` for XK. `Session::respond` reads the prefix and builds the matching HandshakeState.
+The three-message exchange is structurally identical in both patterns. On XK failure (stale
+key), the registry entry is evicted and the next retry falls through to XX. See ADR 020.
 
 Crate: `snow` v0.10, RustCrypto backends. The underlying primitives (x25519-dalek,
 chacha20poly1305) are independently verified. The ring backend uses hand-optimized
@@ -576,7 +580,7 @@ Being clear about this matters as much as being clear about what it does.
 - No WiFi Direct, SMS, or USSD transports
 - No MLS group key exchange (Noise_XX is 1:1 only)
 - No multi-hop BLE routing (single-hop only)
-- No Noise_XK upgrade yet (key registry implemented in v0.3.0; XK handshake path follows)
+- No key gossip yet (Noise_XK implemented in v0.3.0; gossip via address exchange type 2 follows)
 - No OS network event integration for health monitoring (polling via if-addrs; rtnetlink,
   NWPathMonitor, and WinRT network events deferred to v0.3.0). See ADR 013.
 - No real-time cost change notifications via OS events (health_monitor restart provides


### PR DESCRIPTION
## What changed

`Session::initiate` gains an `Option<&[u8; 32]>` parameter. When the key registry has an entry for the target peer, `try_send` passes the stored Curve25519 key and the initiator builds a `Noise_XK` HandshakeState instead of `Noise_XX`. A 1-byte protocol version prefix is sent before the first Noise message (`0x00` = XX, `0x01` = XK). `Session::respond` reads the prefix and builds the matching state. The three-message exchange is structurally identical in both patterns. `PathweaveNode::lookup_key` exposes the registry for external callers. ARCHITECTURE.md updated to reflect the implementation. See ADR 020.

## Why

Noise_XX transmits both peers' static public keys during the handshake. A passive observer capturing the three messages can identify both parties. For peers already in the key registry, Noise_XK hides the responder's identity: the initiator encrypts message 1 to the responder's static key before any exchange, so an observer learns the initiator's identity (message 3) but never the responder's.

Closes #80.

## Alternatives considered

**Apply XK to discovery probes (`try_connect`) as well.** Rejected. `try_connect` is called when a new address is discovered; the remote peer's identity is unknown before the handshake completes. There is no registry entry to look up. XX is the only option for first contact with an unknown peer. This is why Pathweave used XX in the first place (ADR 001).

**Dedicated fallback path instead of registry eviction.** On stale key, the alternative is detecting the XK failure inside `Session::initiate` and immediately retrying with XX on the same connection. Rejected: the connection is in an indeterminate state after a failed handshake. Evicting the registry entry and relying on the existing `MAX_SEND_ATTEMPTS` retry loop is simpler and reuses infrastructure already proven correct by the ACK round-trip work in PR #35.

**Separate `initiate_xx` and `initiate_xk` functions instead of `Option`.** Cleaner call sites would result, but every caller would need to branch before calling. The `Option` parameter keeps the branch inside `Session` where it belongs, and the two callers (`try_connect` with `None`, `try_send` with `registry.get(peer_id)`) express intent clearly.

## Security considerations

Noise_XK hides the responder's static public key from a passive observer. The initiator's identity is still transmitted in message 3, which is the same exposure as Noise_XX. This is an intentional property of XK: it protects the party being contacted, not the party initiating contact.

The 1-byte prefix is sent in plaintext before the handshake. An observer learns which pattern was used (`0x00` vs `0x01`), and from `0x01` can infer that the initiator has previously contacted the responder. No key material is exposed by the prefix.

Wrong or stale key detection: if the initiator supplies the wrong key, the AEAD MAC check on message 2 fails and no session is established. The failed handshake reveals nothing about the responder's actual key. After eviction and fallback to XX, the correct key is learned and stored for subsequent connections.

## Test plan

- `xk_handshake_succeeds_with_known_key`: XK path completes end-to-end; both sides derive the correct PeerId and see the correct remote static key.
- `xk_with_wrong_key_returns_session_error`: supplying a different peer's key causes the handshake to fail on at least one side.
- `tampered_ciphertext_returns_error`: updated relay count (2 to 3) keeps tampering at the transport layer as intended; test continues to verify decryption failure on tampered ciphertext.
- All 48 existing tests pass across all workspace crates.
- `cargo clippy -- -D warnings` and `cargo fmt --check` clean.