### PR TITLE
chore: add crate-level lint and safety attributes

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![forbid(unsafe_code)]
+
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::BoxStream;

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -1,3 +1,7 @@
+#![deny(clippy::all)]
+// unsafe is required for macOS CoreBluetooth interop via the objc2 crate.
+// All unsafe blocks are confined to the macos peripheral module below.
+
 use std::sync::Arc;
 
 use async_trait::async_trait;

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -1,3 +1,6 @@
+#![deny(clippy::all)]
+#![forbid(unsafe_code)]
+
 use std::{
     net::{IpAddr, Ipv4Addr, SocketAddr},
     sync::{

--- a/crates/pathweave-uniffi/src/lib.rs
+++ b/crates/pathweave-uniffi/src/lib.rs
@@ -1,2 +1,5 @@
+#![deny(clippy::all)]
+#![forbid(unsafe_code)]
+
 // UDL and bindings generation are added before the Rust API is finalized.
 // See notes/architecture/ARCHITECTURE.md.


### PR DESCRIPTION
## What changed

Added `#![deny(clippy::all)]` and `#![forbid(unsafe_code)]` to `pathweave-core`, `pathweave-transport-quic`, and `pathweave-uniffi`. Added only `#![deny(clippy::all)]` to `pathweave-transport-ble`, with a comment explaining why unsafe is required there.

## Why

CI runs `cargo clippy -- -D warnings`, which denies warnings at the CI gate but does not protect local builds. `clippy::all` also covers a broader lint group than the default set; lints disabled by default are invisible to CI but would fire locally once the attribute is present. No new lints fired when the attributes were added to this codebase.

`forbid(unsafe_code)` makes unsafe a compile error in the three crates that have no reason to use it. For a project seeking a security audit, this matters: the absence of unsafe becomes machine-verified rather than reviewer-dependent. `pathweave-transport-ble` is excluded because its unsafe blocks cover macOS CoreBluetooth delegate callbacks and pointer wrapping via `objc2`; that unsafe is necessary and cannot be eliminated.

Closes #81.

## Alternatives considered

**Add `#![forbid(unsafe_code)]` to `pathweave-transport-ble` and isolate unsafe in a sub-module.** The `objc2` delegate pattern requires `unsafe impl` at the type level (for `NSObjectProtocol` and `CBPeripheralManagerDelegate`), which cannot be hidden inside a sub-module without re-exporting the types. The attribute would have to be removed from the crate root regardless. Not worth the indirection.

**Add `#![warn(clippy::pedantic)]` at the same time.** Pedantic lints cover style preferences rather than correctness concerns. Adding them now would generate noise without raising the correctness bar. Separate issue if the project wants to adopt them later.

## Security considerations

`#![forbid(unsafe_code)]` in `pathweave-core` is the most significant change here. `pathweave-core` contains the Noise handshake, the key registry, and all session-layer logic. A future contributor cannot introduce unsafe code in that crate without explicitly removing the attribute, making the decision visible in the diff and in code review.

## Test plan

- `cargo clippy --workspace` with no flags: zero warnings, zero errors across all crates.
- `cargo clippy -- -D warnings`: continues to pass (CI gate unchanged).
- `cargo test --workspace`: all 48 tests pass.
- `cargo fmt --check`: clean.