### PR TITLE
feat(core): implement post-handshake address exchange

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -256,6 +256,9 @@ pub trait Transport: Send + Sync {
     fn cost(&self) -> TransportCost;
     fn kind(&self) -> TransportKind;
     fn name(&self) -> &'static str;
+    fn local_addresses(&self) -> Vec<PeerAddress> {
+        vec![]
+    }
 }
 
 #[async_trait]
@@ -272,6 +275,15 @@ pub trait Connection: Send + Sync {
 pub(crate) type KeyRegistry = Arc<Mutex<HashMap<PeerId, [u8; 32]>>>;
 
 pub(crate) fn new_key_registry() -> KeyRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+// -- peer table ----------------------------------------------------------
+
+/// Shared peer table: PeerId -> known addresses for routing. See ADR 016 and ADR 017.
+pub(crate) type PeerTable = Arc<Mutex<HashMap<PeerId, Vec<PeerAnnouncement>>>>;
+
+pub(crate) fn new_peer_table() -> PeerTable {
     Arc::new(Mutex::new(HashMap::new()))
 }
 

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -2,14 +2,15 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
+use bytes::Bytes;
 use futures::stream::BoxStream;
 
 use tokio::sync::watch;
 
 use crate::{
-    new_key_registry, BundleLayer, Connection, KeyRegistry, MessageHandler, NodeConfig,
-    NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId, Result, Router, Session,
-    Transport, TransportEvent,
+    new_key_registry, new_peer_table, router, BundleLayer, Connection, KeyRegistry, MessageHandler,
+    NodeConfig, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId, PeerTable,
+    Result, Router, Session, Transport, TransportEvent,
 };
 
 const DEDUP_TTL: Duration = Duration::from_secs(60);
@@ -74,7 +75,7 @@ impl DeduplicationCache {
 pub struct PathweaveNode {
     router: Router,
     identity: NodeIdentity,
-    peers: Arc<Mutex<HashMap<PeerId, Vec<PeerAnnouncement>>>>,
+    peers: PeerTable,
     // Dedup-only: tracks addresses currently in-flight or already connected.
     // Not authoritative for routing — peers is. peer_stream only upserts to
     // peers; it never removes. This invariant is what makes the concurrent
@@ -93,7 +94,7 @@ impl PathweaveNode {
         Ok(Self {
             router: Router::new(),
             identity,
-            peers: Arc::new(Mutex::new(HashMap::new())),
+            peers: new_peer_table(),
             known_addrs: Arc::new(Mutex::new(HashSet::new())),
             handler: Arc::new(Mutex::new(None)),
             dedup: Arc::new(Mutex::new(DeduplicationCache::new())),
@@ -123,6 +124,7 @@ impl PathweaveNode {
             dedup,
             started.clone(),
             Arc::clone(&self.key_registry),
+            Arc::clone(&self.peers),
         ));
 
         tokio::spawn(crate::router::peer_stream(
@@ -151,6 +153,7 @@ impl PathweaveNode {
                 std::slice::from_ref(&announcement),
                 &self.identity,
                 &self.key_registry,
+                &self.peers,
             )
             .await?;
         self.known_addrs
@@ -204,6 +207,7 @@ impl PathweaveNode {
                 payload,
                 &peer_id,
                 &self.key_registry,
+                &self.peers,
             )
             .await
     }
@@ -242,8 +246,10 @@ async fn accept_loop(
     dedup: Arc<Mutex<DeduplicationCache>>,
     mut started: watch::Receiver<bool>,
     key_registry: KeyRegistry,
+    peers: PeerTable,
 ) {
     let _ = started.wait_for(|v| *v).await;
+    let local_addrs = Arc::new(transport.local_addresses());
     loop {
         match transport.accept().await {
             Ok(conn) => {
@@ -251,12 +257,16 @@ async fn accept_loop(
                 let handler = Arc::clone(&handler);
                 let dedup = Arc::clone(&dedup);
                 let key_registry = Arc::clone(&key_registry);
+                let peers = Arc::clone(&peers);
+                let local_addrs = Arc::clone(&local_addrs);
                 tokio::spawn(handle_incoming(
                     conn,
                     identity,
                     handler,
                     dedup,
                     key_registry,
+                    peers,
+                    local_addrs,
                 ));
             }
             Err(e) => {
@@ -267,19 +277,20 @@ async fn accept_loop(
     }
 }
 
-/// Completes the Noise_XX handshake as the responder, then loops receiving
-/// messages and delivering them to the handler until the connection closes.
-///
-/// Each payload begins with an 8-byte big-endian message ID. The ID is checked
-/// against the deduplication cache: if the (peer_id, message_id) pair was seen
-/// recently, on_message() is skipped. The ACK is sent regardless so the sender
-/// does not time out (see ADR 009 and ADR 011).
+/// Completes the Noise_XX handshake as the responder, then receives and dispatches
+/// messages until the connection closes. The first message is inspected before the
+/// receive loop: if its first byte is 0x00, it is an address exchange control frame
+/// (ADR 017); the exchange is handled and the next message is the application frame.
+/// Otherwise the first message is treated directly as the application frame, which
+/// allows communication with older nodes that do not implement address exchange.
 async fn handle_incoming(
     conn: Box<dyn Connection>,
     identity: NodeIdentity,
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
     key_registry: KeyRegistry,
+    peers: PeerTable,
+    local_addrs: Arc<Vec<PeerAddress>>,
 ) {
     let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(conn));
     let mut session = match Session::respond(&identity, bundled).await {
@@ -294,31 +305,58 @@ async fn handle_incoming(
         .lock()
         .unwrap()
         .insert(peer_id.clone(), *session.remote_static_key());
-    while let Ok(payload) = session.recv().await {
-        if payload.len() < 8 {
-            tracing::debug!(peer = %peer_id, "received payload shorter than 8 bytes; skipping");
-            let _ = session.send(b"").await;
-            continue;
-        }
-        let msg_id = u64::from_be_bytes([
-            payload[0], payload[1], payload[2], payload[3], payload[4], payload[5], payload[6],
-            payload[7],
-        ]);
-        let data = payload[8..].to_vec();
 
-        let is_dup = dedup.lock().unwrap().check_and_insert(&peer_id, msg_id);
-        if !is_dup {
-            let guard = handler.lock().unwrap();
-            if let Some(h) = guard.as_ref() {
-                h.on_message(peer_id.clone(), data);
-            }
-        } else {
-            tracing::debug!(peer = %peer_id, "suppressed duplicate message");
+    let first = match session.recv().await {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+
+    let app_payload = if first.len() >= 8 && first[0] == 0x00 {
+        match router::decode_addr_exchange(&first) {
+            Some(addrs) => router::upsert_peer_addresses(&peers, &peer_id, addrs),
+            None => tracing::debug!(peer = %peer_id, "addr-exchange: parse failed; skipping"),
         }
-        // ACK so the sender knows the data was delivered before it tears
-        // down the QUIC connection (see try_send in router.rs and ADR 009).
-        let _ = session.send(b"").await;
+        let _ = session.send(&router::encode_addr_exchange(&local_addrs)).await;
+        match session.recv().await {
+            Ok(p) => p,
+            Err(_) => return,
+        }
+    } else {
+        first
+    };
+
+    dispatch_payload(&peer_id, app_payload, &dedup, &handler, &mut session).await;
+    while let Ok(payload) = session.recv().await {
+        dispatch_payload(&peer_id, payload, &dedup, &handler, &mut session).await;
     }
+}
+
+async fn dispatch_payload(
+    peer_id: &PeerId,
+    payload: Bytes,
+    dedup: &Arc<Mutex<DeduplicationCache>>,
+    handler: &Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
+    session: &mut Session,
+) {
+    if payload.len() < 8 {
+        tracing::debug!(peer = %peer_id, "received payload shorter than 8 bytes; skipping");
+        let _ = session.send(b"").await;
+        return;
+    }
+    let msg_id = u64::from_be_bytes([
+        payload[0], payload[1], payload[2], payload[3], payload[4], payload[5], payload[6],
+        payload[7],
+    ]);
+    let data = payload[8..].to_vec();
+    let is_dup = dedup.lock().unwrap().check_and_insert(peer_id, msg_id);
+    if !is_dup {
+        if let Some(h) = handler.lock().unwrap().as_ref() {
+            h.on_message(peer_id.clone(), data);
+        }
+    } else {
+        tracing::debug!(peer = %peer_id, "suppressed duplicate message");
+    }
+    let _ = session.send(b"").await;
 }
 
 #[cfg(test)]
@@ -507,8 +545,10 @@ mod tests {
     async fn run_responder(conn: TestConn, identity: NodeIdentity) {
         let bundled = Box::new(BundleLayer::new(Box::new(conn)));
         let mut session = Session::respond(&identity, bundled).await.unwrap();
-        let _ = session.recv().await;
-        let _ = session.send(b"").await;
+        let _ = session.recv().await; // addr exchange from initiator
+        let _ = session.send(b"").await; // addr exchange response (empty = no addresses)
+        let _ = session.recv().await; // application frame (absent for try_connect)
+        let _ = session.send(b"").await; // delivery ACK
     }
 
     // -------------------------------------------------------------------------

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -316,7 +316,9 @@ async fn handle_incoming(
             Some(addrs) => router::upsert_peer_addresses(&peers, &peer_id, addrs),
             None => tracing::debug!(peer = %peer_id, "addr-exchange: parse failed; skipping"),
         }
-        let _ = session.send(&router::encode_addr_exchange(&local_addrs)).await;
+        let _ = session
+            .send(&router::encode_addr_exchange(&local_addrs))
+            .await;
         match session.recv().await {
             Ok(p) => p,
             Err(_) => return,

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -10,12 +10,14 @@ use tokio::task::JoinHandle;
 
 use crate::{
     BundleLayer, KeyRegistry, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId,
-    Result, Session, Transport, TransportCost, TransportEvent, TransportKind,
+    PeerTable, Result, Session, Transport, TransportCost, TransportEvent, TransportKind,
 };
 
 const MAX_SEND_ATTEMPTS: usize = 3;
 const RETRY_BACKOFF: Duration = Duration::from_secs(1);
 const NETWORK_POLL_INTERVAL: Duration = Duration::from_secs(3);
+const ADDR_EXCHANGE_CTRL: [u8; 8] = [0, 0, 0, 0, 0, 0, 0, 1];
+const ADDR_EXCHANGE_TIMEOUT: Duration = Duration::from_secs(2);
 
 struct TransportEntry {
     transport: Arc<dyn Transport>,
@@ -98,6 +100,7 @@ impl Router {
         payload: Vec<u8>,
         peer_id: &PeerId,
         key_registry: &KeyRegistry,
+        peer_table: &PeerTable,
     ) -> Result<()> {
         let any_available = self
             .transports
@@ -150,6 +153,7 @@ impl Router {
                     message_id,
                     key_registry,
                     peer_id,
+                    peer_table,
                 )
                 .await
                 {
@@ -189,6 +193,7 @@ impl Router {
         peers: &[PeerAnnouncement],
         identity: &NodeIdentity,
         key_registry: &KeyRegistry,
+        peer_table: &PeerTable,
     ) -> Result<PeerId> {
         let mut candidates: Vec<(&TransportEntry, &PeerAnnouncement)> = self
             .transports
@@ -212,8 +217,14 @@ impl Router {
         });
 
         for (entry, ann) in candidates {
-            if let Ok(peer_id) =
-                try_connect(entry.transport.as_ref(), ann, identity, key_registry).await
+            if let Ok(peer_id) = try_connect(
+                entry.transport.as_ref(),
+                ann,
+                identity,
+                key_registry,
+                peer_table,
+            )
+            .await
             {
                 return Ok(peer_id);
             }
@@ -225,6 +236,14 @@ impl Router {
     /// Returns a clone of the event sender so callers can fire events into the same channel.
     pub(crate) fn event_tx(&self) -> broadcast::Sender<TransportEvent> {
         self.event_tx.clone()
+    }
+
+    /// Returns all addresses currently advertised by registered transports.
+    pub fn local_addresses(&self) -> Vec<PeerAddress> {
+        self.transports
+            .iter()
+            .flat_map(|e| e.transport.local_addresses())
+            .collect()
     }
 
     /// Returns a stream of transport lifecycle events.
@@ -342,13 +361,14 @@ fn current_ipv4_addrs() -> HashSet<Ipv4Addr> {
 
 /// Dials the transport, completes the Noise_XX handshake, and returns the remote PeerId.
 /// Always uses Noise_XX because the target identity is unknown before dialing.
-/// The session is closed explicitly so transports that require an active teardown
-/// (e.g. BLE peripheral.disconnect()) release their resources before the next connect.
+/// Performs an address exchange after the handshake (ADR 017), then closes the session.
+/// The close is explicit so transports that require active teardown release resources.
 async fn try_connect(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
     identity: &NodeIdentity,
     key_registry: &KeyRegistry,
+    peers: &PeerTable,
 ) -> Result<PeerId> {
     let raw = transport.connect(peer).await?;
     let bundled = Box::new(BundleLayer::new(raw));
@@ -358,25 +378,153 @@ async fn try_connect(
         .lock()
         .unwrap()
         .insert(peer_id.clone(), *session.remote_static_key());
+    let local = transport.local_addresses();
+    let _ = session.send(&encode_addr_exchange(&local)).await;
+    match tokio::time::timeout(ADDR_EXCHANGE_TIMEOUT, session.recv()).await {
+        Ok(Ok(bytes)) => match decode_addr_exchange(&bytes) {
+            Some(addrs) => upsert_peer_addresses(peers, &peer_id, addrs),
+            None => tracing::debug!(peer = %peer_id, "addr-exchange: parse failed; skipping"),
+        },
+        Ok(Err(e)) => tracing::debug!(peer = %peer_id, "addr-exchange recv error: {}", e),
+        Err(_) => tracing::debug!(peer = %peer_id, "addr-exchange: timed out"),
+    }
     let _ = session.close().await;
     Ok(peer_id)
 }
 
 /// Generates a cryptographically random 64-bit message ID from OS entropy.
 ///
+/// The high bit of the first byte is forced to 1, placing all application
+/// message IDs in the range 0x80–0xFF for the first byte. Control messages
+/// use first byte 0x00; the two ranges are non-overlapping. See ADR 017.
+///
 /// Panics if the system entropy source is unavailable — the same condition
 /// that would have already caused NodeIdentity::generate() to panic.
 fn new_message_id() -> u64 {
     let mut bytes = [0u8; 8];
     getrandom::getrandom(&mut bytes).expect("system entropy unavailable");
+    bytes[0] |= 0x80;
     u64::from_be_bytes(bytes)
 }
 
+/// Encodes `addrs` into an address exchange control frame (wire format per ADR 017).
+pub(crate) fn encode_addr_exchange(addrs: &[PeerAddress]) -> Vec<u8> {
+    let count = addrs.len().min(255);
+    let mut buf = Vec::new();
+    buf.extend_from_slice(&ADDR_EXCHANGE_CTRL);
+    buf.push(count as u8);
+    for addr in addrs.iter().take(255) {
+        match addr {
+            PeerAddress::Quic(sa) => match sa.ip() {
+                std::net::IpAddr::V4(ip) => {
+                    buf.push(0x00);
+                    buf.extend_from_slice(&ip.octets());
+                    buf.extend_from_slice(&sa.port().to_be_bytes());
+                }
+                std::net::IpAddr::V6(ip) => {
+                    buf.push(0x01);
+                    buf.extend_from_slice(&ip.octets());
+                    buf.extend_from_slice(&sa.port().to_be_bytes());
+                }
+            },
+            PeerAddress::Ble(id) => {
+                let bytes = id.as_bytes();
+                let len = bytes.len().min(255) as u8;
+                buf.push(0x02);
+                buf.push(len);
+                buf.extend_from_slice(&bytes[..len as usize]);
+            }
+        }
+    }
+    buf
+}
+
+/// Decodes an address exchange control frame. Returns None on any parse failure.
+/// Unknown control types (bytes[0..8] != ADDR_EXCHANGE_CTRL) also return None.
+pub(crate) fn decode_addr_exchange(bytes: &[u8]) -> Option<Vec<PeerAddress>> {
+    if bytes.len() < 9 || bytes[0..8] != ADDR_EXCHANGE_CTRL {
+        return None;
+    }
+    let count = bytes[8] as usize;
+    let mut pos = 9;
+    let mut addrs = Vec::with_capacity(count);
+    for _ in 0..count {
+        if pos >= bytes.len() {
+            return None;
+        }
+        match bytes[pos] {
+            0x00 => {
+                pos += 1;
+                if pos + 6 > bytes.len() {
+                    return None;
+                }
+                let ip = std::net::Ipv4Addr::new(
+                    bytes[pos],
+                    bytes[pos + 1],
+                    bytes[pos + 2],
+                    bytes[pos + 3],
+                );
+                let port = u16::from_be_bytes([bytes[pos + 4], bytes[pos + 5]]);
+                pos += 6;
+                addrs.push(PeerAddress::Quic(std::net::SocketAddr::V4(
+                    std::net::SocketAddrV4::new(ip, port),
+                )));
+            }
+            0x01 => {
+                pos += 1;
+                if pos + 18 > bytes.len() {
+                    return None;
+                }
+                let mut ip_bytes = [0u8; 16];
+                ip_bytes.copy_from_slice(&bytes[pos..pos + 16]);
+                let ip = std::net::Ipv6Addr::from(ip_bytes);
+                let port = u16::from_be_bytes([bytes[pos + 16], bytes[pos + 17]]);
+                pos += 18;
+                addrs.push(PeerAddress::Quic(std::net::SocketAddr::V6(
+                    std::net::SocketAddrV6::new(ip, port, 0, 0),
+                )));
+            }
+            0x02 => {
+                pos += 1;
+                if pos >= bytes.len() {
+                    return None;
+                }
+                let len = bytes[pos] as usize;
+                pos += 1;
+                if pos + len > bytes.len() {
+                    return None;
+                }
+                let id = std::str::from_utf8(&bytes[pos..pos + len]).ok()?.to_string();
+                pos += len;
+                addrs.push(PeerAddress::Ble(id));
+            }
+            _ => return None,
+        }
+    }
+    Some(addrs)
+}
+
+/// Upserts `addrs` into the peer table entry for `peer_id`, deduplicating by address.
+pub(crate) fn upsert_peer_addresses(peers: &PeerTable, peer_id: &PeerId, addrs: Vec<PeerAddress>) {
+    let mut guard = peers.lock().unwrap();
+    let entry = guard.entry(peer_id.clone()).or_default();
+    for addr in addrs {
+        let ann = PeerAnnouncement {
+            address: addr,
+            short_id: None,
+        };
+        if !entry.iter().any(|a| a.address == ann.address) {
+            entry.push(ann);
+        }
+    }
+}
+
 /// Opens a connection through the given transport, wraps it in BundleLayer and
-/// Session, prepends the 8-byte message ID for receiver-side deduplication,
-/// sends the framed payload, waits for the receiver's delivery ACK, then closes.
-/// Uses Noise_XK when the key registry has an entry for peer_id; falls back to
-/// Noise_XX on XK failure and evicts the stale entry so the next retry uses XX.
+/// Session, performs an address exchange (ADR 017), prepends the 8-byte message
+/// ID for receiver-side deduplication, sends the framed payload, and waits for
+/// the receiver's delivery ACK. Uses Noise_XK when the key registry has an entry
+/// for peer_id; falls back to Noise_XX on XK failure and evicts the stale entry.
+#[allow(clippy::too_many_arguments)]
 async fn try_send(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
@@ -385,6 +533,7 @@ async fn try_send(
     message_id: u64,
     key_registry: &KeyRegistry,
     peer_id: &PeerId,
+    peers: &PeerTable,
 ) -> Result<()> {
     let remote_key = key_registry.lock().unwrap().get(peer_id).copied();
     let raw = transport.connect(peer).await.map_err(|e| {
@@ -407,6 +556,17 @@ async fn try_send(
         .lock()
         .unwrap()
         .insert(session.peer_id().clone(), *session.remote_static_key());
+
+    let local = transport.local_addresses();
+    let _ = session.send(&encode_addr_exchange(&local)).await;
+    match tokio::time::timeout(ADDR_EXCHANGE_TIMEOUT, session.recv()).await {
+        Ok(Ok(bytes)) => match decode_addr_exchange(&bytes) {
+            Some(addrs) => upsert_peer_addresses(peers, peer_id, addrs),
+            None => tracing::debug!(peer = %peer_id, "addr-exchange: parse failed; skipping"),
+        },
+        Ok(Err(e)) => tracing::debug!(peer = %peer_id, "addr-exchange recv error: {}", e),
+        Err(_) => tracing::debug!(peer = %peer_id, "addr-exchange: timed out"),
+    }
 
     let mut framed = Vec::with_capacity(8 + payload.len());
     framed.extend_from_slice(&message_id.to_be_bytes());
@@ -464,7 +624,9 @@ pub(crate) async fn peer_stream(
                 continue;
             }
 
-            match try_connect(transport.as_ref(), &announcement, &identity, &key_registry).await {
+            match try_connect(transport.as_ref(), &announcement, &identity, &key_registry, &peers)
+                .await
+            {
                 Ok(peer_id) if peer_id == local_peer_id => {
                     // Self-discovery: keep addr in known_addrs so we don't retry.
                     tracing::debug!(addr = %addr, "discovered self; skipping");
@@ -495,7 +657,10 @@ pub(crate) async fn peer_stream(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{new_key_registry, Connection, NodeIdentity, PeerAddress, Session, TransportKind};
+    use crate::{
+        new_key_registry, new_peer_table, Connection, NodeIdentity, PeerAddress, Session,
+        TransportKind,
+    };
     use async_trait::async_trait;
     use bytes::Bytes;
     use std::sync::atomic::AtomicUsize;
@@ -684,13 +849,17 @@ mod tests {
         ]
     }
 
-    /// Runs a responder: completes the Noise_XX handshake, receives one message, and
-    /// sends an empty ACK so try_send() can return before dropping the connection.
+    /// Runs a responder: completes the Noise_XX handshake, handles the address exchange
+    /// round-trip (ADR 017), receives the application frame, and sends the delivery ACK.
+    /// Extra recv/send calls return errors silently when the initiator used try_connect
+    /// (which closes after the exchange without sending an application frame).
     async fn run_responder(conn: TestConn, identity: NodeIdentity) {
         let bundled = Box::new(BundleLayer::new(Box::new(conn)));
         let mut session = Session::respond(&identity, bundled).await.unwrap();
-        let _ = session.recv().await;
-        let _ = session.send(b"").await;
+        let _ = session.recv().await; // addr exchange from initiator
+        let _ = session.send(b"").await; // addr exchange response (empty = no addresses)
+        let _ = session.recv().await; // application frame (absent for try_connect)
+        let _ = session.send(b"").await; // delivery ACK
     }
 
     #[tokio::test]
@@ -724,6 +893,7 @@ mod tests {
                 b"hello".to_vec(),
                 sender_id.peer_id(),
                 &new_key_registry(),
+                &new_peer_table(),
             )
             .await
             .unwrap();
@@ -767,6 +937,7 @@ mod tests {
                 b"hello".to_vec(),
                 sender_id.peer_id(),
                 &new_key_registry(),
+                &new_peer_table(),
             )
             .await
             .unwrap();
@@ -811,6 +982,7 @@ mod tests {
                 b"fallback".to_vec(),
                 sender_id.peer_id(),
                 &new_key_registry(),
+                &new_peer_table(),
             )
             .await
             .unwrap();
@@ -852,6 +1024,7 @@ mod tests {
                 b"ignored".to_vec(),
                 sender_id.peer_id(),
                 &new_key_registry(),
+                &new_peer_table(),
             )
             .await;
 
@@ -882,6 +1055,7 @@ mod tests {
                 b"ignored".to_vec(),
                 sender_id.peer_id(),
                 &new_key_registry(),
+                &new_peer_table(),
             )
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
@@ -915,6 +1089,7 @@ mod tests {
                 b"hello".to_vec(),
                 sender_id.peer_id(),
                 &new_key_registry(),
+                &new_peer_table(),
             )
             .await
             .unwrap();
@@ -943,6 +1118,7 @@ mod tests {
                 b"ignored".to_vec(),
                 sender_id.peer_id(),
                 &new_key_registry(),
+                &new_peer_table(),
             )
             .await;
 
@@ -978,7 +1154,7 @@ mod tests {
         });
 
         let peer_id = router
-            .connect(&[dummy_peer()], &initiator_id, &new_key_registry())
+            .connect(&[dummy_peer()], &initiator_id, &new_key_registry(), &new_peer_table())
             .await
             .unwrap();
         assert_eq!(peer_id, expected_peer_id);
@@ -989,7 +1165,7 @@ mod tests {
         let router = Router::new();
         let identity = NodeIdentity::generate();
         let result = router
-            .connect(&[dummy_peer()], &identity, &new_key_registry())
+            .connect(&[dummy_peer()], &identity, &new_key_registry(), &new_peer_table())
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -494,7 +494,9 @@ pub(crate) fn decode_addr_exchange(bytes: &[u8]) -> Option<Vec<PeerAddress>> {
                 if pos + len > bytes.len() {
                     return None;
                 }
-                let id = std::str::from_utf8(&bytes[pos..pos + len]).ok()?.to_string();
+                let id = std::str::from_utf8(&bytes[pos..pos + len])
+                    .ok()?
+                    .to_string();
                 pos += len;
                 addrs.push(PeerAddress::Ble(id));
             }
@@ -624,8 +626,14 @@ pub(crate) async fn peer_stream(
                 continue;
             }
 
-            match try_connect(transport.as_ref(), &announcement, &identity, &key_registry, &peers)
-                .await
+            match try_connect(
+                transport.as_ref(),
+                &announcement,
+                &identity,
+                &key_registry,
+                &peers,
+            )
+            .await
             {
                 Ok(peer_id) if peer_id == local_peer_id => {
                     // Self-discovery: keep addr in known_addrs so we don't retry.
@@ -1154,7 +1162,12 @@ mod tests {
         });
 
         let peer_id = router
-            .connect(&[dummy_peer()], &initiator_id, &new_key_registry(), &new_peer_table())
+            .connect(
+                &[dummy_peer()],
+                &initiator_id,
+                &new_key_registry(),
+                &new_peer_table(),
+            )
             .await
             .unwrap();
         assert_eq!(peer_id, expected_peer_id);
@@ -1165,7 +1178,12 @@ mod tests {
         let router = Router::new();
         let identity = NodeIdentity::generate();
         let result = router
-            .connect(&[dummy_peer()], &identity, &new_key_registry(), &new_peer_table())
+            .connect(
+                &[dummy_peer()],
+                &identity,
+                &new_key_registry(),
+                &new_peer_table(),
+            )
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
     }

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -54,6 +54,9 @@ pub struct QuicTransport {
     instance_name: String,
     // Detected at start() time; read lock-free by cost(). Encoding: 0=Free, 1=Metered, 2=Unknown.
     cost: AtomicU8,
+    // Set to Some(addr) in start(), cleared to None in stop(). Accessed by the sync
+    // local_addresses() method, so a std::sync::Mutex is used instead of tokio's.
+    started_addr: std::sync::Mutex<Option<SocketAddr>>,
 }
 
 impl QuicTransport {
@@ -67,6 +70,7 @@ impl QuicTransport {
             mdns: std::sync::Mutex::new(None),
             instance_name,
             cost: AtomicU8::new(2), // Unknown until start() detects the interface type
+            started_addr: std::sync::Mutex::new(None),
         }
     }
 
@@ -301,6 +305,7 @@ impl Transport for QuicTransport {
             Endpoint::server(server_config, self.listen_addr).map_err(PathweaveError::Io)?;
         let local_addr = endpoint.local_addr().map_err(PathweaveError::Io)?;
         *self.endpoint.lock().await = Some(endpoint);
+        *self.started_addr.lock().unwrap() = Some(local_addr);
 
         let daemon = ServiceDaemon::new().map_err(|e| PathweaveError::Transport(e.to_string()))?;
 
@@ -371,6 +376,7 @@ impl Transport for QuicTransport {
     }
 
     async fn stop(&self) -> Result<()> {
+        *self.started_addr.lock().unwrap() = None;
         if let Some(ep) = self.endpoint.lock().await.take() {
             ep.close(0u32.into(), b"shutdown");
         }
@@ -468,6 +474,14 @@ impl Transport for QuicTransport {
 
     fn name(&self) -> &'static str {
         "quic"
+    }
+
+    fn local_addresses(&self) -> Vec<PeerAddress> {
+        self.started_addr
+            .lock()
+            .unwrap()
+            .map(|addr| vec![PeerAddress::Quic(addr)])
+            .unwrap_or_default()
     }
 }
 

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -314,30 +314,41 @@ The accept loop:
 
 ```
 wait for health_monitor to signal start() success   // prevents startup race
+local_addrs = transport.local_addresses()           // snapshot own addresses for exchange
 loop {
     conn = transport.accept().await
     if error: log, sleep 5 s, retry    // handles transports that don't support inbound
-    spawn handle_incoming(conn)
+    spawn handle_incoming(conn, peers, local_addrs)
 }
 ```
 
 `handle_incoming` runs per-connection:
 
 ```
-BundleLayer::new(conn)               // wraps in bundle framing
-Session::respond(identity, bundled)  // Noise_XX handshake as responder
-peer_id = session.peer_id()          // identity revealed after handshake
-loop:
-    payload = session.recv()         // payload = [message_id: u64 big-endian] ++ [app bytes]
+BundleLayer::new(conn)                   // wraps in bundle framing
+Session::respond(identity, bundled)      // Noise_XX handshake as responder
+peer_id = session.peer_id()             // identity revealed after handshake
+
+first = session.recv()                  // inspect before looping
+if first[0] == 0x00:                    // address exchange control frame (ADR 017)
+    addrs = decode_addr_exchange(first) // parse peer's addresses
+    upsert_peer_addresses(peers, peer_id, addrs)
+    session.send(encode_addr_exchange(local_addrs))  // send own addresses
+    app_payload = session.recv()        // now read the application frame
+else:
+    app_payload = first                 // old peer: first message is the app frame
+
+// process app_payload, then loop for subsequent messages:
+loop on app_payload, then session.recv():
     if payload.len() < 8:
-        session.send(b"")            // ACK malformed frame so sender doesn't hang
+        session.send(b"")              // ACK malformed frame so sender doesn't hang
         continue
-    message_id = payload[0..8]       // extract 8-byte ID prepended by the sender
+    message_id = payload[0..8]         // extract 8-byte ID prepended by the sender
     if dedup_cache.check_and_insert(peer_id, message_id):
-        session.send(b"")            // ACK even on duplicate -- stops the sender retrying
+        session.send(b"")              // ACK even on duplicate -- stops the sender retrying
         continue
     handler.on_message(peer_id, payload[8..])   // deliver app bytes (ID stripped)
-    session.send(b"")                // empty ACK to the sender (see note below)
+    session.send(b"")                   // empty ACK to the sender (see note below)
 ```
 
 **Why the ACK is required:** Quinn's `write_all()` writes to an internal send buffer; actual transmission is async. If the sender drops the session immediately after `send()`, Quinn fires `CONNECTION_CLOSE` before flushing the buffer and the data is silently lost. The receiver's empty ACK keeps the sender's connection alive long enough for the data to be transmitted. `send()` returning `Ok(())` is only meaningful when this round-trip completes. See ADR 009 and issue #34.
@@ -349,6 +360,22 @@ call to `on_message()` but still sends the ACK so the sender stops retrying. Cac
 entries are keyed on `(PeerId, message_id)` and expire after `DEDUP_TTL` (60 seconds).
 Given `MAX_SEND_ATTEMPTS = 3` and `RETRY_BACKOFF = 1s`, the entire retry window is well
 under 60 seconds, so a duplicate will always hit a live cache entry. See ADR 011.
+
+**Why message IDs have the high bit set:** `new_message_id()` sets `bytes[0] |= 0x80`,
+placing all application message IDs in the range 0x80–0xFF for the first byte. This
+reserves the 0x00–0x7F range for control messages. The control space is used for address
+exchange (type `[0,0,0,0,0,0,0,1]`). The deduplication cache operates on the full 8-byte
+ID and is unaffected; the application ID space is 2^63 values, sufficient for dedup
+purposes. See ADR 017.
+
+**Address exchange:** After every Noise handshake, both sides share their currently
+advertised addresses before any application payload flows. The initiator sends an address
+exchange frame (control ID type 1, followed by the count and per-address bytes), then
+waits up to 2 seconds for the responder's reply. `handle_incoming` detects the control
+frame by checking `first[0] == 0x00` and routes accordingly. A node running an older
+version sends an application frame first, which has `first[0] >= 0x80` (guaranteed by the
+high-bit mask above); `handle_incoming` treats it as an application frame directly. This
+is the backwards-compatibility branch. See ADR 017.
 
 The handler is stored as `Arc<Mutex<Option<Box<dyn MessageHandler>>>>`. The Arc is
 cloned into each accept loop task so a single handler registration covers all
@@ -580,7 +607,7 @@ Being clear about this matters as much as being clear about what it does.
 - No WiFi Direct, SMS, or USSD transports
 - No MLS group key exchange (Noise_XX is 1:1 only)
 - No multi-hop BLE routing (single-hop only)
-- No key gossip yet (Noise_XK implemented in v0.3.0; gossip via address exchange type 2 follows)
+- No key gossip yet (address exchange type 1 implemented in v0.3.0; key gossip via type 2 follows)
 - No OS network event integration for health monitoring (polling via if-addrs; rtnetlink,
   NWPathMonitor, and WinRT network events deferred to v0.3.0). See ADR 013.
 - No real-time cost change notifications via OS events (health_monitor restart provides


### PR DESCRIPTION
## What changed

After every Noise handshake, both sides exchange their currently advertised addresses before any application payload flows. The initiator sends a control frame, the responder replies with its own, and both upsert the received addresses into the peer table. This gives `send()` a complete candidate set for cost-ordered fallback when transport discovery paths complete at different speeds. The core design decision is the high-bit mask on `new_message_id()` (`bytes[0] |= 0x80`), which places all application message IDs in the `0x80`–`0xFF` first-byte range and reserves `0x00`–`0x7F` for control messages. `handle_incoming` uses `first[0] == 0x00` to detect the exchange and `first[0] >= 0x80` to fall through to the backwards-compatible app-frame path, making the change safe to roll out without coordinating upgrades. Wire format and protocol flow are specified in ADR 017.

## Why

The peer table holds `Vec<PeerAnnouncement>` per peer. Before this change, the Vec was populated only by transport-specific discovery: mDNS for QUIC, BLE scan for BLE. These paths run at different speeds. If a transport failure happened before the slower path completed, the Vec was incomplete and delivery failed even though the peer was reachable on the other transport. A node in manual `--peer` mode only ever had the one manually supplied address. ADR 017 identifies this as the root cause of the routing gap that ADR 016's multi-address Vec was designed to fix.

Closes #84.

## Alternatives considered

**Separate framing byte on every application frame instead of the high-bit mask:** adding an explicit type byte before the message ID would give a cleaner protocol boundary. It was ruled out because it changes the wire format for all existing messages and breaks any deployed nodes mid-upgrade. The mask is backwards-compatible at zero wire cost: old senders never produce `first_byte < 0x80`, so old receivers never misidentify a new control frame, and `handle_incoming` detects old peers by the same construction invariant without any version negotiation.

**Lazy `local_addresses()` snapshot per spawn instead of once after `wait_for`:** computing `transport.local_addresses()` inside each `handle_incoming` spawn would give fresher addresses if the transport restarts between connections. The current approach snapshots once in `accept_loop` after the `wait_for(started)` gate and shares it via `Arc`. For v0.3.0, transports do not change their address between start and stop, so the snapshot is always accurate. Revisit if hot-restart behaviour is added.

## Security considerations

The address exchange frame is sent over an established Noise session, so it benefits from Noise's AEAD authentication. A tampered or replayed exchange frame fails MAC verification before it reaches the parser; `decode_addr_exchange` is never called on unauthenticated bytes. A malicious peer can advertise any address in its exchange frame, but those addresses only enter the peer table as candidates. Routing to them still requires a successful Noise handshake from that address, which requires the private key corresponding to the peer's PeerId. A man-in-the-middle cannot inject addresses to redirect traffic without also holding the target's private key. The backwards-compatibility branch in `handle_incoming` is keyed on `first[0] >= 0x80`, which is guaranteed by the mask in `new_message_id()` for all legitimate senders; there is no path by which a control frame from the local node is mistaken for an application frame.

## Test plan

- All 48 existing tests pass with `cargo test --workspace`. `run_responder` helpers updated to handle the address exchange round-trip; no test logic changed.
- `incoming_message_delivered_to_handler` and `duplicate_message_delivered_only_once` use message IDs with `first_byte >= 0x80` and exercise the backwards-compatibility branch in `handle_incoming`.
- `connect_learns_and_stores_peer_id`, `connect_stores_peer_key_in_registry`, and `send_to_known_peer_routes_through_transport` exercise the updated `try_connect` and `try_send` paths end-to-end through `run_responder`.
- `cargo clippy --workspace -- -D warnings` clean.
- [ ] Verify address exchange populates the peer table in a two-node local integration test (manual, post-merge)