### PR TITLE
feat(core): introduce Transport::departures() to fire PeerDisconnected

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use bytes::Bytes;
-use futures::stream::BoxStream;
+use futures::stream::{self, BoxStream};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
@@ -258,6 +258,15 @@ pub trait Transport: Send + Sync {
     fn name(&self) -> &'static str;
     fn local_addresses(&self) -> Vec<PeerAddress> {
         vec![]
+    }
+
+    /// Returns a stream of addresses that have departed the discovery layer.
+    ///
+    /// Fires when a previously resolved peer stops advertising (e.g. mDNS record
+    /// expires). The default returns an empty stream for transports that have no
+    /// departure signal.
+    fn departures(&self) -> BoxStream<'static, PeerAddress> {
+        Box::pin(stream::empty())
     }
 }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -591,19 +591,25 @@ async fn try_send(
     }
 }
 
+enum PeerEvent {
+    Arrival(PeerAnnouncement),
+    Departure(PeerAddress),
+}
+
 /// Drives peer discovery for a single transport across restarts.
 ///
-/// Waits for the transport to start, then drains its discover() stream. For
-/// each announced address that is not already in `known_addrs`, performs a
-/// Noise_XX handshake to learn the remote PeerId. On success, upserts the
-/// PeerId -> PeerAnnouncement mapping into the shared peer table. On failure,
-/// removes the address from `known_addrs` so the next re-announcement retries.
-/// Skips self-announcements by comparing the remote PeerId with `local_peer_id`.
+/// Waits for the transport to start, then drains discover() and departures()
+/// concurrently via stream::select. For each announced address not already in
+/// `known_addrs`, performs a Noise_XX handshake to learn the remote PeerId;
+/// on success upserts the mapping and fires PeerConnected. On handshake failure,
+/// removes from `known_addrs` so the next re-announcement retries. Skips
+/// self-announcements. For each departed address, finds the owning PeerId in the
+/// peer table, removes from `known_addrs` so re-discovery works if the peer
+/// returns, and fires PeerDisconnected.
 ///
-/// When the discover stream ends (transport stopped by health_monitor), loops
-/// back and waits for the next started -> stopped -> started cycle. The
-/// wait_for(false) step prevents a spin loop on transports whose discover()
-/// returns an empty stream immediately.
+/// The combined stream ends when both discover() and departures() are exhausted
+/// (transport stopped by health_monitor). The wait_for(false) step prevents a
+/// spin loop on transports whose streams return immediately.
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn peer_stream(
     transport: Arc<dyn Transport>,
@@ -617,47 +623,67 @@ pub(crate) async fn peer_stream(
 ) {
     loop {
         let _ = started.wait_for(|v| *v).await;
-        let mut discover = transport.discover();
-        while let Some(announcement) = discover.next().await {
-            let addr = announcement.address.clone();
+        let arrivals = transport.discover().map(PeerEvent::Arrival);
+        let departures = transport.departures().map(PeerEvent::Departure);
+        let mut combined = stream::select(arrivals, departures);
+        while let Some(event) = combined.next().await {
+            match event {
+                PeerEvent::Arrival(announcement) => {
+                    let addr = announcement.address.clone();
 
-            // Skip re-announcements from already-connected addresses (O(1) check).
-            if !known_addrs.lock().unwrap().insert(addr.clone()) {
-                continue;
-            }
+                    // Skip re-announcements from already-connected addresses (O(1) check).
+                    if !known_addrs.lock().unwrap().insert(addr.clone()) {
+                        continue;
+                    }
 
-            match try_connect(
-                transport.as_ref(),
-                &announcement,
-                &identity,
-                &key_registry,
-                &peers,
-            )
-            .await
-            {
-                Ok(peer_id) if peer_id == local_peer_id => {
-                    // Self-discovery: keep addr in known_addrs so we don't retry.
-                    tracing::debug!(addr = %addr, "discovered self; skipping");
+                    match try_connect(
+                        transport.as_ref(),
+                        &announcement,
+                        &identity,
+                        &key_registry,
+                        &peers,
+                    )
+                    .await
+                    {
+                        Ok(peer_id) if peer_id == local_peer_id => {
+                            // Self-discovery: keep addr in known_addrs so we don't retry.
+                            tracing::debug!(addr = %addr, "discovered self; skipping");
+                        }
+                        Ok(peer_id) => {
+                            tracing::debug!(addr = %addr, peer = %peer_id, "peer connected");
+                            peers
+                                .lock()
+                                .unwrap()
+                                .entry(peer_id.clone())
+                                .or_default()
+                                .push(announcement);
+                            let _ = event_tx.send(TransportEvent::PeerConnected(peer_id));
+                        }
+                        Err(e) => {
+                            tracing::debug!(addr = %addr, "handshake failed: {}", e);
+                            // Remove so we retry on the next re-announcement.
+                            known_addrs.lock().unwrap().remove(&addr);
+                        }
+                    }
                 }
-                Ok(peer_id) => {
-                    tracing::debug!(addr = %addr, peer = %peer_id, "peer connected");
-                    peers
-                        .lock()
-                        .unwrap()
-                        .entry(peer_id.clone())
-                        .or_default()
-                        .push(announcement);
-                    let _ = event_tx.send(TransportEvent::PeerConnected(peer_id));
-                }
-                Err(e) => {
-                    tracing::debug!(addr = %addr, "handshake failed: {}", e);
-                    // Remove so we retry on the next re-announcement.
-                    known_addrs.lock().unwrap().remove(&addr);
+                PeerEvent::Departure(addr) => {
+                    let peer_id = peers.lock().unwrap().iter().find_map(|(pid, anns)| {
+                        if anns.iter().any(|a| a.address == addr) {
+                            Some(pid.clone())
+                        } else {
+                            None
+                        }
+                    });
+                    if let Some(peer_id) = peer_id {
+                        known_addrs.lock().unwrap().remove(&addr);
+                        tracing::debug!(addr = %addr, peer = %peer_id, "peer departed");
+                        let _ = event_tx.send(TransportEvent::PeerDisconnected(peer_id));
+                    }
                 }
             }
         }
-        // Stream ended (transport stopped). Wait for the stopped signal before
-        // looping so we don't spin if discover() returns an empty stream.
+        // Combined stream ended (both discover and departures exhausted). Wait
+        // for the stopped signal before looping to avoid spinning.
         let _ = started.wait_for(|v| !v).await;
     }
 }
@@ -1447,6 +1473,119 @@ mod tests {
             discover_calls.load(Ordering::Relaxed),
             2,
             "discover() must be called again after a restart cycle"
+        );
+    }
+
+    // --- peer_stream departure test -------------------------------------------
+
+    struct DepartureOnlyTransport {
+        departure_rx: std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<PeerAddress>>>,
+    }
+
+    #[async_trait]
+    impl Transport for DepartureOnlyTransport {
+        async fn start(&self, _: &NodeIdentity) -> Result<()> {
+            Ok(())
+        }
+        async fn stop(&self) -> Result<()> {
+            Ok(())
+        }
+        fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
+            Box::pin(stream::empty())
+        }
+        fn departures(&self) -> BoxStream<'static, PeerAddress> {
+            let rx = self.departure_rx.lock().unwrap().take();
+            match rx {
+                Some(rx) => Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+                    rx.recv().await.map(|a| (a, rx))
+                })),
+                None => Box::pin(stream::empty()),
+            }
+        }
+        async fn connect(&self, _: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
+            Err(PathweaveError::Transport("not used".into()))
+        }
+        async fn accept(&self) -> Result<Box<dyn Connection>> {
+            futures::future::pending::<()>().await;
+            unreachable!()
+        }
+        fn mtu_hint(&self) -> usize {
+            65535
+        }
+        fn cost(&self) -> TransportCost {
+            TransportCost::Free
+        }
+        fn kind(&self) -> TransportKind {
+            TransportKind::Quic
+        }
+        fn name(&self) -> &'static str {
+            "departure-only"
+        }
+    }
+
+    #[tokio::test]
+    async fn peer_stream_fires_disconnected_on_departure() {
+        // Verify that a departure from the discovery layer fires PeerDisconnected.
+        // The peer table is pre-populated (simulating a prior successful handshake).
+        // No arrival stream is needed; departure-only mock drives the test.
+        let (dep_tx, dep_rx) = tokio::sync::mpsc::unbounded_channel();
+        let transport = Arc::new(DepartureOnlyTransport {
+            departure_rx: std::sync::Mutex::new(Some(dep_rx)),
+        });
+
+        let (started_tx, started_rx) = watch::channel(false);
+        let peers: Arc<Mutex<HashMap<PeerId, Vec<PeerAnnouncement>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let known_addrs = Arc::new(Mutex::new(HashSet::new()));
+        let local_peer_id = NodeIdentity::generate().peer_id().clone();
+        let (event_tx, mut event_rx) = broadcast::channel(8);
+
+        // Pre-populate the peer table as if try_connect had already succeeded.
+        let remote_peer_id = PeerId::from_bytes([7u8; 32]);
+        let departing_addr = PeerAddress::Quic("127.0.0.1:9099".parse().unwrap());
+        peers.lock().unwrap().insert(
+            remote_peer_id.clone(),
+            vec![PeerAnnouncement {
+                address: departing_addr.clone(),
+                short_id: None,
+            }],
+        );
+        known_addrs.lock().unwrap().insert(departing_addr.clone());
+
+        tokio::spawn(peer_stream(
+            transport,
+            NodeIdentity::generate(),
+            started_rx,
+            Arc::clone(&peers),
+            Arc::clone(&known_addrs),
+            local_peer_id,
+            event_tx,
+            new_key_registry(),
+        ));
+
+        // Start the transport so peer_stream enters the combined stream loop.
+        let _ = started_tx.send(true);
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        // Inject the departure event.
+        dep_tx.send(departing_addr.clone()).unwrap();
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        match tokio::time::timeout(std::time::Duration::from_secs(1), event_rx.recv()).await {
+            Ok(Ok(TransportEvent::PeerDisconnected(pid))) => {
+                assert_eq!(pid, remote_peer_id);
+            }
+            Ok(Ok(other)) => panic!("expected PeerDisconnected, got: {other:?}"),
+            Ok(Err(e)) => panic!("event channel error: {e}"),
+            Err(_) => panic!("timed out waiting for PeerDisconnected"),
+        }
+
+        // The departed address must be removed from known_addrs so re-discovery works.
+        assert!(
+            !known_addrs.lock().unwrap().contains(&departing_addr),
+            "departed address must be removed from known_addrs"
         );
     }
 }

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -40,6 +40,8 @@ struct MdnsState {
     service_fullname: String,
     // Taken by discover() on first call; None afterwards.
     announce_rx: Option<tokio::sync::mpsc::UnboundedReceiver<PeerAnnouncement>>,
+    // Taken by departures() on first call; None afterwards.
+    departure_rx: Option<tokio::sync::mpsc::UnboundedReceiver<PeerAddress>>,
     bridge: tokio::task::JoinHandle<()>,
 }
 
@@ -330,26 +332,47 @@ impl Transport for QuicTransport {
             .browse(SERVICE_TYPE)
             .map_err(|e| PathweaveError::Transport(e.to_string()))?;
 
-        // Bridge: drains flume ServiceEvents into a tokio mpsc channel so that
-        // discover() can return a BoxStream<'static, PeerAnnouncement> without
-        // borrowing from self.
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel::<PeerAnnouncement>();
+        // Bridge: drains flume ServiceEvents into two tokio mpsc channels.
+        // announce_tx carries PeerAnnouncement for discover(); dep_tx carries
+        // PeerAddress for departures(). The bridge tracks fullname -> Vec<SocketAddr>
+        // internally because ServiceRemoved only provides the fullname, not the
+        // address, so we must look up the address from the prior ServiceResolved.
+        let (announce_tx, announce_rx) = tokio::sync::mpsc::unbounded_channel::<PeerAnnouncement>();
+        let (dep_tx, dep_rx) = tokio::sync::mpsc::unbounded_channel::<PeerAddress>();
         let bridge = tokio::spawn(async move {
+            let mut resolved: std::collections::HashMap<String, Vec<SocketAddr>> =
+                std::collections::HashMap::new();
             while let Ok(event) = browse_rx.recv_async().await {
-                if let ServiceEvent::ServiceResolved(info) = event {
-                    let port = info.get_port();
-                    for ip in info.get_addresses_v4() {
-                        let addr = SocketAddr::new(IpAddr::V4(*ip), port);
-                        if tx
-                            .send(PeerAnnouncement {
-                                address: PeerAddress::Quic(addr),
-                                short_id: None,
-                            })
-                            .is_err()
-                        {
-                            return;
+                match event {
+                    ServiceEvent::ServiceResolved(info) => {
+                        let port = info.get_port();
+                        let fullname = info.get_fullname().to_string();
+                        let mut addrs = Vec::new();
+                        for ip in info.get_addresses_v4() {
+                            let addr = SocketAddr::new(IpAddr::V4(*ip), port);
+                            addrs.push(addr);
+                            if announce_tx
+                                .send(PeerAnnouncement {
+                                    address: PeerAddress::Quic(addr),
+                                    short_id: None,
+                                })
+                                .is_err()
+                            {
+                                return;
+                            }
+                        }
+                        resolved.insert(fullname, addrs);
+                    }
+                    ServiceEvent::ServiceRemoved(_, fullname) => {
+                        if let Some(addrs) = resolved.remove(&fullname) {
+                            for addr in addrs {
+                                if dep_tx.send(PeerAddress::Quic(addr)).is_err() {
+                                    return;
+                                }
+                            }
                         }
                     }
+                    _ => {}
                 }
             }
         });
@@ -357,7 +380,8 @@ impl Transport for QuicTransport {
         *self.mdns.lock().unwrap() = Some(MdnsState {
             daemon,
             service_fullname,
-            announce_rx: Some(rx),
+            announce_rx: Some(announce_rx),
+            departure_rx: Some(dep_rx),
             bridge,
         });
 
@@ -482,6 +506,22 @@ impl Transport for QuicTransport {
             .unwrap()
             .map(|addr| vec![PeerAddress::Quic(addr)])
             .unwrap_or_default()
+    }
+
+    fn departures(&self) -> BoxStream<'static, PeerAddress> {
+        let rx = self
+            .mdns
+            .lock()
+            .unwrap()
+            .as_mut()
+            .and_then(|state| state.departure_rx.take());
+
+        match rx {
+            Some(rx) => Box::pin(futures::stream::unfold(rx, |mut rx| async move {
+                rx.recv().await.map(|addr| (addr, rx))
+            })),
+            None => Box::pin(futures::stream::empty()),
+        }
     }
 }
 

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -307,8 +307,18 @@ See the delivery guarantees section.
 `register_transport()` on `PathweaveNode` does three things: registers the transport
 with the Router (which starts its `health_monitor` task), spawns an `accept_loop` task
 that delivers incoming connections to the message handler, and spawns a `peer_stream`
-task that drives `discover()` and populates the peer table for outbound routing. All
-three tasks run for the lifetime of the node.
+task that drives `discover()` and `departures()` to populate the peer table and fire
+lifecycle events. All three tasks run for the lifetime of the node.
+
+`peer_stream` drains arrivals from `Transport::discover()` and departures from
+`Transport::departures()` concurrently using `stream::select`. For each arriving address
+not already in `known_addrs`, it performs a Noise_XX handshake to learn the remote
+PeerId, upserts the mapping, and fires `PeerConnected`. For each departing address, it
+looks up the owning PeerId in the peer table, removes the address from `known_addrs`
+(so re-discovery works if the peer returns), and fires `PeerDisconnected`. The combined
+stream ends when both sub-streams are exhausted, which happens when the transport stops.
+Firing `PeerDisconnected` from session closure would be wrong: sessions are per-message
+and ephemeral. The correct signal is peer absence from the discovery layer.
 
 The accept loop:
 


### PR DESCRIPTION
## What changed

`Transport::departures()` is added to the trait with a default empty-stream implementation so existing transports and mocks need no changes. The QUIC mDNS bridge is extended to handle `ServiceEvent::ServiceRemoved` alongside `ServiceResolved`. Because `ServiceRemoved` gives only the service fullname and not the address, the bridge now tracks `fullname -> Vec<SocketAddr>` internally (populated on `ServiceResolved`) so it can emit the correct `PeerAddress` on removal. `peer_stream` drains `discover()` and `departures()` concurrently via `stream::select`, firing `PeerDisconnected` when a departure matches a known peer and clearing the address from `known_addrs` so re-discovery works if the peer returns.

One new test: `peer_stream_fires_disconnected_on_departure` pre-populates the peer table (simulating a prior handshake) and verifies that injecting a departure event through the new stream fires `PeerDisconnected` with the correct `PeerId` and removes the address from `known_addrs`.

## Why

`PeerDisconnected` was defined but never fired. Session closure was the only candidate trigger, but sessions are per-message and ephemeral; firing there would have produced a `PeerDisconnected` after every single `send()`. The correct trigger is peer absence from the discovery layer: when a node stops or loses the network, mdns-sd expires its `_pathweave._udp.local.` record and fires `ServiceRemoved`. Closes #61.

## Alternatives considered

**Fire from `handle_incoming` when the recv loop exits.** Rejected. The recv loop exits normally after every message delivery; it is not a departure signal.

**Carry removal events inside `PeerAnnouncement` as a new variant.** Rejected. It conflates arrivals and departures in a single type, forces every caller to match on a variant it never wants, and leaks a transport-internal concept into the shared announcement type.

**Add a separate `peer_departures()` method returning `BoxStream<PeerId>` instead of `BoxStream<PeerAddress>`.** Rejected. The departure source knows the address, not the PeerId; resolving PeerId at the transport layer would require the transport to hold a reference to the peer table, inverting the dependency direction. Looking up PeerId from the address in `peer_stream` keeps the peer table access in one place.

## Security considerations

No new authentication surface. The departure path reads the peer table under the existing mutex, modifies `known_addrs`, and sends an event (no I/O, no new network connections, no cryptographic operations). A malicious `ServiceRemoved` from a rogue mDNS responder can cause a spurious `PeerDisconnected` event but cannot forge a handshake or inject application data.

## Test plan

- `cargo test --workspace`: 49 tests pass, 0 fail
- `cargo clippy --workspace -- -D warnings`: clean
- `cargo fmt --all -- --check`: clean
- New test `peer_stream_fires_disconnected_on_departure` covers the departure path end to end
