### PR TITLE
feat(core): route packets via TTL-limited flooding

### DIFF
--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -13,6 +13,8 @@ use crate::{
     Result, Router, Session, Transport, TransportEvent,
 };
 
+const MAX_TTL: u8 = 7;
+
 const DEDUP_TTL: Duration = Duration::from_secs(60);
 
 /// Tracks recently seen (PeerId, message_id) pairs to suppress duplicate deliveries.
@@ -22,6 +24,7 @@ const DEDUP_TTL: Duration = Duration::from_secs(60);
 /// sending the ACK so the sender does not time out. Entries expire after DEDUP_TTL.
 struct DeduplicationCache {
     seen: HashMap<(PeerId, u64), Instant>,
+    seen_routed: HashMap<u64, Instant>,
     ttl: Duration,
 }
 
@@ -29,6 +32,7 @@ impl DeduplicationCache {
     fn new() -> Self {
         Self {
             seen: HashMap::new(),
+            seen_routed: HashMap::new(),
             ttl: DEDUP_TTL,
         }
     }
@@ -53,10 +57,30 @@ impl DeduplicationCache {
         false
     }
 
+    /// Returns true if message_id was seen within the TTL window (routed dedup).
+    ///
+    /// Keyed on message_id alone because the immediate sender is a relay and varies
+    /// across paths. If not seen before, records and returns false. See ADR 019.
+    fn check_and_insert_routed(&mut self, message_id: u64) -> bool {
+        let now = Instant::now();
+        let ttl = self.ttl;
+        self.seen_routed.retain(|_, inserted_at| {
+            now.checked_duration_since(*inserted_at)
+                .map(|age| age < ttl)
+                .unwrap_or(true)
+        });
+        if self.seen_routed.contains_key(&message_id) {
+            return true;
+        }
+        self.seen_routed.insert(message_id, now);
+        false
+    }
+
     #[cfg(test)]
     fn with_ttl(ttl: Duration) -> Self {
         Self {
             seen: HashMap::new(),
+            seen_routed: HashMap::new(),
             ttl,
         }
     }
@@ -73,7 +97,7 @@ impl DeduplicationCache {
 /// transport) populates it automatically via discovery. add_peer() and connect() also
 /// push addresses for manually-supplied peers. See ADR 016.
 pub struct PathweaveNode {
-    router: Router,
+    router: Arc<Router>,
     identity: NodeIdentity,
     peers: PeerTable,
     // Dedup-only: tracks addresses currently in-flight or already connected.
@@ -92,7 +116,7 @@ impl PathweaveNode {
     /// implementations are complete; callers should pass `NodeConfig::default()` for now.
     pub async fn new(_config: NodeConfig, identity: NodeIdentity) -> Result<Self> {
         Ok(Self {
-            router: Router::new(),
+            router: Arc::new(Router::new()),
             identity,
             peers: new_peer_table(),
             known_addrs: Arc::new(Mutex::new(HashSet::new())),
@@ -125,6 +149,8 @@ impl PathweaveNode {
             started.clone(),
             Arc::clone(&self.key_registry),
             Arc::clone(&self.peers),
+            Arc::clone(&self.router),
+            self.identity.peer_id().clone(),
         ));
 
         tokio::spawn(crate::router::peer_stream(
@@ -200,16 +226,76 @@ impl PathweaveNode {
             .get(&peer_id)
             .cloned()
             .ok_or(PathweaveError::NoTransportAvailable)?;
+        let mut framed = Vec::with_capacity(1 + payload.len());
+        framed.push(0x00); // direct route_flag (ADR 019)
+        framed.extend_from_slice(&payload);
         self.router
             .send(
                 &announcements,
                 &self.identity,
-                payload,
+                framed,
                 &peer_id,
                 &self.key_registry,
                 &self.peers,
+                None,
             )
             .await
+    }
+
+    /// Sends `payload` to `dest_peer_id` via mesh routing (ADR 019).
+    ///
+    /// Floods a routed frame to all known direct peers with TTL=7. Each relay decrements
+    /// TTL and re-floods to all its known peers except the immediate sender. Delivery
+    /// stops when the destination receives the frame or TTL reaches zero.
+    ///
+    /// Returns Ok(()) if at least one neighbor accepted the frame. Does not confirm
+    /// end-to-end delivery to `dest_peer_id`.
+    pub async fn send_routed(&self, dest_peer_id: PeerId, payload: Vec<u8>) -> Result<()> {
+        let msg_id = router::new_message_id();
+        let mut frame_body = Vec::with_capacity(1 + 32 + 1 + payload.len());
+        frame_body.push(0x01); // routed route_flag
+        frame_body.extend_from_slice(dest_peer_id.as_bytes());
+        frame_body.push(MAX_TTL);
+        frame_body.extend_from_slice(&payload);
+
+        let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = self
+            .peers
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(pid, _)| **pid != *self.identity.peer_id())
+            .map(|(pid, anns)| (pid.clone(), anns.clone()))
+            .collect();
+
+        if neighbors.is_empty() {
+            return Err(PathweaveError::NoTransportAvailable);
+        }
+
+        let mut any_ok = false;
+        for (peer_id, announcements) in neighbors {
+            if self
+                .router
+                .send(
+                    &announcements,
+                    &self.identity,
+                    frame_body.clone(),
+                    &peer_id,
+                    &self.key_registry,
+                    &self.peers,
+                    Some(msg_id),
+                )
+                .await
+                .is_ok()
+            {
+                any_ok = true;
+            }
+        }
+
+        if any_ok {
+            Ok(())
+        } else {
+            Err(PathweaveError::DeliveryFailed)
+        }
     }
 
     /// Registers a handler that will be called for each incoming message.
@@ -239,6 +325,7 @@ impl PathweaveNode {
 /// before the first accept() call, eliminating the startup race. Each accepted
 /// connection is handed to handle_incoming in a spawned task. On error, backs off
 /// for 5 seconds to avoid busy-looping for transports that don't support inbound.
+#[allow(clippy::too_many_arguments)]
 async fn accept_loop(
     transport: Arc<dyn Transport>,
     identity: NodeIdentity,
@@ -247,6 +334,8 @@ async fn accept_loop(
     mut started: watch::Receiver<bool>,
     key_registry: KeyRegistry,
     peers: PeerTable,
+    router: Arc<Router>,
+    local_peer_id: PeerId,
 ) {
     let _ = started.wait_for(|v| *v).await;
     let local_addrs = Arc::new(transport.local_addresses());
@@ -259,6 +348,8 @@ async fn accept_loop(
                 let key_registry = Arc::clone(&key_registry);
                 let peers = Arc::clone(&peers);
                 let local_addrs = Arc::clone(&local_addrs);
+                let router = Arc::clone(&router);
+                let local_peer_id = local_peer_id.clone();
                 tokio::spawn(handle_incoming(
                     conn,
                     identity,
@@ -267,6 +358,8 @@ async fn accept_loop(
                     key_registry,
                     peers,
                     local_addrs,
+                    router,
+                    local_peer_id,
                 ));
             }
             Err(e) => {
@@ -283,6 +376,7 @@ async fn accept_loop(
 /// (ADR 017); the exchange is handled and the next message is the application frame.
 /// Otherwise the first message is treated directly as the application frame, which
 /// allows communication with older nodes that do not implement address exchange.
+#[allow(clippy::too_many_arguments)]
 async fn handle_incoming(
     conn: Box<dyn Connection>,
     identity: NodeIdentity,
@@ -291,6 +385,8 @@ async fn handle_incoming(
     key_registry: KeyRegistry,
     peers: PeerTable,
     local_addrs: Arc<Vec<PeerAddress>>,
+    router: Arc<Router>,
+    local_peer_id: PeerId,
 ) {
     let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(conn));
     let mut session = match Session::respond(&identity, bundled).await {
@@ -300,11 +396,11 @@ async fn handle_incoming(
             return;
         }
     };
-    let peer_id = session.peer_id().clone();
+    let sender_peer_id = session.peer_id().clone();
     key_registry
         .lock()
         .unwrap()
-        .insert(peer_id.clone(), *session.remote_static_key());
+        .insert(sender_peer_id.clone(), *session.remote_static_key());
 
     let first = match session.recv().await {
         Ok(p) => p,
@@ -313,8 +409,10 @@ async fn handle_incoming(
 
     let app_payload = if first.len() >= 8 && first[0] == 0x00 {
         match router::decode_addr_exchange(&first) {
-            Some(addrs) => router::upsert_peer_addresses(&peers, &peer_id, addrs),
-            None => tracing::debug!(peer = %peer_id, "addr-exchange: parse failed; skipping"),
+            Some(addrs) => router::upsert_peer_addresses(&peers, &sender_peer_id, addrs),
+            None => {
+                tracing::debug!(peer = %sender_peer_id, "addr-exchange: parse failed; skipping")
+            }
         }
         let _ = session
             .send(&router::encode_addr_exchange(&local_addrs))
@@ -327,21 +425,51 @@ async fn handle_incoming(
         first
     };
 
-    dispatch_payload(&peer_id, app_payload, &dedup, &handler, &mut session).await;
+    dispatch_payload(
+        &sender_peer_id,
+        app_payload,
+        &dedup,
+        &handler,
+        &mut session,
+        &local_peer_id,
+        &router,
+        &peers,
+        &identity,
+        &key_registry,
+    )
+    .await;
     while let Ok(payload) = session.recv().await {
-        dispatch_payload(&peer_id, payload, &dedup, &handler, &mut session).await;
+        dispatch_payload(
+            &sender_peer_id,
+            payload,
+            &dedup,
+            &handler,
+            &mut session,
+            &local_peer_id,
+            &router,
+            &peers,
+            &identity,
+            &key_registry,
+        )
+        .await;
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn dispatch_payload(
-    peer_id: &PeerId,
+    sender_peer_id: &PeerId,
     payload: Bytes,
     dedup: &Arc<Mutex<DeduplicationCache>>,
     handler: &Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     session: &mut Session,
+    local_peer_id: &PeerId,
+    router: &Arc<Router>,
+    peers: &PeerTable,
+    identity: &NodeIdentity,
+    key_registry: &KeyRegistry,
 ) {
-    if payload.len() < 8 {
-        tracing::debug!(peer = %peer_id, "received payload shorter than 8 bytes; skipping");
+    if payload.len() < 9 {
+        tracing::debug!(peer = %sender_peer_id, "received payload shorter than 9 bytes; skipping");
         let _ = session.send(b"").await;
         return;
     }
@@ -349,15 +477,93 @@ async fn dispatch_payload(
         payload[0], payload[1], payload[2], payload[3], payload[4], payload[5], payload[6],
         payload[7],
     ]);
-    let data = payload[8..].to_vec();
-    let is_dup = dedup.lock().unwrap().check_and_insert(peer_id, msg_id);
-    if !is_dup {
-        if let Some(h) = handler.lock().unwrap().as_ref() {
-            h.on_message(peer_id.clone(), data);
+    let route_flag = payload[8];
+
+    match route_flag {
+        0x00 => {
+            let data = payload[9..].to_vec();
+            let is_dup = dedup
+                .lock()
+                .unwrap()
+                .check_and_insert(sender_peer_id, msg_id);
+            if !is_dup {
+                if let Some(h) = handler.lock().unwrap().as_ref() {
+                    h.on_message(sender_peer_id.clone(), data);
+                }
+            } else {
+                tracing::debug!(peer = %sender_peer_id, "suppressed duplicate direct message");
+            }
         }
-    } else {
-        tracing::debug!(peer = %peer_id, "suppressed duplicate message");
+        0x01 => {
+            if payload.len() < 9 + 32 + 1 {
+                tracing::debug!(peer = %sender_peer_id, "routed frame too short; skipping");
+                let _ = session.send(b"").await;
+                return;
+            }
+            let dest_bytes: [u8; 32] = payload[9..41].try_into().unwrap();
+            let dest = PeerId::from_bytes(dest_bytes);
+            let ttl = payload[41].min(MAX_TTL);
+            let app_payload = payload[42..].to_vec();
+
+            if &dest == local_peer_id {
+                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                if !is_dup {
+                    if let Some(h) = handler.lock().unwrap().as_ref() {
+                        h.on_message(sender_peer_id.clone(), app_payload);
+                    }
+                } else {
+                    tracing::debug!(msg_id, "suppressed duplicate routed message at destination");
+                }
+            } else if ttl == 0 {
+                tracing::debug!(msg_id, "TTL=0: silently dropping routed message");
+            } else {
+                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                if !is_dup {
+                    let new_ttl = ttl - 1;
+                    let mut relay_body = Vec::with_capacity(1 + 32 + 1 + app_payload.len());
+                    relay_body.push(0x01);
+                    relay_body.extend_from_slice(dest.as_bytes());
+                    relay_body.push(new_ttl);
+                    relay_body.extend_from_slice(&app_payload);
+
+                    let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
+                        .lock()
+                        .unwrap()
+                        .iter()
+                        .filter(|(pid, _)| **pid != *sender_peer_id && **pid != *local_peer_id)
+                        .map(|(pid, anns)| (pid.clone(), anns.clone()))
+                        .collect();
+
+                    for (next_peer_id, announcements) in neighbors {
+                        let router = Arc::clone(router);
+                        let identity = identity.clone();
+                        let relay_body = relay_body.clone();
+                        let key_registry = Arc::clone(key_registry);
+                        let peers = Arc::clone(peers);
+                        tokio::spawn(async move {
+                            let _ = router
+                                .send(
+                                    &announcements,
+                                    &identity,
+                                    relay_body,
+                                    &next_peer_id,
+                                    &key_registry,
+                                    &peers,
+                                    Some(msg_id),
+                                )
+                                .await;
+                        });
+                    }
+                } else {
+                    tracing::debug!(msg_id, "suppressed duplicate routed message at relay");
+                }
+            }
+        }
+        _ => {
+            tracing::debug!(peer = %sender_peer_id, route_flag, "unknown route_flag; skipping");
+        }
     }
+
     let _ = session.send(b"").await;
 }
 
@@ -675,10 +881,11 @@ mod tests {
         tokio::spawn(async move {
             let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(Box::new(client_conn)));
             let mut session = Session::initiate(&sender_id, bundled, None).await.unwrap();
-            // Prepend the 8-byte message ID as handle_incoming now expects (ADR 011).
+            // Prepend msg_id + route_flag=0x00 (direct) as dispatch_payload expects (ADR 019).
             let msg_id: u64 = 0x0102030405060708;
-            let mut framed = Vec::with_capacity(8 + b"hello from peer".len());
+            let mut framed = Vec::with_capacity(9 + b"hello from peer".len());
             framed.extend_from_slice(&msg_id.to_be_bytes());
+            framed.push(0x00); // direct
             framed.extend_from_slice(b"hello from peer");
             session.send(&framed).await.unwrap();
         });
@@ -839,8 +1046,9 @@ mod tests {
         tokio::task::yield_now().await;
 
         let msg_id: u64 = 0xDEADBEEFCAFEBABE;
-        let mut framed = Vec::with_capacity(8 + b"hello".len());
+        let mut framed = Vec::with_capacity(9 + b"hello".len());
         framed.extend_from_slice(&msg_id.to_be_bytes());
+        framed.push(0x00); // direct
         framed.extend_from_slice(b"hello");
 
         // Send two connections from the same sender with the same message ID.
@@ -868,6 +1076,458 @@ mod tests {
             call_count.load(Ordering::Relaxed),
             1,
             "on_message must be called exactly once for a duplicated message"
+        );
+    }
+
+    // --- routed dedup unit tests ---------------------------------------------
+
+    #[test]
+    fn routed_dedup_first_insert_not_duplicate() {
+        let mut cache = DeduplicationCache::new();
+        assert!(!cache.check_and_insert_routed(0xABCD));
+    }
+
+    #[test]
+    fn routed_dedup_second_insert_same_id_is_duplicate() {
+        let mut cache = DeduplicationCache::new();
+        cache.check_and_insert_routed(0xABCD);
+        assert!(cache.check_and_insert_routed(0xABCD));
+    }
+
+    #[test]
+    fn routed_dedup_different_id_not_duplicate() {
+        let mut cache = DeduplicationCache::new();
+        cache.check_and_insert_routed(1);
+        assert!(!cache.check_and_insert_routed(2));
+    }
+
+    #[test]
+    fn routed_dedup_redeliverable_after_ttl_expires() {
+        let mut cache = DeduplicationCache::with_ttl(Duration::from_millis(10));
+        cache.check_and_insert_routed(0xABCD);
+        std::thread::sleep(Duration::from_millis(20));
+        assert!(!cache.check_and_insert_routed(0xABCD));
+    }
+
+    #[test]
+    fn routed_dedup_independent_of_direct_dedup() {
+        let mut cache = DeduplicationCache::new();
+        let peer = NodeIdentity::generate().peer_id().clone();
+        // Direct dedup on (peer, id) must not affect routed dedup on id alone.
+        cache.check_and_insert(&peer, 42);
+        assert!(!cache.check_and_insert_routed(42));
+    }
+
+    // --- mesh routing test infrastructure ------------------------------------
+
+    /// Bidirectional in-memory transport pair for multi-hop tests.
+    ///
+    /// When A calls connect(), the server-side connection lands in B's accept queue.
+    /// When B calls connect(), the server-side connection lands in A's accept queue.
+    /// Both sides share the same kind so router candidate selection works.
+    struct InMemoryTransport {
+        accept_rx: tokio::sync::Mutex<tokio::sync::mpsc::UnboundedReceiver<Box<dyn Connection>>>,
+        connect_server_tx: tokio::sync::mpsc::UnboundedSender<Box<dyn Connection>>,
+        kind: TransportKind,
+    }
+
+    fn wire_transports(kind: TransportKind) -> (InMemoryTransport, InMemoryTransport) {
+        let (a_to_b_tx, b_accept_rx) = tokio::sync::mpsc::unbounded_channel();
+        let (b_to_a_tx, a_accept_rx) = tokio::sync::mpsc::unbounded_channel();
+        (
+            InMemoryTransport {
+                accept_rx: tokio::sync::Mutex::new(a_accept_rx),
+                connect_server_tx: a_to_b_tx,
+                kind,
+            },
+            InMemoryTransport {
+                accept_rx: tokio::sync::Mutex::new(b_accept_rx),
+                connect_server_tx: b_to_a_tx,
+                kind,
+            },
+        )
+    }
+
+    #[async_trait]
+    impl crate::Transport for InMemoryTransport {
+        async fn start(&self, _: &NodeIdentity) -> Result<()> {
+            Ok(())
+        }
+        async fn stop(&self) -> Result<()> {
+            Ok(())
+        }
+        fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
+            Box::pin(stream::empty())
+        }
+        async fn connect(&self, _peer: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
+            let (client, server) = conn_pair();
+            self.connect_server_tx.send(Box::new(server)).ok();
+            Ok(Box::new(client))
+        }
+        async fn accept(&self) -> Result<Box<dyn Connection>> {
+            self.accept_rx
+                .lock()
+                .await
+                .recv()
+                .await
+                .ok_or_else(|| PathweaveError::Transport("channel closed".into()))
+        }
+        fn mtu_hint(&self) -> usize {
+            65535
+        }
+        fn cost(&self) -> TransportCost {
+            TransportCost::Free
+        }
+        fn kind(&self) -> TransportKind {
+            self.kind
+        }
+        fn name(&self) -> &'static str {
+            "in-memory"
+        }
+    }
+
+    struct CountingHandler {
+        count: Arc<std::sync::atomic::AtomicUsize>,
+        payload_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>>,
+    }
+
+    impl MessageHandler for CountingHandler {
+        fn on_message(&self, _peer_id: PeerId, payload: Vec<u8>) {
+            self.count.fetch_add(1, Ordering::Relaxed);
+            if let Some(tx) = self.payload_tx.lock().unwrap().take() {
+                let _ = tx.send(payload);
+            }
+        }
+    }
+
+    // --- mesh routing integration tests --------------------------------------
+
+    // Topology: A --[Ble]--> B --[Quic]--> C
+    // A and C have no direct path. A sends a routed message to C; B relays.
+    //
+    // The test asserts all five invariants from ADR 019:
+    // (1) destination check, (2) TTL enforcement, (3) source suppression,
+    // (4) dedup, (5) no cross-delivery.
+
+    #[tokio::test]
+    async fn routed_message_delivered_via_relay() {
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+
+        let pid_a = id_a.peer_id().clone();
+        let pid_b = id_b.peer_id().clone();
+        let pid_c = id_c.peer_id().clone();
+
+        // Wire A→B: A connects, B accepts.
+        let (t_a, t_b_inbound) = wire_transports(TransportKind::Ble);
+        // Wire B→C: B connects, C accepts.
+        let (t_b_outbound, t_c) = wire_transports(TransportKind::Quic);
+
+        let ann_b_for_a = PeerAnnouncement {
+            address: PeerAddress::Ble("node-b".into()),
+            short_id: None,
+        };
+        let ann_a_for_b = PeerAnnouncement {
+            address: PeerAddress::Ble("node-a".into()),
+            short_id: None,
+        };
+        let ann_c_for_b = PeerAnnouncement {
+            address: PeerAddress::Quic("127.0.0.1:1".parse().unwrap()),
+            short_id: None,
+        };
+        let ann_b_for_c = PeerAnnouncement {
+            address: PeerAddress::Quic("127.0.0.1:2".parse().unwrap()),
+            short_id: None,
+        };
+
+        // Build node A.
+        let mut node_a = PathweaveNode::new(NodeConfig::default(), id_a)
+            .await
+            .unwrap();
+        node_a.register_transport(Box::new(t_a));
+        node_a.add_peer(pid_b.clone(), ann_b_for_a);
+
+        // Build node B (relay): two transports.
+        let mut node_b = PathweaveNode::new(NodeConfig::default(), id_b)
+            .await
+            .unwrap();
+        node_b.register_transport(Box::new(t_b_inbound));
+        node_b.register_transport(Box::new(t_b_outbound));
+        node_b.add_peer(pid_a.clone(), ann_a_for_b);
+        node_b.add_peer(pid_c.clone(), ann_c_for_b);
+
+        // Build node C.
+        let mut node_c = PathweaveNode::new(NodeConfig::default(), id_c)
+            .await
+            .unwrap();
+        node_c.register_transport(Box::new(t_c));
+        node_c.add_peer(pid_b.clone(), ann_b_for_c);
+
+        // Track handler call counts on all three nodes.
+        let count_a = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let count_b = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (c_tx, c_rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+        let c_tx = Arc::new(Mutex::new(Some(c_tx)));
+        let count_c = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+        node_a.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_a),
+            payload_tx: Arc::new(Mutex::new(None)),
+        }));
+        node_b.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_b),
+            payload_tx: Arc::new(Mutex::new(None)),
+        }));
+        node_c.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_c),
+            payload_tx: Arc::clone(&c_tx),
+        }));
+
+        // Yield to let health monitors start transports.
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        node_a
+            .send_routed(pid_c.clone(), b"hello via relay".to_vec())
+            .await
+            .unwrap();
+
+        let delivered = tokio::time::timeout(tokio::time::Duration::from_secs(5), c_rx)
+            .await
+            .expect("timed out waiting for routed delivery")
+            .unwrap();
+
+        assert_eq!(
+            delivered, b"hello via relay",
+            "invariant 1: destination receives payload"
+        );
+        assert_eq!(
+            count_c.load(Ordering::Relaxed),
+            1,
+            "invariant 1: delivered exactly once at C"
+        );
+        assert_eq!(
+            count_b.load(Ordering::Relaxed),
+            0,
+            "invariant 5: relay does not call on_message"
+        );
+        assert_eq!(
+            count_a.load(Ordering::Relaxed),
+            0,
+            "invariant 5: originator does not receive its own message"
+        );
+    }
+
+    #[tokio::test]
+    async fn routed_message_ttl_zero_dropped_at_relay() {
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+
+        let pid_b = id_b.peer_id().clone();
+        let pid_c = id_c.peer_id().clone();
+
+        let (t_a, t_b_inbound) = wire_transports(TransportKind::Ble);
+        let (t_b_outbound, t_c) = wire_transports(TransportKind::Quic);
+
+        let mut node_a = PathweaveNode::new(NodeConfig::default(), id_a.clone())
+            .await
+            .unwrap();
+        node_a.register_transport(Box::new(t_a));
+        node_a.add_peer(
+            pid_b.clone(),
+            PeerAnnouncement {
+                address: PeerAddress::Ble("b".into()),
+                short_id: None,
+            },
+        );
+
+        let mut node_b = PathweaveNode::new(NodeConfig::default(), id_b.clone())
+            .await
+            .unwrap();
+        node_b.register_transport(Box::new(t_b_inbound));
+        node_b.register_transport(Box::new(t_b_outbound));
+        node_b.add_peer(
+            id_a.peer_id().clone(),
+            PeerAnnouncement {
+                address: PeerAddress::Ble("a".into()),
+                short_id: None,
+            },
+        );
+        node_b.add_peer(
+            pid_c.clone(),
+            PeerAnnouncement {
+                address: PeerAddress::Quic("127.0.0.1:3".parse().unwrap()),
+                short_id: None,
+            },
+        );
+
+        let mut node_c = PathweaveNode::new(NodeConfig::default(), id_c)
+            .await
+            .unwrap();
+        node_c.register_transport(Box::new(t_c));
+
+        let count_c = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        node_c.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_c),
+            payload_tx: Arc::new(Mutex::new(None)),
+        }));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        // Send a routed frame directly to B with TTL=0 inside the frame body,
+        // bypassing PathweaveNode::send_routed (which always sets TTL=7).
+        // B must drop it without forwarding to C (invariant 2).
+        let msg_id = crate::router::new_message_id();
+        let mut frame_body = Vec::with_capacity(1 + 32 + 1 + 5);
+        frame_body.push(0x01);
+        frame_body.extend_from_slice(pid_c.as_bytes());
+        frame_body.push(0u8); // TTL = 0
+        frame_body.extend_from_slice(b"drop");
+
+        let b_anns = vec![PeerAnnouncement {
+            address: PeerAddress::Ble("b".into()),
+            short_id: None,
+        }];
+        node_a
+            .router
+            .send(
+                &b_anns,
+                &id_a,
+                frame_body,
+                &pid_b,
+                &node_a.key_registry,
+                &node_a.peers,
+                Some(msg_id),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+        assert_eq!(
+            count_c.load(Ordering::Relaxed),
+            0,
+            "invariant 2: TTL=0 message must not reach destination"
+        );
+    }
+
+    #[tokio::test]
+    async fn routed_message_deduplicated_across_two_relay_paths() {
+        // Inject the same routed frame (same msg_id, dest=C) from two distinct sender
+        // nodes via two different transport paths. C must call on_message exactly once.
+        //
+        // Invariant 4 (ADR 019): routed dedup is keyed on msg_id alone, not on
+        // (sender_peer_id, msg_id). S1 and S2 have different PeerIds, so if dedup
+        // were keyed on the pair, C would deliver twice. It must not.
+        let id_s1 = NodeIdentity::generate();
+        let id_s2 = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+        let pid_c = id_c.peer_id().clone();
+
+        // S1 connects to C via Ble; S2 connects to C via Quic.
+        let (t_s1, t_c1) = wire_transports(TransportKind::Ble);
+        let (t_s2, t_c2) = wire_transports(TransportKind::Quic);
+
+        // Node C: two inbound transports, one per sender.
+        let mut node_c = PathweaveNode::new(NodeConfig::default(), id_c.clone())
+            .await
+            .unwrap();
+        node_c.register_transport(Box::new(t_c1));
+        node_c.register_transport(Box::new(t_c2));
+
+        let count_c = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let (c_tx, c_rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+        let c_tx_arc = Arc::new(Mutex::new(Some(c_tx)));
+        node_c.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_c),
+            payload_tx: Arc::clone(&c_tx_arc),
+        }));
+
+        // Sender S1: one Ble transport to C.
+        let mut node_s1 = PathweaveNode::new(NodeConfig::default(), id_s1.clone())
+            .await
+            .unwrap();
+        node_s1.register_transport(Box::new(t_s1));
+        node_s1.add_peer(
+            pid_c.clone(),
+            PeerAnnouncement {
+                address: PeerAddress::Ble("c".into()),
+                short_id: None,
+            },
+        );
+
+        // Sender S2: one Quic transport to C.
+        let mut node_s2 = PathweaveNode::new(NodeConfig::default(), id_s2.clone())
+            .await
+            .unwrap();
+        node_s2.register_transport(Box::new(t_s2));
+        node_s2.add_peer(
+            pid_c.clone(),
+            PeerAnnouncement {
+                address: PeerAddress::Quic("127.0.0.1:20".parse().unwrap()),
+                short_id: None,
+            },
+        );
+
+        for _ in 0..8 {
+            tokio::task::yield_now().await;
+        }
+
+        // Build one routed frame with a fixed message_id. Both senders transmit it.
+        let msg_id = crate::router::new_message_id();
+        let mut frame_body = Vec::new();
+        frame_body.push(0x01); // route_flag
+        frame_body.extend_from_slice(pid_c.as_bytes());
+        frame_body.push(3u8); // TTL
+        frame_body.extend_from_slice(b"dedup test");
+
+        node_s1
+            .router
+            .send(
+                &[PeerAnnouncement {
+                    address: PeerAddress::Ble("c".into()),
+                    short_id: None,
+                }],
+                &id_s1,
+                frame_body.clone(),
+                &pid_c,
+                &node_s1.key_registry,
+                &node_s1.peers,
+                Some(msg_id),
+            )
+            .await
+            .unwrap();
+
+        node_s2
+            .router
+            .send(
+                &[PeerAnnouncement {
+                    address: PeerAddress::Quic("127.0.0.1:20".parse().unwrap()),
+                    short_id: None,
+                }],
+                &id_s2,
+                frame_body.clone(),
+                &pid_c,
+                &node_s2.key_registry,
+                &node_s2.peers,
+                Some(msg_id),
+            )
+            .await
+            .unwrap();
+
+        let _ = tokio::time::timeout(tokio::time::Duration::from_secs(5), c_rx)
+            .await
+            .expect("timed out waiting for routed delivery");
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+        assert_eq!(
+            count_c.load(Ordering::Relaxed),
+            1,
+            "invariant 4: routed message delivered exactly once despite two distinct sender paths"
         );
     }
 }

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -31,7 +31,7 @@ struct TransportEntry {
 /// task per transport tracks availability so send() always reflects current state.
 /// Connections are lazy: opened on send(), closed after.
 pub struct Router {
-    transports: Vec<TransportEntry>,
+    transports: std::sync::Mutex<Vec<TransportEntry>>,
     event_tx: broadcast::Sender<TransportEvent>,
 }
 
@@ -39,7 +39,7 @@ impl Router {
     pub fn new() -> Self {
         let (event_tx, _) = broadcast::channel(64);
         Self {
-            transports: Vec::new(),
+            transports: std::sync::Mutex::new(Vec::new()),
             event_tx,
         }
     }
@@ -52,7 +52,7 @@ impl Router {
     /// returned receiver. Unlike `Notify`, a watch receiver that arrives late
     /// still sees `true` because the value is retained.
     pub fn register_transport(
-        &mut self,
+        &self,
         transport: Arc<dyn Transport>,
         identity: Arc<NodeIdentity>,
     ) -> watch::Receiver<bool> {
@@ -71,7 +71,7 @@ impl Router {
             kind,
         ));
 
-        self.transports.push(TransportEntry {
+        self.transports.lock().unwrap().push(TransportEntry {
             transport,
             available,
             task,
@@ -93,6 +93,7 @@ impl Router {
     /// Returns NoTransportAvailable if no transport is currently available or no
     /// registered transport can handle any of the given addresses.
     /// Returns DeliveryFailed if all attempts are exhausted without a delivery ACK.
+    #[allow(clippy::too_many_arguments)]
     pub async fn send(
         &self,
         peers: &[PeerAnnouncement],
@@ -101,52 +102,57 @@ impl Router {
         peer_id: &PeerId,
         key_registry: &KeyRegistry,
         peer_table: &PeerTable,
+        message_id: Option<u64>,
     ) -> Result<()> {
         let any_available = self
             .transports
+            .lock()
+            .unwrap()
             .iter()
             .any(|t| t.available.load(Ordering::Acquire));
         if !any_available {
             return Err(PathweaveError::NoTransportAvailable);
         }
 
-        let message_id = new_message_id();
+        let message_id = message_id.unwrap_or_else(new_message_id);
 
         for attempt in 0..MAX_SEND_ATTEMPTS {
-            let mut candidates: Vec<(&TransportEntry, &PeerAnnouncement)> = self
-                .transports
-                .iter()
-                .filter(|t| t.available.load(Ordering::Acquire))
-                .flat_map(|entry| {
-                    peers.iter().filter_map(move |ann| {
-                        if ann.address.kind() == entry.transport.kind() {
-                            Some((entry, ann))
-                        } else {
-                            None
-                        }
+            let mut candidates: Vec<(Arc<dyn Transport>, PeerAnnouncement)> = {
+                let guard = self.transports.lock().unwrap();
+                guard
+                    .iter()
+                    .filter(|t| t.available.load(Ordering::Acquire))
+                    .flat_map(|entry| {
+                        peers.iter().filter_map(move |ann| {
+                            if ann.address.kind() == entry.transport.kind() {
+                                Some((Arc::clone(&entry.transport), ann.clone()))
+                            } else {
+                                None
+                            }
+                        })
                     })
-                })
-                .collect();
+                    .collect()
+            };
 
             if candidates.is_empty() {
                 return Err(PathweaveError::NoTransportAvailable);
             }
 
-            candidates.sort_by_key(|(entry, _)| match entry.transport.cost() {
+            candidates.sort_by_key(|(transport, _)| match transport.cost() {
                 TransportCost::Free => 0u8,
                 TransportCost::Metered => 1,
                 TransportCost::Unknown => 2,
             });
 
-            for (entry, ann) in &candidates {
+            for (transport, ann) in &candidates {
                 tracing::debug!(
                     attempt,
-                    transport = entry.transport.name(),
+                    transport = transport.name(),
                     addr = ?ann.address,
                     "try_send attempt"
                 );
                 match try_send(
-                    entry.transport.as_ref(),
+                    transport.as_ref(),
                     ann,
                     identity,
                     &payload,
@@ -160,13 +166,13 @@ impl Router {
                     Ok(()) => {
                         let _ = self.event_tx.send(TransportEvent::MessageDelivered {
                             peer_id: peer_id.clone(),
-                            transport: entry.transport.kind(),
+                            transport: transport.kind(),
                         });
                         return Ok(());
                     }
                     Err(e) => tracing::debug!(
                         attempt,
-                        transport = entry.transport.name(),
+                        transport = transport.name(),
                         addr = ?ann.address,
                         error = %e,
                         "try_send failed"
@@ -195,36 +201,32 @@ impl Router {
         key_registry: &KeyRegistry,
         peer_table: &PeerTable,
     ) -> Result<PeerId> {
-        let mut candidates: Vec<(&TransportEntry, &PeerAnnouncement)> = self
-            .transports
-            .iter()
-            .filter(|t| t.available.load(Ordering::Acquire))
-            .flat_map(|entry| {
-                peers.iter().filter_map(move |ann| {
-                    if ann.address.kind() == entry.transport.kind() {
-                        Some((entry, ann))
-                    } else {
-                        None
-                    }
+        let mut candidates: Vec<(Arc<dyn Transport>, PeerAnnouncement)> = {
+            let guard = self.transports.lock().unwrap();
+            guard
+                .iter()
+                .filter(|t| t.available.load(Ordering::Acquire))
+                .flat_map(|entry| {
+                    peers.iter().filter_map(move |ann| {
+                        if ann.address.kind() == entry.transport.kind() {
+                            Some((Arc::clone(&entry.transport), ann.clone()))
+                        } else {
+                            None
+                        }
+                    })
                 })
-            })
-            .collect();
+                .collect()
+        };
 
-        candidates.sort_by_key(|(entry, _)| match entry.transport.cost() {
+        candidates.sort_by_key(|(transport, _)| match transport.cost() {
             TransportCost::Free => 0u8,
             TransportCost::Metered => 1,
             TransportCost::Unknown => 2,
         });
 
-        for (entry, ann) in candidates {
-            if let Ok(peer_id) = try_connect(
-                entry.transport.as_ref(),
-                ann,
-                identity,
-                key_registry,
-                peer_table,
-            )
-            .await
+        for (transport, ann) in candidates {
+            if let Ok(peer_id) =
+                try_connect(transport.as_ref(), &ann, identity, key_registry, peer_table).await
             {
                 return Ok(peer_id);
             }
@@ -241,6 +243,8 @@ impl Router {
     /// Returns all addresses currently advertised by registered transports.
     pub fn local_addresses(&self) -> Vec<PeerAddress> {
         self.transports
+            .lock()
+            .unwrap()
             .iter()
             .flat_map(|e| e.transport.local_addresses())
             .collect()
@@ -269,7 +273,7 @@ impl Default for Router {
 
 impl Drop for Router {
     fn drop(&mut self) {
-        for entry in &self.transports {
+        for entry in self.transports.lock().unwrap().iter() {
             entry.task.abort();
         }
     }
@@ -400,7 +404,7 @@ async fn try_connect(
 ///
 /// Panics if the system entropy source is unavailable — the same condition
 /// that would have already caused NodeIdentity::generate() to panic.
-fn new_message_id() -> u64 {
+pub(crate) fn new_message_id() -> u64 {
     let mut bytes = [0u8; 8];
     getrandom::getrandom(&mut bytes).expect("system entropy unavailable");
     bytes[0] |= 0x80;
@@ -905,7 +909,7 @@ mod tests {
             make_transport(TransportCost::Metered, TransportKind::Quic, false);
 
         let identity = Arc::new(NodeIdentity::generate());
-        let mut router = Router::new();
+        let router = Router::new();
         router.register_transport(ble, Arc::clone(&identity));
         router.register_transport(quic, Arc::clone(&identity));
 
@@ -928,6 +932,7 @@ mod tests {
                 sender_id.peer_id(),
                 &new_key_registry(),
                 &new_peer_table(),
+                None,
             )
             .await
             .unwrap();
@@ -948,7 +953,7 @@ mod tests {
             make_transport(TransportCost::Metered, TransportKind::Quic, false);
 
         let identity = Arc::new(NodeIdentity::generate());
-        let mut router = Router::new();
+        let router = Router::new();
         router.register_transport(ble, Arc::clone(&identity));
         router.register_transport(quic, Arc::clone(&identity));
 
@@ -972,6 +977,7 @@ mod tests {
                 sender_id.peer_id(),
                 &new_key_registry(),
                 &new_peer_table(),
+                None,
             )
             .await
             .unwrap();
@@ -994,7 +1000,7 @@ mod tests {
             make_transport(TransportCost::Metered, TransportKind::Quic, false);
 
         let identity = Arc::new(NodeIdentity::generate());
-        let mut router = Router::new();
+        let router = Router::new();
         router.register_transport(ble, Arc::clone(&identity));
         router.register_transport(quic, Arc::clone(&identity));
 
@@ -1017,6 +1023,7 @@ mod tests {
                 sender_id.peer_id(),
                 &new_key_registry(),
                 &new_peer_table(),
+                None,
             )
             .await
             .unwrap();
@@ -1043,7 +1050,7 @@ mod tests {
             make_transport(TransportCost::Metered, TransportKind::Quic, true);
 
         let identity = Arc::new(NodeIdentity::generate());
-        let mut router = Router::new();
+        let router = Router::new();
         router.register_transport(ble, Arc::clone(&identity));
         router.register_transport(quic, Arc::clone(&identity));
 
@@ -1059,6 +1066,7 @@ mod tests {
                 sender_id.peer_id(),
                 &new_key_registry(),
                 &new_peer_table(),
+                None,
             )
             .await;
 
@@ -1090,6 +1098,7 @@ mod tests {
                 sender_id.peer_id(),
                 &new_key_registry(),
                 &new_peer_table(),
+                None,
             )
             .await;
         assert!(matches!(result, Err(PathweaveError::NoTransportAvailable)));
@@ -1102,7 +1111,7 @@ mod tests {
             make_transport_with_failures(TransportCost::Free, TransportKind::Ble, 1);
 
         let identity = Arc::new(NodeIdentity::generate());
-        let mut router = Router::new();
+        let router = Router::new();
         router.register_transport(transport, Arc::clone(&identity));
 
         tokio::task::yield_now().await;
@@ -1124,6 +1133,7 @@ mod tests {
                 sender_id.peer_id(),
                 &new_key_registry(),
                 &new_peer_table(),
+                None,
             )
             .await
             .unwrap();
@@ -1140,7 +1150,7 @@ mod tests {
             make_transport(TransportCost::Free, TransportKind::Ble, false);
 
         let identity = Arc::new(NodeIdentity::generate());
-        let mut router = Router::new();
+        let router = Router::new();
         router.register_transport(ble, Arc::clone(&identity));
 
         // No yield: monitoring task has not run, available = false.
@@ -1153,6 +1163,7 @@ mod tests {
                 sender_id.peer_id(),
                 &new_key_registry(),
                 &new_peer_table(),
+                None,
             )
             .await;
 
@@ -1172,7 +1183,7 @@ mod tests {
         let (transport, mut rx, _) = make_transport(TransportCost::Free, TransportKind::Ble, false);
 
         let identity = Arc::new(NodeIdentity::generate());
-        let mut router = Router::new();
+        let router = Router::new();
         router.register_transport(transport, Arc::clone(&identity));
 
         tokio::task::yield_now().await;

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -78,7 +78,7 @@ node.on_message(handler); // handler implements MessageHandler (see below)
 let mut events = node.events(); // Stream<Item = TransportEvent>
 ```
 
-**Rust-only (three, not in the UDL):**
+**Rust-only (four, not in the UDL):**
 
 ```rust
 // register a transport before first use
@@ -90,6 +90,10 @@ node.connect(announcement).await?;
 
 // inject a known peer address (e.g. QUIC --peer <address> from the command line)
 node.add_peer(peer_id, announcement);
+
+// send a message via mesh routing to a peer that may not be directly reachable
+// floods to all known neighbors with TTL=7; intermediate nodes relay until dest receives
+node.send_routed(peer_id, payload).await?;
 ```
 
 `connect()` tries transports in cost order (Free first). It returns the PeerId learned
@@ -254,7 +258,7 @@ level, signal quality, and payload-size routing are deferred beyond v0.2.0.
 
 ## The routing layer
 
-Static priority fallback. That's what it is and what we call it.
+Static priority fallback plus TTL-limited mesh flooding.
 
 **Peer table:** `HashMap<PeerId, Vec<PeerAnnouncement>>`. A peer discovered via both
 mDNS (QUIC address) and BLE scan (BLE address) accumulates both addresses in its Vec.
@@ -299,6 +303,27 @@ candidate list (all matching transport-address pairs in cost order), tries every
 in the list, then backs off for 1 second (`RETRY_BACKOFF`) before the next attempt. If
 all attempts across all candidates fail, `send()` returns `PathweaveError::DeliveryFailed`.
 See the delivery guarantees section.
+
+**Mesh routing**
+
+`send_routed(dest_peer_id, payload)` sends a message that may travel through intermediate
+relay nodes. The caller supplies the destination PeerId; the node floods the message to all
+known direct peers with TTL=7. Each relay decrements TTL and floods to all its known peers
+except the immediate sender. When the destination receives the message, it delivers to
+`on_message` and stops forwarding. TTL=0 causes a silent drop.
+
+The wire format adds a `route_flag` byte after the 8-byte message ID:
+- `0x00` — direct message; payload follows immediately (used by `send()`)
+- `0x01` — routed message; 32-byte dest_peer_id, 1-byte TTL, then payload follow
+
+Deduplication for routed messages is keyed on `message_id` alone (not
+`(sender_peer_id, message_id)`) because the immediate sender is a relay and varies
+across paths. Maximum TTL is 7; nodes clamp any received TTL to 7 before decrementing.
+See ADR 019 for the full specification.
+
+A node registered with multiple transports acts as a cross-transport bridge automatically:
+when it relays a routed message, `Router::send()` selects the best available transport
+for the next-hop peer. No explicit bridge configuration is required.
 
 ---
 
@@ -350,15 +375,29 @@ else:
 
 // process app_payload, then loop for subsequent messages:
 loop on app_payload, then session.recv():
-    if payload.len() < 8:
+    if payload.len() < 9:
         session.send(b"")              // ACK malformed frame so sender doesn't hang
         continue
     message_id = payload[0..8]         // extract 8-byte ID prepended by the sender
-    if dedup_cache.check_and_insert(peer_id, message_id):
-        session.send(b"")              // ACK even on duplicate -- stops the sender retrying
-        continue
-    handler.on_message(peer_id, payload[8..])   // deliver app bytes (ID stripped)
-    session.send(b"")                   // empty ACK to the sender (see note below)
+    route_flag = payload[8]            // 0x00 = direct, 0x01 = routed (ADR 019)
+
+    if route_flag == 0x00:             // direct delivery
+        if dedup_cache.check_and_insert(peer_id, message_id):
+            session.send(b"")          // ACK duplicate -- stops sender retrying
+            continue
+        handler.on_message(peer_id, payload[9..])   // deliver app bytes
+    else if route_flag == 0x01:        // routed delivery
+        dest = payload[9..41]          // 32-byte destination PeerId
+        ttl  = payload[41]             // remaining hops
+        data = payload[42..]
+        if dest == local_peer_id:
+            if !dedup_cache.check_routed(message_id):
+                handler.on_message(sender_peer_id, data)
+        else if ttl == 0:
+            // silent drop
+        else if !dedup_cache.check_routed(message_id):
+            // forward to all peers except sender with ttl-1, same message_id
+    session.send(b"")                   // hop-to-hop ACK in all cases
 ```
 
 **Why the ACK is required:** Quinn's `write_all()` writes to an internal send buffer; actual transmission is async. If the sender drops the session immediately after `send()`, Quinn fires `CONNECTION_CLOSE` before flushing the buffer and the data is silently lost. The receiver's empty ACK keeps the sender's connection alive long enough for the data to be transmitted. `send()` returning `Ok(())` is only meaningful when this round-trip completes. See ADR 009 and issue #34.
@@ -614,9 +653,9 @@ with a phone running the native SDK.
 
 Being clear about this matters as much as being clear about what it does.
 
-- No WiFi Direct, SMS, or USSD transports
+- No WiFi Direct, SMS, or USSD transports (planned; WiFi Direct targeted for v0.4.0)
 - No MLS group key exchange (Noise_XX is 1:1 only)
-- No multi-hop BLE routing (single-hop only)
+- No WiFi Direct, acoustic, SMS, or USSD transports
 - No key gossip yet (address exchange type 1 implemented in v0.3.0; key gossip via type 2 follows)
 - No OS network event integration for health monitoring (polling via if-addrs; rtnetlink,
   NWPathMonitor, and WinRT network events deferred to v0.3.0). See ADR 013.


### PR DESCRIPTION
## What changed

Implements multi-hop mesh routing per ADR 019. A new `route_flag` byte is inserted between the message_id and payload in the wire format: `0x00` for direct delivery (existing behaviour, unchanged), `0x01` for routed delivery with a 32-byte `dest_peer_id` and a `ttl` byte following. `dispatch_payload` branches on the flag: the direct path is identical to before; the routed path checks destination, enforces all five invariants from ADR 019 (destination check, TTL enforcement, source suppression, deduplication, no cross-delivery), and floods to all known peers except the sender via fire-and-forget relay tasks. `PathweaveNode` gains `send_routed()`, which builds the routed frame, assigns a message_id, and floods to all directly known peers.

To make the router available inside `accept_loop` (a long-lived spawned task), `Router` moves from `Vec<TransportEntry>` to `Mutex<Vec<TransportEntry>>` for interior mutability, allowing `PathweaveNode` to hold it as `Arc<Router>` and share it across tasks without `&mut` borrows.

`DeduplicationCache` gains a second index keyed on `message_id` alone for routed frames. The direct path continues to key on `(sender_peer_id, message_id)`. `Router::send` gains an `Option<u64>` parameter so relay tasks can pass the original `message_id` through; `None` generates a new ID, preserving existing call sites.

## Why

The current router is direct-only: if a peer is not reachable on any registered transport, delivery fails with `NoTransportAvailable` even when an intermediate node could bridge the gap. ADR 019 specifies TTL-limited flooding as the first mesh routing protocol for v0.3.0.

Closes #87.

## Alternatives considered

**`&mut Router` instead of `Arc<Router>`:** `accept_loop` is spawned as a `tokio::task`, which requires `'static` bounds on all captures. A mutable reference cannot satisfy `'static`. The only options are `Arc<Mutex<Router>>` or interior mutability on the fields that need shared access. Since only the transport registry needs mutation after construction, `Mutex<Vec<TransportEntry>>` on the one field that changes is the minimal change: the rest of `Router` stays immutable and the `Arc<Router>` is unboxed.

**`RouteContext` struct to bundle `Arc<Router>` + `local_peer_id`:** would have cleaned up the `accept_loop` and `handle_incoming` signatures. Rejected because both functions are private to `node.rs` and the struct would be visible only within that file. The `#[allow(clippy::too_many_arguments)]` attribute is a more honest signal that these are internal wiring functions, not public API.

**Dedup keyed on `(sender_peer_id, message_id)` for routed messages:** would not suppress duplicates arriving via different relay paths, because the immediate sender differs per path. The same frame from origin A, relayed by B1 and B2, arrives at C with different `sender_peer_id` values but the same `message_id`. ADR 019 invariant 4 requires keying on `message_id` alone. Collision risk is 1-in-2^63 per ADR 017, which is negligible.

**Route tables instead of flooding:** requires topology state that does not yet exist in the mesh. For the expected v0.3.0 deployment scale (fewer than twenty nodes), flooding with per-message dedup is correct by construction: every reachable node receives the message exactly once regardless of topology. ADR 019 documents the tradeoff in the Rationale section.

## Security considerations

TTL is clamped to 7 before decrementing at each relay. Without clamping, a malicious sender could inflate TTL and force O(N^TTL) relay copies across the mesh. The dedup cache bounds this further: each node forwards a given `message_id` at most once within the 60-second dedup window regardless of how many relay copies arrive.

The `dest_peer_id` in the routing header is not end-to-end authenticated by this layer; it is carried hop-to-hop inside Noise-encrypted sessions. A compromised relay can drop or misroute frames, but cannot forge origin identity: the Noise session between each pair of nodes authenticates the channel endpoints. End-to-end payload authentication is planned separately and is out of scope here (see issue #87 out-of-scope section).

## Test plan

- [x] `cargo test --workspace`: 51 tests pass, 0 failed
- [x] `cargo clippy --workspace -- -D warnings`: clean
- [x] `cargo fmt --check`: clean
- [x] Three-node relay test (`routed_message_delivered_via_relay`): A(Ble) → B(Ble+Quic) → C(Quic). A calls `send_routed(pid_c, payload)`. C receives the payload exactly once. B and A handlers do not fire.
- [x] TTL=0 drop test (`routed_message_ttl_zero_dropped_at_relay`): frame with TTL=0 injected directly via `router.send()`. C receives nothing after 200ms sleep.
- [x] Dedup test (`routed_message_deduplicated_across_two_relay_paths`): same `msg_id` injected from two senders with distinct PeerIds (simulating two relay paths). C delivers exactly once.
- [x] Five unit tests for `DeduplicationCache::check_and_insert_routed` covering: first insert returns false, second insert same id returns true, different id returns false, re-deliverable after TTL expires, independent of direct dedup cache.