### PR TITLE
feat(node): store-and-forward queues with drain-on-reconnect delivery

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -6,6 +6,7 @@ use bytes::Bytes;
 use futures::stream::{self, BoxStream};
 use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 
 pub mod bundle;
 pub use bundle::BundleLayer;
@@ -239,6 +240,11 @@ pub enum TransportEvent {
         peer_id: PeerId,
         transport: TransportKind,
     },
+    /// Fired once per store_forward or store_forward_routed entry that expires before
+    /// the destination is reached. See ADR 021.
+    StoreFailed {
+        peer_id: PeerId,
+    },
 }
 
 pub trait MessageHandler: Send + Sync {
@@ -301,4 +307,7 @@ pub(crate) fn new_peer_table() -> PeerTable {
 #[derive(Default)]
 pub struct NodeConfig {
     pub listen_port: Option<u16>,
+    /// How long to hold a payload in the store-and-forward queue before expiring it.
+    /// `None` uses the 24-hour default. See ADR 021.
+    pub store_ttl: Option<Duration>,
 }

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -1,11 +1,11 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use bytes::Bytes;
 use futures::stream::BoxStream;
 
-use tokio::sync::watch;
+use tokio::sync::{broadcast, watch};
 
 use crate::{
     new_key_registry, new_peer_table, router, BundleLayer, Connection, KeyRegistry, MessageHandler,
@@ -16,6 +16,13 @@ use crate::{
 const MAX_TTL: u8 = 7;
 
 const DEDUP_TTL: Duration = Duration::from_secs(60);
+
+const STORE_TTL_DEFAULT: Duration = Duration::from_secs(86_400); // 24 hours
+
+/// (msg_id, app_payload, queued_at). msg_id is assigned at enqueue and reused on every
+/// drain attempt so the receiver's DeduplicationCache can suppress retried deliveries.
+/// See ADR 021.
+type PendingStore = Arc<Mutex<HashMap<PeerId, VecDeque<(u64, Vec<u8>, Instant)>>>>;
 
 /// Tracks recently seen (PeerId, message_id) pairs to suppress duplicate deliveries.
 ///
@@ -109,20 +116,59 @@ pub struct PathweaveNode {
     handler: Arc<Mutex<Option<Box<dyn MessageHandler>>>>,
     dedup: Arc<Mutex<DeduplicationCache>>,
     key_registry: KeyRegistry,
+    store_ttl: Duration,
+    pending_direct: PendingStore,
+    pending_routed: PendingStore,
 }
 
 impl PathweaveNode {
-    /// Creates a new node. `config` is accepted but unused until transport
-    /// implementations are complete; callers should pass `NodeConfig::default()` for now.
-    pub async fn new(_config: NodeConfig, identity: NodeIdentity) -> Result<Self> {
+    pub async fn new(config: NodeConfig, identity: NodeIdentity) -> Result<Self> {
+        let store_ttl = config.store_ttl.unwrap_or(STORE_TTL_DEFAULT);
+        let router = Arc::new(Router::new());
+        let peers = new_peer_table();
+        let key_registry = new_key_registry();
+        let pending_direct: PendingStore = Arc::new(Mutex::new(HashMap::new()));
+        let pending_routed: PendingStore = Arc::new(Mutex::new(HashMap::new()));
+
+        // Drain queued payloads whenever a PeerConnected event arrives from discovery.
+        // connect() and add_peer() trigger drains directly; this task covers the
+        // peer_stream (automatic discovery) path. Exits when the broadcast channel closes.
+        {
+            let mut event_rx = router.event_tx().subscribe();
+            let pd = Arc::clone(&pending_direct);
+            let pr = Arc::clone(&pending_routed);
+            let p = Arc::clone(&peers);
+            let id = identity.clone();
+            let kr = Arc::clone(&key_registry);
+            let r = Arc::clone(&router);
+            let etx = router.event_tx();
+            tokio::spawn(async move {
+                loop {
+                    match event_rx.recv().await {
+                        Ok(TransportEvent::PeerConnected(peer_id)) => {
+                            drain_direct_for_peer(&peer_id, &pd, &p, &id, &kr, &r, store_ttl, &etx)
+                                .await;
+                            drain_routed_all(&pr, &p, &id, &kr, &r, store_ttl, &etx).await;
+                        }
+                        Ok(_) => {}
+                        Err(broadcast::error::RecvError::Closed) => break,
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    }
+                }
+            });
+        }
+
         Ok(Self {
-            router: Arc::new(Router::new()),
+            router,
             identity,
-            peers: new_peer_table(),
+            peers,
             known_addrs: Arc::new(Mutex::new(HashSet::new())),
             handler: Arc::new(Mutex::new(None)),
             dedup: Arc::new(Mutex::new(DeduplicationCache::new())),
-            key_registry: new_key_registry(),
+            key_registry,
+            store_ttl,
+            pending_direct,
+            pending_routed,
         })
     }
 
@@ -186,11 +232,37 @@ impl PathweaveNode {
             .lock()
             .unwrap()
             .insert(announcement.address.clone());
-        let mut peers = self.peers.lock().unwrap();
-        let addrs = peers.entry(peer_id.clone()).or_default();
-        if !addrs.iter().any(|a| a.address == announcement.address) {
-            addrs.push(announcement);
+        {
+            let mut peers = self.peers.lock().unwrap();
+            let addrs = peers.entry(peer_id.clone()).or_default();
+            if !addrs.iter().any(|a| a.address == announcement.address) {
+                addrs.push(announcement);
+            }
         }
+
+        let event_tx = self.router.event_tx();
+        drain_direct_for_peer(
+            &peer_id,
+            &self.pending_direct,
+            &self.peers,
+            &self.identity,
+            &self.key_registry,
+            &self.router,
+            self.store_ttl,
+            &event_tx,
+        )
+        .await;
+        drain_routed_all(
+            &self.pending_routed,
+            &self.peers,
+            &self.identity,
+            &self.key_registry,
+            &self.router,
+            self.store_ttl,
+            &event_tx,
+        )
+        .await;
+
         Ok(peer_id)
     }
 
@@ -203,11 +275,45 @@ impl PathweaveNode {
             .lock()
             .unwrap()
             .insert(announcement.address.clone());
-        let mut peers = self.peers.lock().unwrap();
-        let addrs = peers.entry(peer_id).or_default();
-        if !addrs.iter().any(|a| a.address == announcement.address) {
-            addrs.push(announcement);
+        {
+            let mut peers = self.peers.lock().unwrap();
+            let addrs = peers.entry(peer_id.clone()).or_default();
+            if !addrs.iter().any(|a| a.address == announcement.address) {
+                addrs.push(announcement);
+            }
         }
+
+        let pd = Arc::clone(&self.pending_direct);
+        let pr = Arc::clone(&self.pending_routed);
+        let peers = Arc::clone(&self.peers);
+        let identity = self.identity.clone();
+        let key_registry = Arc::clone(&self.key_registry);
+        let router = Arc::clone(&self.router);
+        let store_ttl = self.store_ttl;
+        let event_tx = self.router.event_tx();
+        tokio::spawn(async move {
+            drain_direct_for_peer(
+                &peer_id,
+                &pd,
+                &peers,
+                &identity,
+                &key_registry,
+                &router,
+                store_ttl,
+                &event_tx,
+            )
+            .await;
+            drain_routed_all(
+                &pr,
+                &peers,
+                &identity,
+                &key_registry,
+                &router,
+                store_ttl,
+                &event_tx,
+            )
+            .await;
+        });
     }
 
     /// Sends `payload` to the peer identified by `peer_id`.
@@ -298,6 +404,111 @@ impl PathweaveNode {
         }
     }
 
+    /// Accepts `payload` for deferred delivery to `peer_id` and returns immediately.
+    ///
+    /// If the peer is already reachable, delivery is attempted right away using the same
+    /// path as `send()`. On success the payload is gone. On failure, or if the peer is
+    /// not yet in the peer table, the payload is queued. It drains when the peer next
+    /// appears via discovery, `connect()`, or `add_peer()`.
+    ///
+    /// Entries that remain undelivered past `NodeConfig::store_ttl` are expired with a
+    /// `TransportEvent::StoreFailed` event. See ADR 021.
+    pub async fn store_forward(&self, peer_id: PeerId, payload: Vec<u8>) {
+        let msg_id = router::new_message_id();
+        let queued_at = Instant::now();
+
+        let announcements = self.peers.lock().unwrap().get(&peer_id).cloned();
+        if let Some(anns) = announcements {
+            if !anns.is_empty() {
+                let mut framed = Vec::with_capacity(1 + payload.len());
+                framed.push(0x00);
+                framed.extend_from_slice(&payload);
+                if self
+                    .router
+                    .send(
+                        &anns,
+                        &self.identity,
+                        framed,
+                        &peer_id,
+                        &self.key_registry,
+                        &self.peers,
+                        Some(msg_id),
+                    )
+                    .await
+                    .is_ok()
+                {
+                    return;
+                }
+            }
+        }
+
+        self.pending_direct
+            .lock()
+            .unwrap()
+            .entry(peer_id)
+            .or_default()
+            .push_back((msg_id, payload, queued_at));
+    }
+
+    /// Accepts `payload` for deferred mesh delivery to `dest_peer_id` and returns immediately.
+    ///
+    /// If any neighbor is reachable, the payload is flooded immediately (same as `send_routed`).
+    /// If no neighbors are reachable, the payload is queued and flooded when any neighbor next
+    /// appears. Delivery is confirmed at the neighbor level only; no end-to-end confirmation.
+    ///
+    /// Entries expire the same way as `store_forward`. See ADR 021.
+    pub async fn store_forward_routed(&self, dest_peer_id: PeerId, payload: Vec<u8>) {
+        let msg_id = router::new_message_id();
+        let queued_at = Instant::now();
+
+        let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = self
+            .peers
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(pid, _)| **pid != *self.identity.peer_id())
+            .map(|(pid, anns)| (pid.clone(), anns.clone()))
+            .collect();
+
+        if !neighbors.is_empty() {
+            let mut frame_body = Vec::with_capacity(1 + 32 + 1 + payload.len());
+            frame_body.push(0x01);
+            frame_body.extend_from_slice(dest_peer_id.as_bytes());
+            frame_body.push(MAX_TTL);
+            frame_body.extend_from_slice(&payload);
+
+            let mut any_ok = false;
+            for (neighbor_id, anns) in &neighbors {
+                if self
+                    .router
+                    .send(
+                        anns,
+                        &self.identity,
+                        frame_body.clone(),
+                        neighbor_id,
+                        &self.key_registry,
+                        &self.peers,
+                        Some(msg_id),
+                    )
+                    .await
+                    .is_ok()
+                {
+                    any_ok = true;
+                }
+            }
+            if any_ok {
+                return;
+            }
+        }
+
+        self.pending_routed
+            .lock()
+            .unwrap()
+            .entry(dest_peer_id)
+            .or_default()
+            .push_back((msg_id, payload, queued_at));
+    }
+
     /// Registers a handler that will be called for each incoming message.
     ///
     /// The accept loop is spawned per transport in register_transport(). Transports
@@ -318,6 +529,165 @@ impl PathweaveNode {
     /// and future E2E hop encryption. See ADR 020.
     pub fn lookup_key(&self, peer_id: &PeerId) -> Option<[u8; 32]> {
         self.key_registry.lock().unwrap().get(peer_id).copied()
+    }
+}
+
+/// Drains the direct pending queue for `peer_id`.
+///
+/// Removes all entries atomically under the lock, sends each live entry, and
+/// re-prepends failures to preserve FIFO order. Expired entries fire StoreFailed.
+/// A concurrent drain finds the queue empty and is a no-op. See ADR 021.
+#[allow(clippy::too_many_arguments)]
+async fn drain_direct_for_peer(
+    peer_id: &PeerId,
+    pending_direct: &PendingStore,
+    peers: &PeerTable,
+    identity: &NodeIdentity,
+    key_registry: &KeyRegistry,
+    router: &Arc<Router>,
+    store_ttl: Duration,
+    event_tx: &broadcast::Sender<TransportEvent>,
+) {
+    let entries: Vec<(u64, Vec<u8>, Instant)> = {
+        let mut store = pending_direct.lock().unwrap();
+        match store.remove(peer_id) {
+            Some(q) => q.into_iter().collect(),
+            None => return,
+        }
+    };
+
+    let now = Instant::now();
+    let announcements = peers
+        .lock()
+        .unwrap()
+        .get(peer_id)
+        .cloned()
+        .unwrap_or_default();
+
+    let mut failures: VecDeque<(u64, Vec<u8>, Instant)> = VecDeque::new();
+    for (msg_id, app_payload, queued_at) in entries {
+        if now.saturating_duration_since(queued_at) > store_ttl {
+            let _ = event_tx.send(TransportEvent::StoreFailed {
+                peer_id: peer_id.clone(),
+            });
+            continue;
+        }
+        if announcements.is_empty() {
+            failures.push_back((msg_id, app_payload, queued_at));
+            continue;
+        }
+        let mut framed = Vec::with_capacity(1 + app_payload.len());
+        framed.push(0x00);
+        framed.extend_from_slice(&app_payload);
+        match router
+            .send(
+                &announcements,
+                identity,
+                framed,
+                peer_id,
+                key_registry,
+                peers,
+                Some(msg_id),
+            )
+            .await
+        {
+            Ok(()) => {}
+            Err(_) => failures.push_back((msg_id, app_payload, queued_at)),
+        }
+    }
+
+    if !failures.is_empty() {
+        let mut store = pending_direct.lock().unwrap();
+        let queue = store.entry(peer_id.clone()).or_default();
+        for entry in failures.into_iter().rev() {
+            queue.push_front(entry);
+        }
+    }
+}
+
+/// Drains the routed pending queue for every destination.
+///
+/// Any available neighbor is used as the next hop; routed delivery is confirmed at the
+/// neighbor level only. Failed entries are re-prepended to preserve FIFO order.
+/// Expired entries fire StoreFailed. See ADR 021.
+#[allow(clippy::too_many_arguments)]
+async fn drain_routed_all(
+    pending_routed: &PendingStore,
+    peers: &PeerTable,
+    identity: &NodeIdentity,
+    key_registry: &KeyRegistry,
+    router: &Arc<Router>,
+    store_ttl: Duration,
+    event_tx: &broadcast::Sender<TransportEvent>,
+) {
+    let dest_ids: Vec<PeerId> = pending_routed.lock().unwrap().keys().cloned().collect();
+
+    for dest_peer_id in dest_ids {
+        let entries: Vec<(u64, Vec<u8>, Instant)> = {
+            let mut store = pending_routed.lock().unwrap();
+            match store.remove(&dest_peer_id) {
+                Some(q) => q.into_iter().collect(),
+                None => continue,
+            }
+        };
+
+        let now = Instant::now();
+        let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(pid, _)| **pid != *identity.peer_id())
+            .map(|(pid, anns)| (pid.clone(), anns.clone()))
+            .collect();
+
+        let mut failures: VecDeque<(u64, Vec<u8>, Instant)> = VecDeque::new();
+        for (msg_id, app_payload, queued_at) in entries {
+            if now.saturating_duration_since(queued_at) > store_ttl {
+                let _ = event_tx.send(TransportEvent::StoreFailed {
+                    peer_id: dest_peer_id.clone(),
+                });
+                continue;
+            }
+            if neighbors.is_empty() {
+                failures.push_back((msg_id, app_payload, queued_at));
+                continue;
+            }
+            let mut frame_body = Vec::with_capacity(1 + 32 + 1 + app_payload.len());
+            frame_body.push(0x01);
+            frame_body.extend_from_slice(dest_peer_id.as_bytes());
+            frame_body.push(MAX_TTL);
+            frame_body.extend_from_slice(&app_payload);
+
+            let mut any_ok = false;
+            for (neighbor_id, anns) in &neighbors {
+                if router
+                    .send(
+                        anns,
+                        identity,
+                        frame_body.clone(),
+                        neighbor_id,
+                        key_registry,
+                        peers,
+                        Some(msg_id),
+                    )
+                    .await
+                    .is_ok()
+                {
+                    any_ok = true;
+                }
+            }
+            if !any_ok {
+                failures.push_back((msg_id, app_payload, queued_at));
+            }
+        }
+
+        if !failures.is_empty() {
+            let mut store = pending_routed.lock().unwrap();
+            let queue = store.entry(dest_peer_id.clone()).or_default();
+            for entry in failures.into_iter().rev() {
+                queue.push_front(entry);
+            }
+        }
     }
 }
 
@@ -1529,5 +1899,370 @@ mod tests {
             1,
             "invariant 4: routed message delivered exactly once despite two distinct sender paths"
         );
+    }
+
+    // --- store_forward tests -------------------------------------------------
+
+    fn ble_ann(addr: &str) -> PeerAnnouncement {
+        PeerAnnouncement {
+            address: PeerAddress::Ble(addr.into()),
+            short_id: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn store_forward_delivers_immediately_when_peer_known() {
+        let (t_sender, t_receiver) = wire_transports(TransportKind::Ble);
+
+        let sender_id = NodeIdentity::generate();
+        let receiver_id = NodeIdentity::generate();
+        let pid_receiver = receiver_id.peer_id().clone();
+
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+
+        struct RecordingHandler {
+            done_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>>,
+        }
+        impl MessageHandler for RecordingHandler {
+            fn on_message(&self, _peer_id: PeerId, payload: Vec<u8>) {
+                if let Some(tx) = self.done_tx.lock().unwrap().take() {
+                    let _ = tx.send(payload);
+                }
+            }
+        }
+
+        let mut node_sender = PathweaveNode::new(NodeConfig::default(), sender_id)
+            .await
+            .unwrap();
+        node_sender.register_transport(Box::new(t_sender));
+        node_sender.add_peer(pid_receiver.clone(), ble_ann("receiver"));
+
+        let mut node_receiver = PathweaveNode::new(NodeConfig::default(), receiver_id)
+            .await
+            .unwrap();
+        node_receiver.register_transport(Box::new(t_receiver));
+        node_receiver.on_message(Box::new(RecordingHandler {
+            done_tx: Arc::clone(&done_tx),
+        }));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        // Peer is already in the table, so store_forward delivers immediately.
+        node_sender
+            .store_forward(pid_receiver, b"immediate".to_vec())
+            .await;
+
+        let payload = tokio::time::timeout(tokio::time::Duration::from_secs(5), done_rx)
+            .await
+            .expect("timed out")
+            .unwrap();
+        assert_eq!(payload, b"immediate");
+    }
+
+    #[tokio::test]
+    async fn store_forward_queues_and_delivers_on_add_peer() {
+        let (t_sender, t_receiver) = wire_transports(TransportKind::Ble);
+
+        let sender_id = NodeIdentity::generate();
+        let receiver_id = NodeIdentity::generate();
+        let pid_receiver = receiver_id.peer_id().clone();
+
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+
+        struct RecordingHandler {
+            done_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>>,
+        }
+        impl MessageHandler for RecordingHandler {
+            fn on_message(&self, _peer_id: PeerId, payload: Vec<u8>) {
+                if let Some(tx) = self.done_tx.lock().unwrap().take() {
+                    let _ = tx.send(payload);
+                }
+            }
+        }
+
+        let mut node_sender = PathweaveNode::new(NodeConfig::default(), sender_id)
+            .await
+            .unwrap();
+        node_sender.register_transport(Box::new(t_sender));
+
+        let mut node_receiver = PathweaveNode::new(NodeConfig::default(), receiver_id)
+            .await
+            .unwrap();
+        node_receiver.register_transport(Box::new(t_receiver));
+        node_receiver.on_message(Box::new(RecordingHandler {
+            done_tx: Arc::clone(&done_tx),
+        }));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        // Peer not yet in the table: queued.
+        node_sender
+            .store_forward(pid_receiver.clone(), b"queued delivery".to_vec())
+            .await;
+
+        // Verify payload sits in the queue.
+        assert!(node_sender
+            .pending_direct
+            .lock()
+            .unwrap()
+            .contains_key(&pid_receiver));
+
+        // add_peer triggers the drain.
+        node_sender.add_peer(pid_receiver.clone(), ble_ann("receiver"));
+
+        let payload = tokio::time::timeout(tokio::time::Duration::from_secs(5), done_rx)
+            .await
+            .expect("timed out waiting for store_forward delivery")
+            .unwrap();
+        assert_eq!(payload, b"queued delivery");
+    }
+
+    #[tokio::test]
+    async fn store_forward_queues_and_delivers_on_connect() {
+        let (t_sender, t_receiver) = wire_transports(TransportKind::Ble);
+
+        let sender_id = NodeIdentity::generate();
+        let receiver_id = NodeIdentity::generate();
+        let pid_receiver = receiver_id.peer_id().clone();
+
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+
+        struct RecordingHandler {
+            done_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<Vec<u8>>>>>,
+        }
+        impl MessageHandler for RecordingHandler {
+            fn on_message(&self, _peer_id: PeerId, payload: Vec<u8>) {
+                if let Some(tx) = self.done_tx.lock().unwrap().take() {
+                    let _ = tx.send(payload);
+                }
+            }
+        }
+
+        let mut node_sender = PathweaveNode::new(NodeConfig::default(), sender_id)
+            .await
+            .unwrap();
+        node_sender.register_transport(Box::new(t_sender));
+
+        let mut node_receiver = PathweaveNode::new(NodeConfig::default(), receiver_id)
+            .await
+            .unwrap();
+        node_receiver.register_transport(Box::new(t_receiver));
+        node_receiver.on_message(Box::new(RecordingHandler {
+            done_tx: Arc::clone(&done_tx),
+        }));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        // Peer not yet in the table: queued.
+        node_sender
+            .store_forward(pid_receiver.clone(), b"connect delivery".to_vec())
+            .await;
+
+        // connect() completes the handshake and triggers the drain.
+        node_sender.connect(ble_ann("receiver")).await.unwrap();
+
+        let payload = tokio::time::timeout(tokio::time::Duration::from_secs(5), done_rx)
+            .await
+            .expect("timed out waiting for store_forward delivery after connect")
+            .unwrap();
+        assert_eq!(payload, b"connect delivery");
+    }
+
+    #[tokio::test]
+    async fn store_forward_fifo_order_preserved() {
+        let (t_sender, t_receiver) = wire_transports(TransportKind::Ble);
+
+        let sender_id = NodeIdentity::generate();
+        let receiver_id = NodeIdentity::generate();
+        let pid_receiver = receiver_id.peer_id().clone();
+
+        let received = Arc::new(Mutex::new(Vec::<Vec<u8>>::new()));
+        let (done_tx, done_rx) = tokio::sync::oneshot::channel::<()>();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+        let received_clone = Arc::clone(&received);
+
+        struct OrderHandler {
+            received: Arc<Mutex<Vec<Vec<u8>>>>,
+            done_tx: Arc<Mutex<Option<tokio::sync::oneshot::Sender<()>>>>,
+        }
+        impl MessageHandler for OrderHandler {
+            fn on_message(&self, _peer_id: PeerId, payload: Vec<u8>) {
+                let mut r = self.received.lock().unwrap();
+                r.push(payload);
+                if r.len() == 3 {
+                    if let Some(tx) = self.done_tx.lock().unwrap().take() {
+                        let _ = tx.send(());
+                    }
+                }
+            }
+        }
+
+        let mut node_sender = PathweaveNode::new(NodeConfig::default(), sender_id)
+            .await
+            .unwrap();
+        node_sender.register_transport(Box::new(t_sender));
+
+        let mut node_receiver = PathweaveNode::new(NodeConfig::default(), receiver_id)
+            .await
+            .unwrap();
+        node_receiver.register_transport(Box::new(t_receiver));
+        node_receiver.on_message(Box::new(OrderHandler {
+            received: Arc::clone(&received_clone),
+            done_tx: Arc::clone(&done_tx),
+        }));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        node_sender
+            .store_forward(pid_receiver.clone(), b"first".to_vec())
+            .await;
+        node_sender
+            .store_forward(pid_receiver.clone(), b"second".to_vec())
+            .await;
+        node_sender
+            .store_forward(pid_receiver.clone(), b"third".to_vec())
+            .await;
+
+        node_sender.add_peer(pid_receiver, ble_ann("receiver"));
+
+        tokio::time::timeout(tokio::time::Duration::from_secs(5), done_rx)
+            .await
+            .expect("timed out waiting for three deliveries")
+            .unwrap();
+
+        let r = received.lock().unwrap();
+        assert_eq!(
+            *r,
+            vec![b"first".to_vec(), b"second".to_vec(), b"third".to_vec()]
+        );
+    }
+
+    #[tokio::test]
+    async fn store_forward_fires_store_failed_on_expiry() {
+        let sender_id = NodeIdentity::generate();
+        let unknown_peer = NodeIdentity::generate().peer_id().clone();
+
+        let config = NodeConfig {
+            store_ttl: Some(Duration::from_millis(10)),
+            ..NodeConfig::default()
+        };
+        let mut node = PathweaveNode::new(config, sender_id).await.unwrap();
+
+        // Subscribe before queuing so we don't miss the event.
+        let mut event_rx = node.router.event_tx().subscribe();
+
+        node.store_forward(unknown_peer.clone(), b"will expire".to_vec())
+            .await;
+
+        // Wait past the TTL.
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+
+        // add_peer triggers the drain; the expired check fires StoreFailed before
+        // attempting delivery, even though an announcement is now in the table.
+        node.add_peer(unknown_peer.clone(), ble_ann("unknown"));
+
+        let event = tokio::time::timeout(tokio::time::Duration::from_secs(2), async {
+            loop {
+                match event_rx.recv().await {
+                    Ok(ev @ TransportEvent::StoreFailed { .. }) => return ev,
+                    Ok(_) => continue,
+                    Err(_) => panic!("broadcast channel closed"),
+                }
+            }
+        })
+        .await
+        .expect("timed out waiting for StoreFailed");
+
+        assert!(
+            matches!(event, TransportEvent::StoreFailed { peer_id } if peer_id == unknown_peer)
+        );
+    }
+
+    #[tokio::test]
+    async fn store_forward_routed_delivers_immediately_when_neighbor_known() {
+        let (t_a, t_b) = wire_transports(TransportKind::Ble);
+
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+        let pid_b = id_b.peer_id().clone();
+        let pid_c = id_c.peer_id().clone();
+
+        let mut node_a = PathweaveNode::new(NodeConfig::default(), id_a)
+            .await
+            .unwrap();
+        node_a.register_transport(Box::new(t_a));
+        node_a.add_peer(pid_b.clone(), ble_ann("b"));
+
+        // B accepts the relay frame; no handler needed for this assertion.
+        let mut node_b = PathweaveNode::new(NodeConfig::default(), id_b)
+            .await
+            .unwrap();
+        node_b.register_transport(Box::new(t_b));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        // B is a neighbor. store_forward_routed should flood immediately and leave
+        // nothing in the queue.
+        node_a
+            .store_forward_routed(pid_c.clone(), b"routed immediate".to_vec())
+            .await;
+
+        assert!(node_a.pending_routed.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn store_forward_routed_queues_and_delivers_on_peer_added() {
+        let (t_a, t_b) = wire_transports(TransportKind::Ble);
+
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+        let pid_b = id_b.peer_id().clone();
+        let pid_c = id_c.peer_id().clone();
+
+        // B just needs to accept the frame; no handler needed for this test.
+        let mut node_a = PathweaveNode::new(NodeConfig::default(), id_a)
+            .await
+            .unwrap();
+        node_a.register_transport(Box::new(t_a));
+
+        let mut node_b = PathweaveNode::new(NodeConfig::default(), id_b)
+            .await
+            .unwrap();
+        node_b.register_transport(Box::new(t_b));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        // No neighbors yet: queued.
+        node_a
+            .store_forward_routed(pid_c.clone(), b"routed queued".to_vec())
+            .await;
+
+        assert!(node_a.pending_routed.lock().unwrap().contains_key(&pid_c));
+
+        // Adding B as a neighbor triggers the drain.
+        node_a.add_peer(pid_b, ble_ann("b"));
+
+        // Give the spawned drain task time to run.
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        // Queue must be empty after the drain.
+        assert!(node_a.pending_routed.lock().unwrap().is_empty());
     }
 }

--- a/notes/architecture/ARCHITECTURE.md
+++ b/notes/architecture/ARCHITECTURE.md
@@ -59,8 +59,8 @@ the previous.
 
 ## The public API
 
-The public API has seven surfaces: four exposed through UniFFI to Swift and Kotlin,
-three Rust-only methods that are not part of the FFI boundary.
+The public API has ten surfaces: four exposed through UniFFI to Swift and Kotlin,
+six Rust-only methods that are not part of the FFI boundary.
 
 **UniFFI-facing (four):**
 
@@ -78,7 +78,7 @@ node.on_message(handler); // handler implements MessageHandler (see below)
 let mut events = node.events(); // Stream<Item = TransportEvent>
 ```
 
-**Rust-only (four, not in the UDL):**
+**Rust-only (six, not in the UDL):**
 
 ```rust
 // register a transport before first use
@@ -94,6 +94,14 @@ node.add_peer(peer_id, announcement);
 // send a message via mesh routing to a peer that may not be directly reachable
 // floods to all known neighbors with TTL=7; intermediate nodes relay until dest receives
 node.send_routed(peer_id, payload).await?;
+
+// accept payload now, deliver when the specific peer is next reachable
+// returns immediately; delivery fires MessageDelivered on the event stream
+node.store_forward(peer_id, payload).await;
+
+// accept payload now, flood to the mesh when any neighbor is next reachable
+// returns immediately; no end-to-end confirmation (same guarantee as send_routed)
+node.store_forward_routed(dest_peer_id, payload).await;
 ```
 
 `connect()` tries transports in cost order (Free first). It returns the PeerId learned
@@ -128,6 +136,9 @@ pub enum TransportEvent {
     MessageDelivered {
         peer_id: PeerId,
         transport: TransportKind,
+    },
+    StoreFailed {
+        peer_id: PeerId,  // destination that was never reached before the TTL expired
     },
 }
 
@@ -612,6 +623,30 @@ fail, `send()` returns `PathweaveError::DeliveryFailed`. When no transport can r
 peer at all, `send()` returns `PathweaveError::NoTransportAvailable` immediately. No
 silent queuing.
 
+**Store-and-forward delivery**
+
+`store_forward(peer_id, payload)` and `store_forward_routed(dest_peer_id, payload)` are
+the explicit, caller-opt-in alternative. Both return immediately. The payload is held in
+an in-memory queue until a delivery path is available.
+
+`store_forward` drains when the specific peer next appears: via `PeerConnected`, a
+successful `connect()`, or `add_peer()`. The drain calls `router.send()` with the same
+message ID that was assigned at enqueue time. This is required for dedup correctness: if
+a drain attempt delivers the payload but the ACK is lost, the next attempt carries the
+same ID and the receiver's `DeduplicationCache` suppresses the duplicate. See ADR 021.
+
+`store_forward_routed` drains when any neighbor appears, flooding to the mesh the same
+way `send_routed()` does. It does not wait for the specific destination. Delivery
+confirmation is neighbor-acceptance only, matching `send_routed`.
+
+Entries expire after `NodeConfig::store_ttl` (default: 24 hours). On expiry,
+`TransportEvent::StoreFailed { peer_id }` fires once per expired entry. Expiry is checked
+lazily when the drain runs; if no neighbors ever appear, the drain never runs and
+`StoreFailed` never fires.
+
+Both queues are in-memory. A process restart drops all pending payloads. There is no
+persistence across restarts in this version.
+
 ---
 
 ## Servers
@@ -641,7 +676,7 @@ local networks. BLE discovery is automatic: the transport scans for the Pathweav
 UUID and connects without configuration.
 
 When neither transport can reach the peer: "message failed: no transport available."
-No queuing, no silent retry.
+`send()` does not queue or silently retry. Use `store_forward` if you need hold-and-deliver.
 
 BLE in pw-chat works when at least one peer can advertise. Supported configurations:
 two Linux machines, a Linux or Windows machine and a macOS machine, or any combination

--- a/notes/decisions/021-store-and-forward.md
+++ b/notes/decisions/021-store-and-forward.md
@@ -1,0 +1,149 @@
+# ADR 021: Store-and-forward for direct and mesh delivery
+
+**Status:** Accepted
+
+## Context
+
+`send()` and `send_routed()` are fail-fast. If the destination is not reachable when
+you call them, you get an error back immediately. That is the right behaviour for a chat
+message you are typing right now. It is the wrong behaviour when a node needs to hand
+off a payload before it knows whether the destination is reachable.
+
+Pathweave targets disconnected-intermittent networks: devices that are offline more than
+they are online, that come into range briefly, that forward messages on behalf of people
+who will never share a direct link. BPv7 was designed for exactly this kind of network.
+The bundle layer is already there. What was missing was the hold-and-deliver logic above
+it.
+
+`store_forward(peer_id, payload)` and `store_forward_routed(dest_peer_id, payload)` fill
+this gap. Both accept the payload immediately and return. Delivery happens when the
+conditions are right: a direct path for the first, any neighbor for the second. Payloads
+that never find a path expire after `store_ttl` with a `StoreFailed` event.
+
+## Decision
+
+### Two separate queues
+
+We keep a direct queue and a routed queue on `PathweaveNode`. Both are
+`Arc<Mutex<HashMap<PeerId, VecDeque<(u64, Vec<u8>, Instant)>>>>`. Each entry is
+`(msg_id, app_payload, queued_at)`. The msg_id is generated at enqueue time and reused
+on every drain attempt.
+
+Separating the queues makes the drain logic easier to reason about. The drain triggers
+are different, the send functions are different, and the delivery confirmation semantics
+are different. A unified queue with a type flag would save one field but it would make
+the drain paths harder to follow.
+
+### Message ID generated at enqueue time, not at drain time
+
+This is the most important invariant. The same msg_id is used for every attempt to
+deliver a given queued payload, including the first immediate attempt if the peer is
+already reachable.
+
+The reason is the same as ADR 011: if a send delivers the payload but the ACK is lost,
+the drain retries with the same msg_id. The receiver's `DeduplicationCache` sees a key
+it already knows and suppresses the second delivery. If we generated a fresh msg_id on
+each drain attempt, a lost-ACK retry would look like a new message and the receiver
+would deliver it twice.
+
+### ACK-based removal with re-queue on failure
+
+Entries are removed from the queue only after `router.send()` returns `Ok(())`. That
+return value means the ACK round-trip completed: the receiver confirmed delivery. We do
+not remove optimistically and re-add on failure because that approach has a race: two
+concurrent drains triggered by near-simultaneous events (say `PeerConnected` and
+`connect()` returning at the same moment) would both see the same entries. With drain-
+then-re-queue, the first drain empties the queue atomically under the lock. The second
+drain arrives and finds nothing.
+
+Failed entries are collected and prepended back to the front of the queue after all
+sends in the batch complete, before any new entries that arrived during the drain. FIFO
+order is preserved.
+
+Re-queueing does not create an infinite retry loop because the drain is event-driven.
+It runs when a peer appears, not on a ticker. If every send in a drain batch fails, the
+entries sit in the queue until the next `PeerConnected` event, `connect()`, or
+`add_peer()` call.
+
+### Drain triggers
+
+**Direct queue:** drains for the specific `peer_id` when:
+- `PeerConnected(peer_id)` fires on the background event-watcher task
+- `PathweaveNode::connect()` succeeds and returns that peer_id
+- `PathweaveNode::add_peer()` is called with that peer_id (spawns a task)
+
+The direct drain looks up the peer's announcements from the peer table. `peer_stream`
+inserts the peer into the table before firing `PeerConnected`, so the announcements are
+guaranteed to be there when the event-watcher task reacts.
+
+**Routed queue:** drains for ALL pending destinations when any of the same three
+triggers fire. Any new neighbor is a potential relay. We do not wait for the specific
+destination to appear; we flood to every available neighbor and let the mesh carry it.
+
+### Delivery confirmation semantics differ
+
+For direct delivery: `router.send()` returning `Ok(())` means the ACK completed and the
+destination received the payload. This is the same guarantee as `send()`.
+
+For routed delivery: `router.send()` returns `Ok(())` when one neighbor accepted the
+frame for relay. That is the same guarantee as `send_routed()`. We do not know whether
+the destination ever received it. The entry is removed from the routed queue when one
+neighbor accepts. This is documented behaviour, not a bug.
+
+### TTL in NodeConfig, not per call
+
+`NodeConfig::store_ttl: Option<Duration>` with `None` defaulting to 24 hours. This
+keeps `store_forward` and `store_forward_routed` signatures simple: no TTL parameter.
+The 24-hour default fits most real scenarios (offline contacts, intermittent gateways,
+disaster relief relays). Applications that need shorter or longer windows set
+`store_ttl` on the config they pass to `PathweaveNode::new()`.
+
+We deliberately do not mirror `BUNDLE_LIFETIME` (1 hour) from `bundle.rs`. That
+constant governs how long a BPv7 bundle lives on a single connection. How long we are
+willing to carry a message for an absent peer is a different question.
+
+### StoreFailed event
+
+`TransportEvent::StoreFailed { peer_id: PeerId }` fires once per expired entry, for
+both queues. The existing `Some(_)` catch-all in pw-chat absorbs it without changes.
+Expiry is checked lazily when the drain runs: before attempting any sends, we split the
+queue into expired entries (fire `StoreFailed` for each) and live entries (attempt
+delivery).
+
+## Rationale for alternatives rejected
+
+**Single unified queue with a routing-mode flag.** Avoids one field on
+`PathweaveNode`, but the drain code needs to branch on the flag anyway. Two queues with
+two clear drain functions are easier to test and audit independently.
+
+**Per-call TTL parameter.** Adds an argument to `store_forward` and
+`store_forward_routed`. The common case does not need it. Callers who need a custom
+window set `NodeConfig::store_ttl`. A per-call override can be added later if demand
+appears.
+
+**Drain the routed queue only when the specific destination appears.** This would give
+stronger delivery semantics but defeats the purpose of mesh routing. The whole point is
+that we do not need a direct path to the destination.
+
+**Fire `StoreFailed` on a background ticker rather than lazily at drain time.** A ticker
+would fire expiry events closer to the actual expiry moment. The trade-off is a
+permanent background task that holds Arcs indefinitely even when the queues are empty.
+Lazy eviction at drain time is simpler and the precision difference does not matter in
+practice.
+
+## Implications
+
+**No queue size bound.** Memory grows linearly with enqueue rate if the destination
+never appears. Callers are responsible for rate-limiting. A bound can be added later.
+
+**No persistence across restarts.** Both queues are in-memory. A process restart drops
+all pending payloads. Persistence via BPv7 storage would require a separate design.
+
+**Routed expiry fires on drain, not on schedule.** If no neighbors ever appear, the
+drain never runs, and `StoreFailed` never fires even when entries are long past their
+TTL. This is acceptable: if there are no neighbors, there is nobody to tell either.
+
+**Duplicate `StoreFailed` possible in pathological cases.** If two drain attempts run
+concurrently for the same peer (near-simultaneous triggers), both might check expiry and
+both might fire `StoreFailed` for the same entry if the entry was taken by neither (not
+possible with the atomic-drain design, but worth noting as a non-issue because of it).


### PR DESCRIPTION
## What changed

Adds `store_forward(peer_id, payload)` and `store_forward_routed(dest_peer_id, payload)` to `PathweaveNode`. Both accept a payload immediately and return, queuing it for delivery when a path becomes available. The design is in ADR 021.

The implementation adds two in-memory queues (`pending_direct` and `pending_routed`) backed by `HashMap<PeerId, VecDeque<(u64, Vec<u8>, Instant)>>`. Each entry carries a `msg_id` generated at enqueue time. A background task spawned in `PathweaveNode::new()` subscribes to the router's event broadcast and drains on `PeerConnected`. `connect()` and `add_peer()` trigger drains directly. Entries expire after `NodeConfig::store_ttl` (default 24 hours) with a `TransportEvent::StoreFailed { peer_id }` event per expired entry.

`ARCHITECTURE.md` is updated with both methods, `StoreFailed` in the `TransportEvent` enum, and a store-and-forward subsection in the delivery guarantees section.

## Why

`send()` and `send_routed()` are fail-fast. There was no way to express "accept this payload now and deliver it when you can." That gap is the entire point of store-and-forward for disconnected-intermittent networks.

Closes #90.

## Alternatives considered

**Fresh `msg_id` on each drain attempt.** Rejected. A retry after a lost ACK carries a different ID, so the receiver's `DeduplicationCache` treats it as a new message and delivers twice. The same constraint that drove ADR 011 applies here; the difference is that the retry window is hours instead of seconds.

**Background ticker for TTL expiry instead of lazy drain-time check.** Rejected. A ticker that fires every N seconds would require a permanent background task holding Arcs even when both queues are empty. Lazy eviction at drain time is simpler and the precision difference does not matter in practice: an expired entry that is never drained has nowhere to go anyway.

**Unified queue with a routing-mode flag.** Rejected. The drain triggers, send functions, and delivery confirmation semantics differ between direct and routed. Two queues with two clear drain functions are easier to test and audit independently. The cost is one additional field on `PathweaveNode`.

**Per-call `ttl` parameter on `store_forward` and `store_forward_routed`.** Rejected. The common case does not need it. `NodeConfig::store_ttl` covers applications that need a different window without cluttering the per-call signature.

## Security considerations

`store_forward` and `store_forward_routed` use the same Noise_XX session path as `send()` and `send_routed()`. No new authentication or key material paths are introduced. The `msg_id` is generated by `new_message_id()`, which sets the high bit, placing all queued-payload IDs in the application space (0x80–0xFF first byte) and away from the control frame space reserved in ADR 017. The only new public surface is `StoreFailed`, which carries a `PeerId` (a hash of a public key) already visible to any node that completes a handshake.

## Test plan

Seven new tests in `node::tests`:

- [x] `store_forward_delivers_immediately_when_peer_known` — peer already in table, delivery without queuing
- [x] `store_forward_queues_and_delivers_on_add_peer` — payload sits in queue, drains when `add_peer` is called; queue membership asserted before drain
- [x] `store_forward_queues_and_delivers_on_connect` — payload sits in queue, drains after `connect()` completes the handshake
- [x] `store_forward_fifo_order_preserved` — three payloads queued in order, all three delivered in order to the receiver
- [x] `store_forward_fires_store_failed_on_expiry` — 10ms TTL, 50ms sleep, `StoreFailed` event received on the broadcast; delivery is skipped even though an announcement exists in the table
- [x] `store_forward_routed_delivers_immediately_when_neighbor_known` — neighbor present, payload flooded immediately, `pending_routed` empty after the call
- [x] `store_forward_routed_queues_and_delivers_on_peer_added` — no neighbors initially, payload queued, neighbor added, queue empty after drain

`cargo test --workspace`: 60 tests pass (53 pre-existing + 7 new).
`cargo clippy --workspace -- -D warnings`: clean.
`cargo fmt --check`: clean.