### PR TITLE
feat(transport): WiFi Direct transport for Linux and Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,112 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling 3.11.0",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,6 +236,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
@@ -224,6 +336,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2 0.6.4",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -857,6 +982,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -873,6 +1025,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fastbloom"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -880,7 +1053,7 @@ checksum = "4e7f34442dbe69c60fe8eaf58a8cafff81a1f278816d8ab4db255b3bef4ac3c4"
 dependencies = [
  "getrandom 0.3.4",
  "libm",
- "rand",
+ "rand 0.9.4",
  "siphasher",
 ]
 
@@ -972,6 +1145,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1107,6 +1293,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1399,7 +1591,7 @@ dependencies = [
  "flume",
  "if-addrs",
  "log",
- "polling",
+ "polling 2.8.0",
  "socket2 0.5.10",
 ]
 
@@ -1408,6 +1600,15 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mio"
@@ -1440,6 +1641,7 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -1593,6 +1795,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1683,6 +1901,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "pathweave-transport-wifi-direct"
+version = "0.2.0"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "pathweave-core",
+ "tokio",
+ "tracing",
+ "windows 0.58.0",
+ "zbus",
+]
+
+[[package]]
 name = "pathweave-uniffi"
 version = "0.2.0"
 dependencies = [
@@ -1727,6 +1959,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1746,6 +1989,20 @@ dependencies = [
  "log",
  "pin-project-lite",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1797,6 +2054,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,8 +2081,8 @@ dependencies = [
  "bit-vec",
  "bitflags 2.11.1",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.9.4",
+ "rand_chacha 0.9.0",
  "rand_xorshift",
  "regex-syntax",
  "rusty-fork",
@@ -1876,7 +2142,7 @@ dependencies = [
  "fastbloom",
  "getrandom 0.3.4",
  "lru-slab",
- "rand",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1926,12 +2192,33 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -1949,6 +2236,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -2334,12 +2624,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "sha1"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1da05c97445caa12d05e848c4a4fcbbea29e748ac28f7e80e9b010392063770"
 dependencies = [
  "sha1_smol",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
 ]
 
 [[package]]
@@ -2516,7 +2828,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
- "sha1",
+ "sha1 0.6.1",
  "syn 1.0.109",
 ]
 
@@ -2720,8 +3032,10 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.6.3",
  "tokio-macros",
+ "tracing",
  "windows-sys 0.61.2",
 ]
 
@@ -2759,6 +3073,36 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -2828,6 +3172,17 @@ name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unarray"
@@ -3573,6 +3928,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3679,6 +4043,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "xml"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3691,6 +4065,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
 dependencies = [
  "time",
+]
+
+[[package]]
+name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix",
+ "ordered-stream",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "sha1 0.10.6",
+ "static_assertions",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant",
 ]
 
 [[package]]
@@ -3738,3 +4169,40 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
     "crates/pathweave-core",
     "crates/pathweave-transport-quic",
     "crates/pathweave-transport-ble",
+    "crates/pathweave-transport-wifi-direct",
     "crates/pathweave-uniffi",
     "examples/pw-chat",
 ]

--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -192,6 +192,7 @@ pub struct PeerAnnouncement {
 pub enum PeerAddress {
     Quic(std::net::SocketAddr),
     Ble(String),
+    WifiDirect(String),
 }
 
 impl PeerAddress {
@@ -199,6 +200,7 @@ impl PeerAddress {
         match self {
             PeerAddress::Quic(_) => TransportKind::Quic,
             PeerAddress::Ble(_) => TransportKind::Ble,
+            PeerAddress::WifiDirect(_) => TransportKind::WifiDirect,
         }
     }
 }
@@ -208,6 +210,7 @@ impl std::fmt::Display for PeerAddress {
         match self {
             PeerAddress::Quic(addr) => write!(f, "{}", addr),
             PeerAddress::Ble(id) => write!(f, "{}", id),
+            PeerAddress::WifiDirect(id) => write!(f, "{}", id),
         }
     }
 }
@@ -223,6 +226,7 @@ pub enum TransportCost {
 pub enum TransportKind {
     Quic,
     Ble,
+    WifiDirect,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -479,6 +479,13 @@ pub(crate) fn encode_addr_exchange(addrs: &[PeerAddress]) -> Vec<u8> {
                 buf.push(len);
                 buf.extend_from_slice(&bytes[..len as usize]);
             }
+            PeerAddress::WifiDirect(id) => {
+                let bytes = id.as_bytes();
+                let len = bytes.len().min(255) as u8;
+                buf.push(0x03);
+                buf.push(len);
+                buf.extend_from_slice(&bytes[..len as usize]);
+            }
         }
     }
     buf
@@ -544,6 +551,22 @@ pub(crate) fn decode_addr_exchange(bytes: &[u8]) -> Option<Vec<PeerAddress>> {
                     .to_string();
                 pos += len;
                 addrs.push(PeerAddress::Ble(id));
+            }
+            0x03 => {
+                pos += 1;
+                if pos >= bytes.len() {
+                    return None;
+                }
+                let len = bytes[pos] as usize;
+                pos += 1;
+                if pos + len > bytes.len() {
+                    return None;
+                }
+                let id = std::str::from_utf8(&bytes[pos..pos + len])
+                    .ok()?
+                    .to_string();
+                pos += len;
+                addrs.push(PeerAddress::WifiDirect(id));
             }
             _ => return None,
         }
@@ -853,6 +876,7 @@ mod tests {
             match self.kind {
                 TransportKind::Ble => "mock-ble",
                 TransportKind::Quic => "mock-quic",
+                TransportKind::WifiDirect => "mock-wifi-direct",
             }
         }
     }

--- a/crates/pathweave-transport-wifi-direct/Cargo.toml
+++ b/crates/pathweave-transport-wifi-direct/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "pathweave-transport-wifi-direct"
+description = "WiFi Direct (IEEE 802.11 P2P) transport for Pathweave — Linux and Windows only"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+pathweave-core = { path = "../pathweave-core" }
+tokio = { workspace = true }
+futures = { workspace = true }
+bytes = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = { version = "4", default-features = false, features = ["tokio"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+windows = { version = "0.58", features = [
+    "Devices_Enumeration",
+    "Devices_WiFiDirect",
+    "Devices_WiFiDirect_Services",
+    "Foundation",
+    "Foundation_Collections",
+    "Networking",
+    "Networking_Sockets",
+    "Storage_Streams",
+] }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["test-util"] }

--- a/crates/pathweave-transport-wifi-direct/src/lib.rs
+++ b/crates/pathweave-transport-wifi-direct/src/lib.rs
@@ -1,0 +1,258 @@
+#![deny(clippy::all)]
+#![forbid(unsafe_code)]
+
+//! WiFi Direct (IEEE 802.11 P2P) transport for Pathweave. Linux and Windows only.
+//! See ADR 022 for the full design rationale, GO election rule, and address lifecycle.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use pathweave_core::{
+    Connection, NodeIdentity, PeerAddress, PeerAnnouncement, Result, Transport, TransportCost,
+    TransportKind,
+};
+use tokio::sync::Mutex;
+
+#[cfg(target_os = "linux")]
+mod linux;
+
+#[cfg(target_os = "windows")]
+mod windows;
+
+// --------------------------------------------------------------------------
+// Service name embedded in P2P service records. Both platforms advertise and
+// filter by this name so that cross-platform discovery works (ADR 022).
+// --------------------------------------------------------------------------
+
+pub(crate) const P2P_SERVICE_NAME: &str = "pathweave-p2p";
+
+// The TCP port both sides listen on / connect to once the P2P IP link is up.
+pub(crate) const WIFI_DIRECT_PORT: u16 = 47808;
+
+// --------------------------------------------------------------------------
+// Platform-independent TCP connection (ADR 022)
+//
+// After P2P group formation both ends have a routable IP on the P2P interface.
+// The connection is a TCP stream with a 4-byte big-endian length prefix,
+// matching the framing used by QuicConnection (ADR 004).
+// --------------------------------------------------------------------------
+
+pub(crate) struct WifiDirectConnection {
+    stream: Mutex<tokio::net::TcpStream>,
+}
+
+impl WifiDirectConnection {
+    pub(crate) fn new(stream: tokio::net::TcpStream) -> Self {
+        Self {
+            stream: Mutex::new(stream),
+        }
+    }
+}
+
+#[async_trait]
+impl Connection for WifiDirectConnection {
+    async fn send_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        use tokio::io::AsyncWriteExt;
+        let mut guard = self.stream.lock().await;
+        let len = (bytes.len() as u32).to_be_bytes();
+        guard
+            .write_all(&len)
+            .await
+            .map_err(|e| pathweave_core::PathweaveError::Transport(e.to_string()))?;
+        guard
+            .write_all(bytes)
+            .await
+            .map_err(|e| pathweave_core::PathweaveError::Transport(e.to_string()))
+    }
+
+    async fn recv_bytes(&mut self) -> Result<Bytes> {
+        use tokio::io::AsyncReadExt;
+        let mut guard = self.stream.lock().await;
+        let mut len_buf = [0u8; 4];
+        guard
+            .read_exact(&mut len_buf)
+            .await
+            .map_err(|e| pathweave_core::PathweaveError::Transport(e.to_string()))?;
+        let len = u32::from_be_bytes(len_buf) as usize;
+        let mut buf = vec![0u8; len];
+        guard
+            .read_exact(&mut buf)
+            .await
+            .map_err(|e| pathweave_core::PathweaveError::Transport(e.to_string()))?;
+        Ok(Bytes::from(buf))
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        use tokio::io::AsyncWriteExt;
+        let mut guard = self.stream.lock().await;
+        guard
+            .shutdown()
+            .await
+            .map_err(|e| pathweave_core::PathweaveError::Transport(e.to_string()))
+    }
+
+    fn mtu(&self) -> usize {
+        // TCP has no inherent message size limit. Return the practical maximum
+        // that fits within a single WiFi Direct frame without IP fragmentation.
+        1400
+    }
+}
+
+// --------------------------------------------------------------------------
+// WifiDirectTransport
+// --------------------------------------------------------------------------
+
+/// WiFi Direct transport. Supported on Linux and Windows only.
+///
+/// Registers the node as a WiFi Direct peer using the platform's P2P APIs,
+/// advertises the `pathweave-p2p` service name, and implements the `Transport`
+/// trait over TCP connections established after P2P group formation.
+///
+/// See ADR 022 for the Group Owner election rule, address lifecycle, and
+/// rationale for the design choices made here.
+pub struct WifiDirectTransport {
+    inner: Arc<Inner>,
+}
+
+struct Inner {
+    #[cfg(target_os = "linux")]
+    state: Mutex<Option<linux::LinuxState>>,
+    #[cfg(target_os = "linux")]
+    conn_rx: Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<WifiDirectConnection>>>,
+
+    #[cfg(target_os = "windows")]
+    state: Mutex<Option<windows::WindowsState>>,
+    #[cfg(target_os = "windows")]
+    conn_rx: Mutex<Option<tokio::sync::mpsc::UnboundedReceiver<WifiDirectConnection>>>,
+}
+
+impl WifiDirectTransport {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Inner {
+                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                state: Mutex::new(None),
+                #[cfg(any(target_os = "linux", target_os = "windows"))]
+                conn_rx: Mutex::new(None),
+            }),
+        }
+    }
+}
+
+impl Default for WifiDirectTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Transport for WifiDirectTransport {
+    async fn start(&self, identity: &NodeIdentity) -> Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::start(&self.inner, identity).await
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows::start(&self.inner, identity).await
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            let _ = identity;
+            Err(pathweave_core::PathweaveError::Transport(
+                "WiFi Direct is not supported on this platform. \
+                 Linux (wpa_supplicant) and Windows (WinRT) only."
+                    .into(),
+            ))
+        }
+    }
+
+    async fn stop(&self) -> Result<()> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::stop(&self.inner).await
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows::stop(&self.inner).await
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            Ok(())
+        }
+    }
+
+    fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::discover(Arc::clone(&self.inner))
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows::discover(Arc::clone(&self.inner))
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            Box::pin(futures::stream::empty())
+        }
+    }
+
+    async fn connect(&self, peer: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::connect(&self.inner, peer).await
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows::connect(&self.inner, peer).await
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            let _ = peer;
+            Err(pathweave_core::PathweaveError::Transport(
+                "WiFi Direct is not supported on this platform.".into(),
+            ))
+        }
+    }
+
+    async fn accept(&self) -> Result<Box<dyn Connection>> {
+        #[cfg(target_os = "linux")]
+        {
+            linux::accept(&self.inner).await
+        }
+        #[cfg(target_os = "windows")]
+        {
+            windows::accept(&self.inner).await
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        {
+            futures::future::pending::<()>().await;
+            unreachable!()
+        }
+    }
+
+    fn mtu_hint(&self) -> usize {
+        1400
+    }
+
+    fn cost(&self) -> TransportCost {
+        TransportCost::Free
+    }
+
+    fn kind(&self) -> TransportKind {
+        TransportKind::WifiDirect
+    }
+
+    fn name(&self) -> &'static str {
+        "wifi-direct"
+    }
+
+    fn local_addresses(&self) -> Vec<PeerAddress> {
+        // WiFi Direct addresses are ephemeral and P2P-interface-specific.
+        // The transport does not advertise a persistent local address; peers
+        // discover this node via the P2P service record, not via address exchange.
+        vec![]
+    }
+}

--- a/crates/pathweave-transport-wifi-direct/src/linux.rs
+++ b/crates/pathweave-transport-wifi-direct/src/linux.rs
@@ -1,0 +1,461 @@
+//! Linux WiFi Direct backend via wpa_supplicant D-Bus.
+//!
+//! Protocol:
+//!   `fi.w1.wpa_supplicant1` — main service
+//!   `fi.w1.wpa_supplicant1.Interface.P2PDevice` — per-interface P2P extension
+//!
+//! ADR 022 documents the GO election rule and address lifecycle.
+
+use std::collections::HashMap;
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use futures::stream::BoxStream;
+use futures::StreamExt;
+use pathweave_core::{
+    NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result, TransportKind,
+};
+use tokio::net::TcpStream;
+use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
+use zbus::{Connection as ZbusConn, Proxy};
+
+use super::{Inner, P2P_SERVICE_NAME, WIFI_DIRECT_PORT};
+use crate::WifiDirectConnection;
+
+// --------------------------------------------------------------------------
+// D-Bus interface and service constants
+// --------------------------------------------------------------------------
+
+const WPA_SERVICE: &str = "fi.w1.wpa_supplicant1";
+const WPA_IFACE: &str = "fi.w1.wpa_supplicant1.Interface";
+const WPA_P2P_IFACE: &str = "fi.w1.wpa_supplicant1.Interface.P2PDevice";
+const WPA_PATH: &str = "/fi/w1/wpa_supplicant1";
+
+// --------------------------------------------------------------------------
+// State held while the transport is running
+// --------------------------------------------------------------------------
+
+pub(crate) struct LinuxState {
+    _conn: ZbusConn,
+    iface_path: OwnedObjectPath,
+    conn_tx: tokio::sync::mpsc::UnboundedSender<WifiDirectConnection>,
+    local_short_id: [u8; 8],
+}
+
+// --------------------------------------------------------------------------
+// start / stop
+// --------------------------------------------------------------------------
+
+pub(crate) async fn start(inner: &Arc<Inner>, identity: &NodeIdentity) -> Result<()> {
+    let local_short_id: [u8; 8] = identity.peer_id().as_bytes()[..8]
+        .try_into()
+        .expect("PeerId is always 32 bytes");
+
+    let conn = ZbusConn::system()
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("D-Bus connection failed: {e}")))?;
+
+    // Get the first P2P-capable wireless interface from wpa_supplicant.
+    let wpa_proxy = Proxy::new(
+        &conn,
+        WPA_SERVICE,
+        WPA_PATH,
+        "fi.w1.wpa_supplicant1",
+    )
+    .await
+    .map_err(|e| PathweaveError::Transport(format!("wpa_supplicant proxy failed: {e}")))?;
+
+    let iface_paths: Vec<OwnedObjectPath> = wpa_proxy
+        .get_property("Interfaces")
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("could not read Interfaces: {e}")))?;
+
+    let iface_path = iface_paths
+        .into_iter()
+        .next()
+        .ok_or_else(|| PathweaveError::Transport("no wpa_supplicant interfaces found".into()))?;
+
+    // Register Pathweave P2P service so remote peers can filter by name.
+    let p2p_proxy = Proxy::new(&conn, WPA_SERVICE, iface_path.as_str(), WPA_P2P_IFACE)
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("P2PDevice proxy failed: {e}")))?;
+
+    let mut svc_args: HashMap<&str, OwnedValue> = HashMap::new();
+    svc_args.insert(
+        "service_type",
+        OwnedValue::try_from(Value::from("bonjour")).unwrap(),
+    );
+    svc_args.insert(
+        "version",
+        OwnedValue::try_from(Value::from(1u32)).unwrap(),
+    );
+    svc_args.insert(
+        "service",
+        OwnedValue::try_from(Value::from(P2P_SERVICE_NAME)).unwrap(),
+    );
+
+    p2p_proxy
+        .call_method("ServiceAdd", &(svc_args,))
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("ServiceAdd failed: {e}")))?;
+
+    // Start P2P discovery.
+    let find_args: HashMap<&str, OwnedValue> = HashMap::new();
+    p2p_proxy
+        .call_method("Find", &(0i32, find_args))
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("P2PFind failed: {e}")))?;
+
+    // Spawn the accept listener. Incoming P2P group formations where we are GO
+    // result in a TCP accept on the P2P interface address.
+    let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    let accept_conn = conn.clone();
+    let accept_iface = iface_path.clone();
+    let accept_tx = conn_tx.clone();
+    let short_id = local_short_id;
+    tokio::spawn(async move {
+        accept_loop(accept_conn, accept_iface, accept_tx, short_id).await;
+    });
+
+    let state = LinuxState {
+        _conn: conn,
+        iface_path,
+        conn_tx,
+        local_short_id,
+    };
+
+    *inner.state.lock().await = Some(state);
+    *inner.conn_rx.lock().await = Some(conn_rx);
+    Ok(())
+}
+
+pub(crate) async fn stop(inner: &Arc<Inner>) -> Result<()> {
+    // Dropping LinuxState drops the D-Bus connection, which closes all proxies
+    // and stops any pending signal subscriptions. conn_tx dropping causes
+    // accept_loop's channel send to fail, exiting the loop.
+    *inner.state.lock().await = None;
+    *inner.conn_rx.lock().await = None;
+    Ok(())
+}
+
+// --------------------------------------------------------------------------
+// discover
+// --------------------------------------------------------------------------
+
+pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement> {
+    let (tx, rx) = futures::channel::mpsc::unbounded();
+
+    tokio::spawn(async move {
+        let guard = inner.state.lock().await;
+        let state = match guard.as_ref() {
+            Some(s) => s,
+            None => return,
+        };
+
+        let conn = state._conn.clone();
+        let iface_path = state.iface_path.clone();
+        drop(guard);
+
+        let p2p_proxy = match Proxy::new(&conn, WPA_SERVICE, iface_path.as_str(), WPA_P2P_IFACE)
+            .await
+        {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::warn!("WiFi Direct discover: P2PDevice proxy failed: {e}");
+                return;
+            }
+        };
+
+        // Subscribe to P2PPeerFound signals.
+        let mut stream = match p2p_proxy.receive_signal("P2PPeerFound").await {
+            Ok(s) => s,
+            Err(e) => {
+                tracing::warn!("WiFi Direct discover: P2PPeerFound signal failed: {e}");
+                return;
+            }
+        };
+
+        while let Some(msg) = stream.next().await {
+            // P2PPeerFound body: (object_path: str, properties: dict<str, variant>)
+            let body: zbus::Result<(String, HashMap<String, OwnedValue>)> = msg.body().deserialize();
+            match body {
+                Ok((peer_path, props)) => {
+                    // Extract short_id from service data if present.
+                    let short_id = props
+                        .get("DeviceName")
+                        .and_then(|v| v.downcast_ref::<str>())
+                        .and_then(|s| parse_short_id_from_service_name(s));
+
+                    // The peer P2P device address is the last component of the object path.
+                    let mac = peer_path.rsplit('/').next().unwrap_or("").to_string();
+                    if mac.is_empty() {
+                        continue;
+                    }
+                    tracing::debug!("WiFi Direct: discovered peer {mac}");
+                    let ann = PeerAnnouncement {
+                        address: PeerAddress::WifiDirect(mac),
+                        short_id,
+                    };
+                    if tx.unbounded_send(ann).is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("WiFi Direct: P2PPeerFound parse error: {e}");
+                }
+            }
+        }
+    });
+
+    Box::pin(rx)
+}
+
+// --------------------------------------------------------------------------
+// connect (initiator side)
+// --------------------------------------------------------------------------
+
+pub(crate) async fn connect(inner: &Arc<Inner>, peer: &PeerAnnouncement) -> Result<Box<dyn pathweave_core::Connection>> {
+    let device_id = match &peer.address {
+        PeerAddress::WifiDirect(id) => id.clone(),
+        _ => {
+            return Err(PathweaveError::Transport(
+                "WiFi Direct connect: wrong address type".into(),
+            ))
+        }
+    };
+
+    let guard = inner.state.lock().await;
+    let state = match guard.as_ref() {
+        Some(s) => s,
+        None => {
+            return Err(PathweaveError::Transport(
+                "WiFi Direct transport not started".into(),
+            ))
+        }
+    };
+
+    let conn = state._conn.clone();
+    let iface_path = state.iface_path.clone();
+    let local_short_id = state.local_short_id;
+    drop(guard);
+
+    // Determine GO role from short_id comparison (ADR 022).
+    let peer_short_id = peer.short_id;
+    let we_are_go = match peer_short_id {
+        Some(their_id) => local_short_id > their_id,
+        None => false, // fall back to client if peer short_id unknown
+    };
+
+    let go_intent: u32 = if we_are_go { 15 } else { 0 };
+
+    let p2p_proxy = Proxy::new(&conn, WPA_SERVICE, iface_path.as_str(), WPA_P2P_IFACE)
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("P2PDevice proxy failed: {e}")))?;
+
+    // Subscribe to GroupStarted before calling P2PConnect so we don't miss it.
+    let iface_proxy = Proxy::new(&conn, WPA_SERVICE, iface_path.as_str(), WPA_IFACE)
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("Interface proxy failed: {e}")))?;
+
+    let mut group_stream = iface_proxy
+        .receive_signal("P2PGroupStarted")
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("P2PGroupStarted signal failed: {e}")))?;
+
+    let mut connect_args: HashMap<&str, OwnedValue> = HashMap::new();
+    connect_args.insert(
+        "go_intent",
+        OwnedValue::try_from(Value::from(go_intent)).unwrap(),
+    );
+    connect_args.insert(
+        "wps_method",
+        OwnedValue::try_from(Value::from("pbc")).unwrap(),
+    );
+
+    p2p_proxy
+        .call_method("Connect", &(device_id.as_str(), connect_args))
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("P2PConnect failed: {e}")))?;
+
+    // Wait for GroupStarted with a 30-second timeout.
+    let group_props = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        async {
+            while let Some(msg) = group_stream.next().await {
+                let body: zbus::Result<(HashMap<String, OwnedValue>,)> =
+                    msg.body().deserialize();
+                if let Ok((props,)) = body {
+                    return Some(props);
+                }
+            }
+            None
+        },
+    )
+    .await
+    .map_err(|_| PathweaveError::Transport("WiFi Direct: P2P group formation timed out".into()))?
+    .ok_or_else(|| PathweaveError::Transport("WiFi Direct: GroupStarted stream closed".into()))?;
+
+    let peer_ip = extract_go_ip(&group_props, we_are_go)?;
+
+    let addr: SocketAddr = format!("{peer_ip}:{WIFI_DIRECT_PORT}").parse().map_err(|e| {
+        PathweaveError::Transport(format!("WiFi Direct: invalid peer IP '{peer_ip}': {e}"))
+    })?;
+
+    tracing::debug!("WiFi Direct: connecting TCP to {addr}");
+    let stream = TcpStream::connect(addr)
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("WiFi Direct TCP connect failed: {e}")))?;
+
+    Ok(Box::new(WifiDirectConnection::new(stream)))
+}
+
+// --------------------------------------------------------------------------
+// accept (responder side — called by PathweaveNode's accept loop)
+// --------------------------------------------------------------------------
+
+pub(crate) async fn accept(inner: &Arc<Inner>) -> Result<Box<dyn pathweave_core::Connection>> {
+    let conn = inner
+        .conn_rx
+        .lock()
+        .await
+        .as_mut()
+        .and_then(|rx| {
+            // Non-blocking: return None if no connection is ready yet.
+            rx.try_recv().ok()
+        });
+
+    if let Some(c) = conn {
+        return Ok(Box::new(c));
+    }
+
+    // Block until a connection arrives.
+    let mut guard = inner.conn_rx.lock().await;
+    match guard.as_mut() {
+        Some(rx) => rx.recv().await.map(|c| Box::new(c) as Box<dyn pathweave_core::Connection>).ok_or_else(|| {
+            PathweaveError::Transport("WiFi Direct: accept channel closed".into())
+        }),
+        None => Err(PathweaveError::Transport(
+            "WiFi Direct transport not started".into(),
+        )),
+    }
+}
+
+// --------------------------------------------------------------------------
+// accept_loop: listens for P2PGroupStarted events where we are GO and
+// accepts incoming TCP connections from the client on the P2P interface.
+// --------------------------------------------------------------------------
+
+async fn accept_loop(
+    conn: ZbusConn,
+    iface_path: OwnedObjectPath,
+    conn_tx: tokio::sync::mpsc::UnboundedSender<WifiDirectConnection>,
+    local_short_id: [u8; 8],
+) {
+    let iface_proxy = match Proxy::new(&conn, WPA_SERVICE, iface_path.as_str(), WPA_IFACE).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("WiFi Direct accept_loop: Interface proxy failed: {e}");
+            return;
+        }
+    };
+
+    let mut group_stream = match iface_proxy.receive_signal("P2PGroupStarted").await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("WiFi Direct accept_loop: P2PGroupStarted signal failed: {e}");
+            return;
+        }
+    };
+
+    while let Some(msg) = group_stream.next().await {
+        let body: zbus::Result<(HashMap<String, OwnedValue>,)> = msg.body().deserialize();
+        let props = match body {
+            Ok((p,)) => p,
+            Err(_) => continue,
+        };
+
+        // Only act on groups where we are GO.
+        let role = props
+            .get("role")
+            .and_then(|v| v.downcast_ref::<str>())
+            .unwrap_or("");
+        if role != "GO" {
+            continue;
+        }
+
+        // The GO's address on the P2P interface comes from the "go_dev_addr" property
+        // or can be derived from the P2P interface address.
+        let p2p_iface_addr = match props
+            .get("interface_address")
+            .and_then(|v| v.downcast_ref::<str>())
+        {
+            Some(addr) => addr.to_string(),
+            None => continue,
+        };
+
+        let bind_addr: SocketAddr = match format!("{p2p_iface_addr}:{WIFI_DIRECT_PORT}").parse() {
+            Ok(a) => a,
+            Err(_) => continue,
+        };
+
+        let tx = conn_tx.clone();
+        tokio::spawn(async move {
+            tracing::debug!("WiFi Direct: GO listening on {bind_addr}");
+            match tokio::net::TcpListener::bind(bind_addr).await {
+                Ok(listener) => match listener.accept().await {
+                    Ok((stream, peer_addr)) => {
+                        tracing::debug!("WiFi Direct: accepted TCP from {peer_addr}");
+                        let _ = tx.send(WifiDirectConnection::new(stream));
+                    }
+                    Err(e) => tracing::warn!("WiFi Direct: TCP accept failed: {e}"),
+                },
+                Err(e) => tracing::warn!("WiFi Direct: TCP bind failed: {e}"),
+            }
+        });
+
+        let _ = local_short_id; // used for role determination upstream
+    }
+}
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+/// Extracts the peer's IP address from the GroupStarted properties.
+/// When we are GO, the peer is the client; when we are client, the peer is GO.
+fn extract_go_ip(
+    props: &HashMap<String, OwnedValue>,
+    we_are_go: bool,
+) -> Result<String> {
+    // wpa_supplicant GroupStarted provides "ip_addr_go" (the GO's IP) and
+    // "ip_addr" (the local interface IP). If we are client, the peer is GO.
+    // If we are GO, the client IP is available via "ip_addr_go" only after
+    // DHCP completes; we bind and wait for the incoming TCP connection instead.
+    let key = if we_are_go { "ip_addr" } else { "ip_addr_go" };
+    props
+        .get(key)
+        .and_then(|v| v.downcast_ref::<str>())
+        .map(|s| s.to_string())
+        .ok_or_else(|| {
+            PathweaveError::Transport(format!(
+                "WiFi Direct: '{key}' missing from GroupStarted properties"
+            ))
+        })
+}
+
+/// Attempts to parse an 8-byte short_id encoded as hex from the service
+/// device name field. Returns None if the name does not contain a valid
+/// hex-encoded short_id suffix (format: "<P2P_SERVICE_NAME>:<hex16>").
+fn parse_short_id_from_service_name(name: &str) -> Option<[u8; 8]> {
+    let prefix = format!("{}:", P2P_SERVICE_NAME);
+    let hex = name.strip_prefix(prefix.as_str())?;
+    if hex.len() != 16 {
+        return None;
+    }
+    let bytes = (0..8)
+        .map(|i| u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16))
+        .collect::<std::result::Result<Vec<u8>, _>>()
+        .ok()?;
+    bytes.try_into().ok()
+}

--- a/crates/pathweave-transport-wifi-direct/src/linux.rs
+++ b/crates/pathweave-transport-wifi-direct/src/linux.rs
@@ -38,7 +38,6 @@ const WPA_PATH: &str = "/fi/w1/wpa_supplicant1";
 pub(crate) struct LinuxState {
     _conn: ZbusConn,
     iface_path: OwnedObjectPath,
-    conn_tx: tokio::sync::mpsc::UnboundedSender<WifiDirectConnection>,
     local_short_id: [u8; 8],
 }
 
@@ -113,7 +112,6 @@ pub(crate) async fn start(inner: &Arc<Inner>, identity: &NodeIdentity) -> Result
     let state = LinuxState {
         _conn: conn,
         iface_path,
-        conn_tx,
         local_short_id,
     };
 

--- a/crates/pathweave-transport-wifi-direct/src/linux.rs
+++ b/crates/pathweave-transport-wifi-direct/src/linux.rs
@@ -12,9 +12,7 @@ use std::sync::Arc;
 
 use futures::stream::BoxStream;
 use futures::StreamExt;
-use pathweave_core::{
-    NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result,
-};
+use pathweave_core::{NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result};
 use tokio::net::TcpStream;
 use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
 use zbus::{Connection as ZbusConn, Proxy};
@@ -176,8 +174,9 @@ pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement
                         Value::Str(s) => Some(s.to_string()),
                         _ => None,
                     });
-                    let short_id =
-                        device_name.as_deref().and_then(parse_short_id_from_service_name);
+                    let short_id = device_name
+                        .as_deref()
+                        .and_then(parse_short_id_from_service_name);
 
                     // The peer P2P device address is the last component of the object path.
                     let mac = peer_path.rsplit('/').next().unwrap_or("").to_string();

--- a/crates/pathweave-transport-wifi-direct/src/linux.rs
+++ b/crates/pathweave-transport-wifi-direct/src/linux.rs
@@ -56,14 +56,9 @@ pub(crate) async fn start(inner: &Arc<Inner>, identity: &NodeIdentity) -> Result
         .map_err(|e| PathweaveError::Transport(format!("D-Bus connection failed: {e}")))?;
 
     // Get the first P2P-capable wireless interface from wpa_supplicant.
-    let wpa_proxy = Proxy::new(
-        &conn,
-        WPA_SERVICE,
-        WPA_PATH,
-        "fi.w1.wpa_supplicant1",
-    )
-    .await
-    .map_err(|e| PathweaveError::Transport(format!("wpa_supplicant proxy failed: {e}")))?;
+    let wpa_proxy = Proxy::new(&conn, WPA_SERVICE, WPA_PATH, "fi.w1.wpa_supplicant1")
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("wpa_supplicant proxy failed: {e}")))?;
 
     let iface_paths: Vec<OwnedObjectPath> = wpa_proxy
         .get_property("Interfaces")
@@ -85,10 +80,7 @@ pub(crate) async fn start(inner: &Arc<Inner>, identity: &NodeIdentity) -> Result
         "service_type",
         OwnedValue::try_from(Value::from("bonjour")).unwrap(),
     );
-    svc_args.insert(
-        "version",
-        OwnedValue::try_from(Value::from(1u32)).unwrap(),
-    );
+    svc_args.insert("version", OwnedValue::try_from(Value::from(1u32)).unwrap());
     svc_args.insert(
         "service",
         OwnedValue::try_from(Value::from(P2P_SERVICE_NAME)).unwrap(),
@@ -157,15 +149,14 @@ pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement
         let iface_path = state.iface_path.clone();
         drop(guard);
 
-        let p2p_proxy = match Proxy::new(&conn, WPA_SERVICE, iface_path.as_str(), WPA_P2P_IFACE)
-            .await
-        {
-            Ok(p) => p,
-            Err(e) => {
-                tracing::warn!("WiFi Direct discover: P2PDevice proxy failed: {e}");
-                return;
-            }
-        };
+        let p2p_proxy =
+            match Proxy::new(&conn, WPA_SERVICE, iface_path.as_str(), WPA_P2P_IFACE).await {
+                Ok(p) => p,
+                Err(e) => {
+                    tracing::warn!("WiFi Direct discover: P2PDevice proxy failed: {e}");
+                    return;
+                }
+            };
 
         // Subscribe to P2PPeerFound signals.
         let mut stream = match p2p_proxy.receive_signal("P2PPeerFound").await {
@@ -178,7 +169,8 @@ pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement
 
         while let Some(msg) = stream.next().await {
             // P2PPeerFound body: (object_path: str, properties: dict<str, variant>)
-            let body: zbus::Result<(String, HashMap<String, OwnedValue>)> = msg.body().deserialize();
+            let body: zbus::Result<(String, HashMap<String, OwnedValue>)> =
+                msg.body().deserialize();
             match body {
                 Ok((peer_path, props)) => {
                     // Extract short_id from service data if present.
@@ -215,7 +207,10 @@ pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement
 // connect (initiator side)
 // --------------------------------------------------------------------------
 
-pub(crate) async fn connect(inner: &Arc<Inner>, peer: &PeerAnnouncement) -> Result<Box<dyn pathweave_core::Connection>> {
+pub(crate) async fn connect(
+    inner: &Arc<Inner>,
+    peer: &PeerAnnouncement,
+) -> Result<Box<dyn pathweave_core::Connection>> {
     let device_id = match &peer.address {
         PeerAddress::WifiDirect(id) => id.clone(),
         _ => {
@@ -279,28 +274,26 @@ pub(crate) async fn connect(inner: &Arc<Inner>, peer: &PeerAnnouncement) -> Resu
         .map_err(|e| PathweaveError::Transport(format!("P2PConnect failed: {e}")))?;
 
     // Wait for GroupStarted with a 30-second timeout.
-    let group_props = tokio::time::timeout(
-        std::time::Duration::from_secs(30),
-        async {
-            while let Some(msg) = group_stream.next().await {
-                let body: zbus::Result<(HashMap<String, OwnedValue>,)> =
-                    msg.body().deserialize();
-                if let Ok((props,)) = body {
-                    return Some(props);
-                }
+    let group_props = tokio::time::timeout(std::time::Duration::from_secs(30), async {
+        while let Some(msg) = group_stream.next().await {
+            let body: zbus::Result<(HashMap<String, OwnedValue>,)> = msg.body().deserialize();
+            if let Ok((props,)) = body {
+                return Some(props);
             }
-            None
-        },
-    )
+        }
+        None
+    })
     .await
     .map_err(|_| PathweaveError::Transport("WiFi Direct: P2P group formation timed out".into()))?
     .ok_or_else(|| PathweaveError::Transport("WiFi Direct: GroupStarted stream closed".into()))?;
 
     let peer_ip = extract_go_ip(&group_props, we_are_go)?;
 
-    let addr: SocketAddr = format!("{peer_ip}:{WIFI_DIRECT_PORT}").parse().map_err(|e| {
-        PathweaveError::Transport(format!("WiFi Direct: invalid peer IP '{peer_ip}': {e}"))
-    })?;
+    let addr: SocketAddr = format!("{peer_ip}:{WIFI_DIRECT_PORT}")
+        .parse()
+        .map_err(|e| {
+            PathweaveError::Transport(format!("WiFi Direct: invalid peer IP '{peer_ip}': {e}"))
+        })?;
 
     tracing::debug!("WiFi Direct: connecting TCP to {addr}");
     let stream = TcpStream::connect(addr)
@@ -315,15 +308,10 @@ pub(crate) async fn connect(inner: &Arc<Inner>, peer: &PeerAnnouncement) -> Resu
 // --------------------------------------------------------------------------
 
 pub(crate) async fn accept(inner: &Arc<Inner>) -> Result<Box<dyn pathweave_core::Connection>> {
-    let conn = inner
-        .conn_rx
-        .lock()
-        .await
-        .as_mut()
-        .and_then(|rx| {
-            // Non-blocking: return None if no connection is ready yet.
-            rx.try_recv().ok()
-        });
+    let conn = inner.conn_rx.lock().await.as_mut().and_then(|rx| {
+        // Non-blocking: return None if no connection is ready yet.
+        rx.try_recv().ok()
+    });
 
     if let Some(c) = conn {
         return Ok(Box::new(c));
@@ -332,9 +320,11 @@ pub(crate) async fn accept(inner: &Arc<Inner>) -> Result<Box<dyn pathweave_core:
     // Block until a connection arrives.
     let mut guard = inner.conn_rx.lock().await;
     match guard.as_mut() {
-        Some(rx) => rx.recv().await.map(|c| Box::new(c) as Box<dyn pathweave_core::Connection>).ok_or_else(|| {
-            PathweaveError::Transport("WiFi Direct: accept channel closed".into())
-        }),
+        Some(rx) => rx
+            .recv()
+            .await
+            .map(|c| Box::new(c) as Box<dyn pathweave_core::Connection>)
+            .ok_or_else(|| PathweaveError::Transport("WiFi Direct: accept channel closed".into())),
         None => Err(PathweaveError::Transport(
             "WiFi Direct transport not started".into(),
         )),
@@ -424,10 +414,7 @@ async fn accept_loop(
 
 /// Extracts the peer's IP address from the GroupStarted properties.
 /// When we are GO, the peer is the client; when we are client, the peer is GO.
-fn extract_go_ip(
-    props: &HashMap<String, OwnedValue>,
-    we_are_go: bool,
-) -> Result<String> {
+fn extract_go_ip(props: &HashMap<String, OwnedValue>, we_are_go: bool) -> Result<String> {
     // wpa_supplicant GroupStarted provides "ip_addr_go" (the GO's IP) and
     // "ip_addr" (the local interface IP). If we are client, the peer is GO.
     // If we are GO, the client IP is available via "ip_addr_go" only after

--- a/crates/pathweave-transport-wifi-direct/src/linux.rs
+++ b/crates/pathweave-transport-wifi-direct/src/linux.rs
@@ -13,7 +13,7 @@ use std::sync::Arc;
 use futures::stream::BoxStream;
 use futures::StreamExt;
 use pathweave_core::{
-    NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result, TransportKind,
+    NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result,
 };
 use tokio::net::TcpStream;
 use zbus::zvariant::{OwnedObjectPath, OwnedValue, Value};
@@ -174,10 +174,12 @@ pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement
             match body {
                 Ok((peer_path, props)) => {
                     // Extract short_id from service data if present.
-                    let short_id = props
-                        .get("DeviceName")
-                        .and_then(|v| v.downcast_ref::<str>())
-                        .and_then(|s| parse_short_id_from_service_name(s));
+                    let device_name = props.get("DeviceName").and_then(|v| match &**v {
+                        Value::Str(s) => Some(s.to_string()),
+                        _ => None,
+                    });
+                    let short_id =
+                        device_name.as_deref().and_then(parse_short_id_from_service_name);
 
                     // The peer P2P device address is the last component of the object path.
                     let mac = peer_path.rsplit('/').next().unwrap_or("").to_string();
@@ -366,21 +368,24 @@ async fn accept_loop(
         };
 
         // Only act on groups where we are GO.
-        let role = props
+        let role: String = props
             .get("role")
-            .and_then(|v| v.downcast_ref::<str>())
-            .unwrap_or("");
+            .and_then(|v| match &**v {
+                Value::Str(s) => Some(s.to_string()),
+                _ => None,
+            })
+            .unwrap_or_default();
         if role != "GO" {
             continue;
         }
 
         // The GO's address on the P2P interface comes from the "go_dev_addr" property
         // or can be derived from the P2P interface address.
-        let p2p_iface_addr = match props
-            .get("interface_address")
-            .and_then(|v| v.downcast_ref::<str>())
-        {
-            Some(addr) => addr.to_string(),
+        let p2p_iface_addr = match props.get("interface_address").and_then(|v| match &**v {
+            Value::Str(s) => Some(s.to_string()),
+            _ => None,
+        }) {
+            Some(addr) => addr,
             None => continue,
         };
 
@@ -422,8 +427,10 @@ fn extract_go_ip(props: &HashMap<String, OwnedValue>, we_are_go: bool) -> Result
     let key = if we_are_go { "ip_addr" } else { "ip_addr_go" };
     props
         .get(key)
-        .and_then(|v| v.downcast_ref::<str>())
-        .map(|s| s.to_string())
+        .and_then(|v| match &**v {
+            Value::Str(s) => Some(s.to_string()),
+            _ => None,
+        })
         .ok_or_else(|| {
             PathweaveError::Transport(format!(
                 "WiFi Direct: '{key}' missing from GroupStarted properties"

--- a/crates/pathweave-transport-wifi-direct/src/windows.rs
+++ b/crates/pathweave-transport-wifi-direct/src/windows.rs
@@ -1,0 +1,405 @@
+//! Windows WiFi Direct backend via WinRT (Windows.Devices.WiFiDirect).
+//!
+//! WinRT COM objects are not Send. All WinRT calls are either confined to a
+//! dedicated std::thread (for the publisher/listener lifecycle) or wrapped in
+//! block_in_place (for one-shot calls in connect). No WinRT object is held
+//! across an .await boundary. See also: BLE transport Windows backend for the
+//! same pattern.
+//!
+//! ADR 022 documents the GO election rule and address lifecycle.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+
+use futures::stream::BoxStream;
+use pathweave_core::{NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result};
+use tokio::net::TcpStream;
+use windows::Devices::Enumeration::DeviceInformation;
+use windows::Devices::WiFiDirect::{WiFiDirectConnectionListener, WiFiDirectDevice};
+use windows::Devices::WiFiDirect::WiFiDirectAdvertisementPublisher;
+
+use super::{Inner, WIFI_DIRECT_PORT};
+use crate::WifiDirectConnection;
+
+// --------------------------------------------------------------------------
+// State held while the transport is running.
+// All fields are Send; WinRT objects live on the background thread.
+// --------------------------------------------------------------------------
+
+pub(crate) struct WindowsState {
+    /// Dropping this signals the background thread to stop the publisher and listener.
+    _stop_tx: tokio::sync::oneshot::Sender<()>,
+    pub(crate) local_short_id: [u8; 8],
+}
+
+// --------------------------------------------------------------------------
+// start / stop
+// --------------------------------------------------------------------------
+
+pub(crate) async fn start(inner: &Arc<Inner>, identity: &NodeIdentity) -> Result<()> {
+    let local_short_id: [u8; 8] = identity.peer_id().as_bytes()[..8]
+        .try_into()
+        .expect("PeerId is always 32 bytes");
+
+    let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel::<WifiDirectConnection>();
+    let (stop_tx, stop_rx) = tokio::sync::oneshot::channel::<()>();
+
+    // Capture the tokio handle before spawning so the background thread can
+    // call handle.spawn() from within WinRT callback threads (which have no
+    // tokio runtime). tokio::spawn() directly would panic outside of a runtime.
+    let rt_handle = tokio::runtime::Handle::current();
+
+    // Spawn a std::thread to own all WinRT objects for the lifetime of the transport.
+    let thread_conn_tx = conn_tx.clone();
+    std::thread::spawn(move || {
+        publisher_thread(thread_conn_tx, stop_rx, rt_handle);
+    });
+
+    *inner.state.lock().await = Some(WindowsState {
+        _stop_tx: stop_tx,
+        local_short_id,
+    });
+    *inner.conn_rx.lock().await = Some(conn_rx);
+    Ok(())
+}
+
+pub(crate) async fn stop(inner: &Arc<Inner>) -> Result<()> {
+    // Dropping WindowsState drops _stop_tx, which signals the background thread
+    // to call publisher.Stop() and exit. conn_tx dropping causes accept()'s
+    // recv() to return None.
+    *inner.state.lock().await = None;
+    *inner.conn_rx.lock().await = None;
+    Ok(())
+}
+
+/// Owns the WinRT publisher and listener for the lifetime of the transport.
+/// Runs on a dedicated std::thread because WinRT COM objects are not Send.
+fn publisher_thread(
+    conn_tx: tokio::sync::mpsc::UnboundedSender<WifiDirectConnection>,
+    stop_rx: tokio::sync::oneshot::Receiver<()>,
+    rt_handle: tokio::runtime::Handle,
+) {
+    let publisher = match WiFiDirectAdvertisementPublisher::new() {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("WiFi Direct: publisher creation failed: {e}");
+            return;
+        }
+    };
+
+    let listener = match WiFiDirectConnectionListener::new() {
+        Ok(l) => l,
+        Err(e) => {
+            tracing::warn!("WiFi Direct: listener creation failed: {e}");
+            return;
+        }
+    };
+
+    let tx = conn_tx.clone();
+    let handler_result = listener.ConnectionRequested(
+        &windows::Foundation::TypedEventHandler::new(
+            move |_, args: &Option<windows::Devices::WiFiDirect::WiFiDirectConnectionRequestedEventArgs>| {
+                if let Some(args) = args {
+                    if let Ok(req) = args.GetConnectionRequest() {
+                        if let Ok(device_info) = req.DeviceInformation() {
+                            let tx2 = tx.clone();
+                            let handle2 = rt_handle.clone();
+                            // Spawn a tokio task via the captured handle; direct
+                            // tokio::spawn would panic outside a runtime context.
+                            handle2.spawn(async move {
+                                if let Err(e) = handle_incoming(device_info, tx2).await {
+                                    tracing::warn!("WiFi Direct: incoming connection error: {e}");
+                                }
+                            });
+                        }
+                    }
+                }
+                Ok(())
+            },
+        ),
+    );
+
+    if let Err(e) = handler_result {
+        tracing::warn!("WiFi Direct: ConnectionRequested handler failed: {e}");
+        return;
+    }
+
+    if let Err(e) = publisher.Start() {
+        tracing::warn!("WiFi Direct: publisher Start failed: {e}");
+        return;
+    }
+
+    tracing::debug!("WiFi Direct: publisher started");
+
+    // Block until stop is signalled (stop_tx dropped from WindowsState::drop).
+    let _ = stop_rx.blocking_recv();
+
+    let _ = publisher.Stop();
+    tracing::debug!("WiFi Direct: publisher stopped");
+}
+
+// --------------------------------------------------------------------------
+// discover
+// --------------------------------------------------------------------------
+
+pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement> {
+    let (tx, rx) = futures::channel::mpsc::unbounded();
+
+    tokio::spawn(async move {
+        // Read local_short_id to filter out our own device.
+        let local_short_id = inner
+            .state
+            .lock()
+            .await
+            .as_ref()
+            .map(|s| s.local_short_id);
+
+        // All device enumeration is synchronous WinRT; run in block_in_place.
+        let announcements: Vec<PeerAnnouncement> = tokio::task::block_in_place(|| {
+            enumerate_peers(local_short_id)
+        });
+
+        for ann in announcements {
+            if tx.unbounded_send(ann).is_err() {
+                return;
+            }
+        }
+    });
+
+    Box::pin(rx)
+}
+
+fn enumerate_peers(local_short_id: Option<[u8; 8]>) -> Vec<PeerAnnouncement> {
+    let selector = match WiFiDirectDevice::GetDeviceSelector() {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::warn!("WiFi Direct: GetDeviceSelector failed: {e}");
+            return vec![];
+        }
+    };
+
+    let devices = match DeviceInformation::FindAllAsyncAqsFilter(&selector)
+        .and_then(|op| op.get())
+    {
+        Ok(d) => d,
+        Err(e) => {
+            tracing::warn!("WiFi Direct: device enumeration failed: {e}");
+            return vec![];
+        }
+    };
+
+    let mut out = Vec::new();
+    let count = devices.Size().unwrap_or(0);
+    for i in 0..count {
+        let device = match devices.GetAt(i) {
+            Ok(d) => d,
+            Err(_) => continue,
+        };
+        let id: windows::core::HSTRING = match device.Id() {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        let id_str = id.to_string();
+
+        let short_id: Option<[u8; 8]> = device
+            .Name()
+            .ok()
+            .and_then(|n| parse_short_id_from_name(&n.to_string()));
+
+        // Skip our own device.
+        if let (Some(local), Some(peer)) = (local_short_id, short_id) {
+            if local == peer {
+                continue;
+            }
+        }
+
+        tracing::debug!("WiFi Direct: discovered {id_str}");
+        out.push(PeerAnnouncement {
+            address: PeerAddress::WifiDirect(id_str),
+            short_id,
+        });
+    }
+    out
+}
+
+// --------------------------------------------------------------------------
+// connect (initiator / client side)
+// --------------------------------------------------------------------------
+
+pub(crate) async fn connect(
+    inner: &Arc<Inner>,
+    peer: &PeerAnnouncement,
+) -> Result<Box<dyn pathweave_core::Connection>> {
+    let device_id = match &peer.address {
+        PeerAddress::WifiDirect(id) => id.clone(),
+        _ => {
+            return Err(PathweaveError::Transport(
+                "WiFi Direct connect: wrong address type".into(),
+            ))
+        }
+    };
+
+    let local_short_id = inner
+        .state
+        .lock()
+        .await
+        .as_ref()
+        .map(|s| s.local_short_id)
+        .ok_or_else(|| PathweaveError::Transport("WiFi Direct transport not started".into()))?;
+
+    // Determine role (ADR 022): higher short_id becomes GO.
+    let we_are_go = match peer.short_id {
+        Some(their_id) => local_short_id > their_id,
+        None => false,
+    };
+
+    if we_are_go {
+        // We are GO. The peer will call FromIdAsync() against us. Our accept()
+        // call will deliver the connection when the peer's TCP arrives.
+        return Err(PathweaveError::Transport(
+            "WiFi Direct: this node is GO — the remote side will initiate; \
+             the router should call accept() to receive the inbound connection"
+                .into(),
+        ));
+    }
+
+    // We are client. Call FromIdAsync() and extract the remote IP synchronously,
+    // then do the TCP connect asynchronously. No WinRT object crosses the await.
+    let id_hstring = windows::core::HSTRING::from(device_id.as_str());
+    let remote_ip: String = tokio::task::block_in_place(|| {
+        let wifi_device = WiFiDirectDevice::FromIdAsync(&id_hstring)
+            .and_then(|op| op.get())
+            .map_err(|e| {
+                PathweaveError::Transport(format!("WiFiDirectDevice::FromIdAsync failed: {e}"))
+            })?;
+
+        let endpoints = wifi_device.GetConnectionEndpointPairs().map_err(|e| {
+            PathweaveError::Transport(format!("GetConnectionEndpointPairs failed: {e}"))
+        })?;
+
+        let ep = endpoints
+            .GetAt(0)
+            .map_err(|e| PathweaveError::Transport(format!("no endpoint pairs: {e}")))?;
+
+        let hostname = ep
+            .RemoteHostName()
+            .map_err(|e| PathweaveError::Transport(format!("RemoteHostName failed: {e}")))?;
+
+        hostname
+            .DisplayName()
+            .map(|h| h.to_string())
+            .map_err(|e| PathweaveError::Transport(format!("DisplayName failed: {e}")))
+    })?;
+
+    let addr: SocketAddr = format!("{remote_ip}:{WIFI_DIRECT_PORT}")
+        .parse()
+        .map_err(|e| {
+            PathweaveError::Transport(format!(
+                "WiFi Direct: invalid remote IP '{remote_ip}': {e}"
+            ))
+        })?;
+
+    tracing::debug!("WiFi Direct (Windows): connecting TCP to {addr}");
+    let stream = TcpStream::connect(addr)
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("WiFi Direct TCP connect failed: {e}")))?;
+
+    Ok(Box::new(WifiDirectConnection::new(stream)))
+}
+
+// --------------------------------------------------------------------------
+// accept
+// --------------------------------------------------------------------------
+
+pub(crate) async fn accept(inner: &Arc<Inner>) -> Result<Box<dyn pathweave_core::Connection>> {
+    let mut guard = inner.conn_rx.lock().await;
+    match guard.as_mut() {
+        Some(rx) => rx
+            .recv()
+            .await
+            .map(|c| Box::new(c) as Box<dyn pathweave_core::Connection>)
+            .ok_or_else(|| {
+                PathweaveError::Transport("WiFi Direct: accept channel closed".into())
+            }),
+        None => Err(PathweaveError::Transport(
+            "WiFi Direct transport not started".into(),
+        )),
+    }
+}
+
+// --------------------------------------------------------------------------
+// Helpers
+// --------------------------------------------------------------------------
+
+/// Handles an incoming connection from the publisher_thread event handler.
+/// Binds a TCP listener on the local P2P interface address and waits for the
+/// client to connect.
+async fn handle_incoming(
+    device_info: DeviceInformation,
+    conn_tx: tokio::sync::mpsc::UnboundedSender<WifiDirectConnection>,
+) -> Result<()> {
+    let local_ip: String = tokio::task::block_in_place(|| {
+        let id = device_info
+            .Id()
+            .map_err(|e| PathweaveError::Transport(format!("device Id failed: {e}")))?;
+
+        let wifi_device = WiFiDirectDevice::FromIdAsync(&id)
+            .and_then(|op| op.get())
+            .map_err(|e| PathweaveError::Transport(format!("FromIdAsync (incoming) failed: {e}")))?;
+
+        let endpoints = wifi_device
+            .GetConnectionEndpointPairs()
+            .map_err(|e| PathweaveError::Transport(format!("GetConnectionEndpointPairs: {e}")))?;
+
+        let ep = endpoints
+            .GetAt(0)
+            .map_err(|e| PathweaveError::Transport(format!("no endpoint pairs: {e}")))?;
+
+        let hostname = ep
+            .LocalHostName()
+            .map_err(|e| PathweaveError::Transport(format!("LocalHostName failed: {e}")))?;
+
+        hostname
+            .DisplayName()
+            .map(|h| h.to_string())
+            .map_err(|e| PathweaveError::Transport(format!("DisplayName failed: {e}")))
+    })?;
+
+    let bind_addr: SocketAddr =
+        format!("{local_ip}:{WIFI_DIRECT_PORT}")
+            .parse()
+            .map_err(|e| {
+                PathweaveError::Transport(format!(
+                    "WiFi Direct: invalid local IP '{local_ip}': {e}"
+                ))
+            })?;
+
+    tracing::debug!("WiFi Direct (Windows): GO listening on {bind_addr}");
+    let listener = tokio::net::TcpListener::bind(bind_addr)
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("TCP bind failed: {e}")))?;
+
+    let (stream, peer_addr) = listener
+        .accept()
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("TCP accept failed: {e}")))?;
+
+    tracing::debug!("WiFi Direct (Windows): accepted TCP from {peer_addr}");
+    let _ = conn_tx.send(WifiDirectConnection::new(stream));
+    Ok(())
+}
+
+/// Attempts to extract a short_id from a WinRT device name.
+/// Expected format: "<P2P_SERVICE_NAME>:<hex16>".
+fn parse_short_id_from_name(name: &str) -> Option<[u8; 8]> {
+    let prefix = format!("{}:", super::P2P_SERVICE_NAME);
+    let hex = name.strip_prefix(prefix.as_str())?;
+    if hex.len() != 16 {
+        return None;
+    }
+    let bytes = (0..8)
+        .map(|i| u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16))
+        .collect::<std::result::Result<Vec<u8>, _>>()
+        .ok()?;
+    bytes.try_into().ok()
+}

--- a/crates/pathweave-transport-wifi-direct/src/windows.rs
+++ b/crates/pathweave-transport-wifi-direct/src/windows.rs
@@ -15,8 +15,8 @@ use futures::stream::BoxStream;
 use pathweave_core::{NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result};
 use tokio::net::TcpStream;
 use windows::Devices::Enumeration::DeviceInformation;
-use windows::Devices::WiFiDirect::{WiFiDirectConnectionListener, WiFiDirectDevice};
 use windows::Devices::WiFiDirect::WiFiDirectAdvertisementPublisher;
+use windows::Devices::WiFiDirect::{WiFiDirectConnectionListener, WiFiDirectDevice};
 
 use super::{Inner, WIFI_DIRECT_PORT};
 use crate::WifiDirectConnection;
@@ -96,9 +96,12 @@ fn publisher_thread(
     };
 
     let tx = conn_tx.clone();
-    let handler_result = listener.ConnectionRequested(
-        &windows::Foundation::TypedEventHandler::new(
-            move |_, args: &Option<windows::Devices::WiFiDirect::WiFiDirectConnectionRequestedEventArgs>| {
+    let handler_result =
+        listener.ConnectionRequested(&windows::Foundation::TypedEventHandler::new(
+            move |_,
+                  args: &Option<
+                windows::Devices::WiFiDirect::WiFiDirectConnectionRequestedEventArgs,
+            >| {
                 if let Some(args) = args {
                     if let Ok(req) = args.GetConnectionRequest() {
                         if let Ok(device_info) = req.DeviceInformation() {
@@ -116,8 +119,7 @@ fn publisher_thread(
                 }
                 Ok(())
             },
-        ),
-    );
+        ));
 
     if let Err(e) = handler_result {
         tracing::warn!("WiFi Direct: ConnectionRequested handler failed: {e}");
@@ -147,17 +149,11 @@ pub(crate) fn discover(inner: Arc<Inner>) -> BoxStream<'static, PeerAnnouncement
 
     tokio::spawn(async move {
         // Read local_short_id to filter out our own device.
-        let local_short_id = inner
-            .state
-            .lock()
-            .await
-            .as_ref()
-            .map(|s| s.local_short_id);
+        let local_short_id = inner.state.lock().await.as_ref().map(|s| s.local_short_id);
 
         // All device enumeration is synchronous WinRT; run in block_in_place.
-        let announcements: Vec<PeerAnnouncement> = tokio::task::block_in_place(|| {
-            enumerate_peers(local_short_id)
-        });
+        let announcements: Vec<PeerAnnouncement> =
+            tokio::task::block_in_place(|| enumerate_peers(local_short_id));
 
         for ann in announcements {
             if tx.unbounded_send(ann).is_err() {
@@ -178,8 +174,7 @@ fn enumerate_peers(local_short_id: Option<[u8; 8]>) -> Vec<PeerAnnouncement> {
         }
     };
 
-    let devices = match DeviceInformation::FindAllAsyncAqsFilter(&selector)
-        .and_then(|op| op.get())
+    let devices = match DeviceInformation::FindAllAsyncAqsFilter(&selector).and_then(|op| op.get())
     {
         Ok(d) => d,
         Err(e) => {
@@ -294,9 +289,7 @@ pub(crate) async fn connect(
     let addr: SocketAddr = format!("{remote_ip}:{WIFI_DIRECT_PORT}")
         .parse()
         .map_err(|e| {
-            PathweaveError::Transport(format!(
-                "WiFi Direct: invalid remote IP '{remote_ip}': {e}"
-            ))
+            PathweaveError::Transport(format!("WiFi Direct: invalid remote IP '{remote_ip}': {e}"))
         })?;
 
     tracing::debug!("WiFi Direct (Windows): connecting TCP to {addr}");
@@ -318,9 +311,7 @@ pub(crate) async fn accept(inner: &Arc<Inner>) -> Result<Box<dyn pathweave_core:
             .recv()
             .await
             .map(|c| Box::new(c) as Box<dyn pathweave_core::Connection>)
-            .ok_or_else(|| {
-                PathweaveError::Transport("WiFi Direct: accept channel closed".into())
-            }),
+            .ok_or_else(|| PathweaveError::Transport("WiFi Direct: accept channel closed".into())),
         None => Err(PathweaveError::Transport(
             "WiFi Direct transport not started".into(),
         )),
@@ -345,7 +336,9 @@ async fn handle_incoming(
 
         let wifi_device = WiFiDirectDevice::FromIdAsync(&id)
             .and_then(|op| op.get())
-            .map_err(|e| PathweaveError::Transport(format!("FromIdAsync (incoming) failed: {e}")))?;
+            .map_err(|e| {
+                PathweaveError::Transport(format!("FromIdAsync (incoming) failed: {e}"))
+            })?;
 
         let endpoints = wifi_device
             .GetConnectionEndpointPairs()
@@ -365,14 +358,11 @@ async fn handle_incoming(
             .map_err(|e| PathweaveError::Transport(format!("DisplayName failed: {e}")))
     })?;
 
-    let bind_addr: SocketAddr =
-        format!("{local_ip}:{WIFI_DIRECT_PORT}")
-            .parse()
-            .map_err(|e| {
-                PathweaveError::Transport(format!(
-                    "WiFi Direct: invalid local IP '{local_ip}': {e}"
-                ))
-            })?;
+    let bind_addr: SocketAddr = format!("{local_ip}:{WIFI_DIRECT_PORT}")
+        .parse()
+        .map_err(|e| {
+            PathweaveError::Transport(format!("WiFi Direct: invalid local IP '{local_ip}': {e}"))
+        })?;
 
     tracing::debug!("WiFi Direct (Windows): GO listening on {bind_addr}");
     let listener = tokio::net::TcpListener::bind(bind_addr)

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -84,6 +84,7 @@ fn transport_kind_name(kind: TransportKind) -> &'static str {
     match kind {
         TransportKind::Quic => "QUIC",
         TransportKind::Ble => "BLE",
+        TransportKind::WifiDirect => "WiFiDirect",
     }
 }
 

--- a/notes/decisions/017-post-handshake-address-exchange.md
+++ b/notes/decisions/017-post-handshake-address-exchange.md
@@ -64,6 +64,7 @@ for each address:
     0x00 = QUIC over IPv4
     0x01 = QUIC over IPv6
     0x02 = BLE
+    0x03 = WiFi Direct
   for kind 0x00 (QUIC IPv4):
     [ip:   4 bytes, network byte order]
     [port: 2 bytes, big-endian]
@@ -73,11 +74,19 @@ for each address:
   for kind 0x02 (BLE):
     [len: u8]                 byte length of the UTF-8 string
     [id:  len bytes]          BLE peripheral ID string (MAC or UUID)
+  for kind 0x03 (WiFi Direct):
+    [len: u8]                 byte length of the UTF-8 string
+    [id:  len bytes]          platform device identifier (MAC on Linux, WinRT device ID on Windows)
 ```
 
 BLE peripheral ID strings are platform-specific ASCII: 17 bytes on Linux (MAC format
 `AA:BB:CC:DD:EE:FF`), 36 bytes on Windows and macOS (UUID format). Both fit in a `u8`
 length prefix. The receiver stores the string as-is into `PeerAddress::Ble(String)`.
+
+WiFi Direct device identifier strings follow the same encoding. On Linux the identifier
+is a P2P device MAC address (17 bytes); on Windows it is a WinRT device ID string. Both
+fit in a `u8` length prefix. The receiver stores the string as-is into
+`PeerAddress::WifiDirect(String)`. See ADR 022.
 
 The encoding is intentionally simple: no versioning byte, no checksum, no schema. If a
 future format change is needed, a new control message type handles it. Unrecognised

--- a/notes/decisions/022-wifi-direct-transport.md
+++ b/notes/decisions/022-wifi-direct-transport.md
@@ -1,0 +1,146 @@
+# ADR 022: WiFi Direct transport design
+
+**Status:** Accepted
+
+## Context
+
+The QUIC transport requires an existing IP network: both nodes must share an AP, a VPN,
+or some other routable path. The BLE GATT transport operates without infrastructure but
+is limited to roughly 30–50m and low throughput. Two Pathweave nodes within a few hundred
+meters with no shared AP and no BLE proximity cannot reach each other via either
+transport.
+
+WiFi Direct (IEEE 802.11 P2P) creates a direct device-to-device IP link without an
+access point. One device becomes a Group Owner (GO) and broadcasts a softAP; the other
+connects as a client. Once the link is established, both ends communicate over a normal
+IP interface at WiFi speeds across roughly 200m line of sight and 50m indoors. The
+infrastructure cost is zero.
+
+Two design choices must be made before implementation:
+
+**How deep should the Transport implementation go?** WiFi Direct could be modelled as
+either a full transport (handles discovery, P2P link establishment, and data framing) or
+a connectivity-only layer (handles link setup, then hands off IP addresses to the QUIC
+transport for data).
+
+**Which data protocol runs over the P2P IP link?** Once both ends have routable addresses
+on the P2P interface, any IP protocol can be used: raw TCP, raw UDP, or QUIC.
+
+## Decision
+
+### Full Transport implementation (Option A)
+
+`WifiDirectTransport` implements the `Transport` trait end-to-end: discovery, P2P
+negotiation, and data framing. The router sees it as an independent transport, identical
+in structure to `BleTransport` and `QuicTransport`.
+
+The alternative (Option B) is a connectivity-only layer that establishes the P2P link
+and then reports the resulting IP addresses to the QUIC transport. Option B avoids
+duplicating framing logic but creates a dependency between two transport crates and
+requires the router to understand that a QUIC connection on a particular interface was
+set up by WiFi Direct. Cost attribution and `TransportKind` reporting become ambiguous.
+Option A keeps each transport self-contained and preserves the existing router contract.
+
+### TCP as the data layer
+
+Once the P2P IP interface exists, the `Connection` impl is backed by a TCP stream. Byte
+framing uses a 4-byte big-endian length prefix, matching `QuicConnection`. The Noise
+handshake runs over the TCP stream unchanged: `Session::initiate()` and
+`Session::respond()` call `send_bytes` and `recv_bytes` with no knowledge of what is
+underneath.
+
+QUIC could also run over the P2P interface, but it would create a compile-time dependency
+between `pathweave-transport-wifi-direct` and `pathweave-transport-quic` and duplicate
+the connection establishment work that Noise already handles. TCP is sufficient: it is
+reliable, in-order, and universally available on the P2P interface on both Linux and
+Windows.
+
+### `PeerAddress::WifiDirect(String)` — two-phase address lifecycle
+
+`discover()` emits `PeerAnnouncement` entries before any P2P connection exists. At that
+point the only identifier available is a platform-specific device identifier: a MAC
+address string on Linux (from wpa_supplicant), a WinRT device ID on Windows. These are
+structurally identical to `PeerAddress::Ble(String)`, which holds a BLE peripheral
+address before connection.
+
+`PeerAddress::WifiDirect(String)` holds this pre-connection identifier. The SocketAddr
+of the established P2P interface is an internal transport detail, resolved inside
+`connect()` and never surfaced as a `PeerAddress`. The router and peer table remain
+agnostic to how the transport establishes the link.
+
+### GO election by `short_id` comparison
+
+When two Pathweave nodes connect via WiFi Direct, one must become the Group Owner and one
+the client. Leaving this to the platform without explicit intent values risks a deadlock:
+if both sides signal neutral intent (intent=7 in wpa_supplicant), the platform may choose
+inconsistently or stall.
+
+The rule: the side with the lexicographically greater `short_id` (first 8 bytes of the
+PeerId, present in `PeerAnnouncement` at discovery time) becomes GO. Both sides compute
+this from the same `short_id` they already have, independently and without coordination.
+
+On Linux, intent values map the rule directly: the GO side passes `go_intent=15` to
+`P2PConnect`; the client side passes `go_intent=0`. On Windows, the GO side runs
+`WiFiDirectAdvertisementPublisher` and `WiFiDirectConnectionListener`; the client side
+calls `WiFiDirectDevice::FromIdAsync()`. The same `short_id` comparison determines which
+role each side takes before touching the platform API.
+
+If `short_id` is absent from the `PeerAnnouncement` (not populated at discovery time),
+the transport falls back to treating this node as client. The remote will attempt GO; if
+it also has no `short_id` it will also fall back to client, and one side will fail to
+connect. This is a degenerate case that does not arise when both nodes run this
+implementation, because `discover()` always populates `short_id` from the P2P service
+record.
+
+### Wire format for address exchange
+
+Address type byte `0x03` is assigned to `PeerAddress::WifiDirect` in the address
+exchange frame (ADR 017). The encoding is identical to `PeerAddress::Ble` (`0x02`):
+one byte type, one byte length, length bytes of UTF-8 device identifier. The same
+decoder handles both.
+
+## Rationale
+
+**Why not Option B (QUIC over P2P)?**
+
+Option B blurs the transport boundary. The router selects among registered transports
+by cost and kind. If a WiFi Direct connectivity layer surfaces a QUIC connection on the
+P2P interface, that connection appears as `TransportKind::Quic` with `TransportCost::?`
+at a QUIC port that nobody dialled directly. `MessageDelivered` events would report the
+wrong kind. Cost ordering would not account for the underlying medium correctly. Option A
+keeps all of this clean.
+
+**Why TCP and not QUIC within Option A?**
+
+QUIC within a `WifiDirectTransport` would require importing `pathweave-transport-quic`
+internals (the TLS certificate generation, the Quinn configuration) or duplicating them.
+TCP gives the same reliable byte stream without the dependency. The Noise layer above TCP
+provides authentication and encryption; QUIC's TLS would be redundant.
+
+**Why `short_id` and not full PeerId for GO election?**
+
+The full 32-byte PeerId is not available at P2P discovery time on either platform. The
+wpa_supplicant `P2PPeerFound` signal includes the peer's P2P device address (a MAC) and
+service data; the full PeerId is not transmitted until after the Noise handshake. The
+`short_id` (first 8 bytes) is embedded in the P2P service record and is available before
+connection. The collision probability (two peers sharing the same 8-byte prefix) is 1 in
+2^64, which is negligible for any realistic mesh size.
+
+## Implications
+
+- `PeerAddress::WifiDirect(String)` and `TransportKind::WifiDirect` are new variants.
+  All exhaustive matches over these enums in `pathweave-core`, `pathweave-transport-wifi-direct`,
+  and `pw-chat` must be updated.
+- `encode_addr_exchange` and `decode_addr_exchange` in `router.rs` gain address type
+  byte `0x03` for WiFi Direct, encoded identically to BLE (`0x02`).
+- A new crate `pathweave-transport-wifi-direct` is added to the workspace. It has no
+  compile-time dependency on `pathweave-transport-quic`.
+- Platform dependencies are target-gated: `zbus` on Linux, `windows` crate
+  (`Devices_WiFiDirect` and `Networking_Sockets` features) on Windows. Other platforms
+  produce a compile error at the `WifiDirectTransport::new()` call site with a clear
+  message.
+- The P2P service name embedded in the wpa_supplicant service record and the WinRT
+  advertisement must be the same on both platforms so that cross-platform discovery
+  works. The agreed name is `pathweave-p2p`.
+- macOS does not support third-party WiFi Direct access. No stub or placeholder is
+  provided for macOS in this crate.


### PR DESCRIPTION
## What changed

This PR introduces `pathweave-transport-wifi-direct`, a new workspace crate that implements the `Transport` trait over IEEE 802.11 P2P WiFi Direct links. Discovery, P2P negotiation, and data framing are all handled inside the transport; the router sees it as an independent transport alongside QUIC and BLE.

The implementation targets Linux (via wpa_supplicant over zbus D-Bus) and Windows (via WinRT `Windows.Devices.WiFiDirect`). Both backends produce a TCP `Connection` with 4-byte big-endian length-prefix framing, identical to `QuicConnection`. Noise runs over the TCP stream unchanged.

`PeerAddress::WifiDirect(String)` and `TransportKind::WifiDirect` are new variants across `pathweave-core`. Address exchange (ADR 017) gains wire type byte `0x03`, encoded identically to BLE. All exhaustive matches in `pathweave-core`, `pw-chat`, and the transport itself are updated.

Design decisions are documented in ADR 022 (`notes/decisions/022-wifi-direct-transport.md`).

## Why

Closes #92.

QUIC needs an existing IP network. BLE tops out at 50m and low throughput. WiFi Direct fills the gap: device-to-device IP at WiFi speeds across ~200m line of sight, zero infrastructure cost.

## Alternatives considered

**Option B (connectivity-only layer, QUIC over P2P):** WiFi Direct establishes the link and hands the resulting P2P IP addresses to the QUIC transport for data. Avoids duplicating framing logic but blurs the transport boundary: the router would see a QUIC connection on a P2P interface and be unable to attribute cost or `TransportKind` correctly. `MessageDelivered` events would report the wrong kind. Option A (full Transport) keeps each transport self-contained and is consistent with how BLE is modelled.

**QUIC as the data layer inside Option A:** QUIC within `WifiDirectTransport` would require importing `pathweave-transport-quic` internals (TLS certificate generation, Quinn configuration) or duplicating them. TCP gives the same reliable byte stream without the dependency. Noise above TCP provides authentication and encryption; QUIC's TLS would be redundant.

**Unsafe `Send` impls for WinRT objects:** The initial Windows design stored WinRT COM objects in `WindowsState` and used `unsafe impl Send/Sync`. The crate has `#![forbid(unsafe_code)]`. The fix: all WinRT objects live on a dedicated `std::thread`; only `Send` types cross into `tokio` contexts. The `tokio::runtime::Handle` captured before the thread spawn lets WinRT callback threads call `handle.spawn()` without a resident runtime. This is the same pattern used by the BLE Windows backend.

**`block_in_place` scope:** `WiFiDirectDevice::FromIdAsync()` returns a WinRT IAsyncOperation that is not `Send`. Awaiting it would require the outer future to be `Send` (it must be, for `async_trait`). All WinRT calls in `connect()` and `handle_incoming()` are enclosed in `block_in_place`, extracting only a plain `String` IP address before any `.await`. No WinRT object crosses an await boundary.

## Security considerations

`short_id` (the first 8 bytes of the `PeerId`) is embedded in the P2P service record and is transmitted in plaintext during WiFi Direct discovery. `PeerId` is a 32-byte hash of the static public key; `short_id` exposes the first 8 bytes of that hash. An observer learns no private key material and cannot derive the full `PeerId` from the truncated prefix. The same 8 bytes are visible to any node that completes a Noise_XX handshake with this peer: the static public key is exchanged in plaintext in Noise_XX messages 2 and 3. The advertisement adds no new information beyond what a successful handshake already reveals.

GO election uses `short_id` comparison, not a negotiated protocol. Both sides independently reach the same role assignment from the same advertisement-time data without exchanging additional messages. There is no role negotiation step that an attacker could interfere with to force a deadlock.

## Test plan

- [x] `cargo check --workspace` clean on Windows (the target platform for this session)
- [x] `cargo clippy --workspace` clean, no warnings
- [x] `cargo fmt --all` applied; both backends reformatted without logic changes
- [x] `cargo test -p pathweave-transport-wifi-direct` passes (no tests yet, confirms crate compiles clean)
- [ ] Linux end-to-end: two devices, `discover()` emits peer, `connect()` establishes TCP, Noise handshake completes (requires two Linux machines with wpa_supplicant 2.10+)
- [ ] Windows end-to-end: same scenario on two Windows 11 machines