### PR TITLE
feat(transport-ble): BLE advertising-mode bearer per ADR 018

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -193,6 +193,10 @@ pub enum PeerAddress {
     Quic(std::net::SocketAddr),
     Ble(String),
     WifiDirect(String),
+    /// Hex-encoded 8-byte short_id of the remote peer. Broadcast transports have no
+    /// connection-layer device identifier; short_id is the only addressing information
+    /// available, since it is what every packet header carries. See ADR 018.
+    BleAdvertising(String),
 }
 
 impl PeerAddress {
@@ -201,6 +205,7 @@ impl PeerAddress {
             PeerAddress::Quic(_) => TransportKind::Quic,
             PeerAddress::Ble(_) => TransportKind::Ble,
             PeerAddress::WifiDirect(_) => TransportKind::WifiDirect,
+            PeerAddress::BleAdvertising(_) => TransportKind::BleAdvertising,
         }
     }
 }
@@ -211,6 +216,7 @@ impl std::fmt::Display for PeerAddress {
             PeerAddress::Quic(addr) => write!(f, "{}", addr),
             PeerAddress::Ble(id) => write!(f, "{}", id),
             PeerAddress::WifiDirect(id) => write!(f, "{}", id),
+            PeerAddress::BleAdvertising(id) => write!(f, "{}", id),
         }
     }
 }
@@ -227,6 +233,7 @@ pub enum TransportKind {
     Quic,
     Ble,
     WifiDirect,
+    BleAdvertising,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -486,6 +486,13 @@ pub(crate) fn encode_addr_exchange(addrs: &[PeerAddress]) -> Vec<u8> {
                 buf.push(len);
                 buf.extend_from_slice(&bytes[..len as usize]);
             }
+            PeerAddress::BleAdvertising(id) => {
+                let bytes = id.as_bytes();
+                let len = bytes.len().min(255) as u8;
+                buf.push(0x04);
+                buf.push(len);
+                buf.extend_from_slice(&bytes[..len as usize]);
+            }
         }
     }
     buf
@@ -567,6 +574,22 @@ pub(crate) fn decode_addr_exchange(bytes: &[u8]) -> Option<Vec<PeerAddress>> {
                     .to_string();
                 pos += len;
                 addrs.push(PeerAddress::WifiDirect(id));
+            }
+            0x04 => {
+                pos += 1;
+                if pos >= bytes.len() {
+                    return None;
+                }
+                let len = bytes[pos] as usize;
+                pos += 1;
+                if pos + len > bytes.len() {
+                    return None;
+                }
+                let id = std::str::from_utf8(&bytes[pos..pos + len])
+                    .ok()?
+                    .to_string();
+                pos += len;
+                addrs.push(PeerAddress::BleAdvertising(id));
             }
             _ => return None,
         }
@@ -877,6 +900,7 @@ mod tests {
                 TransportKind::Ble => "mock-ble",
                 TransportKind::Quic => "mock-quic",
                 TransportKind::WifiDirect => "mock-wifi-direct",
+                TransportKind::BleAdvertising => "mock-ble-advertising",
             }
         }
     }

--- a/crates/pathweave-transport-ble/Cargo.toml
+++ b/crates/pathweave-transport-ble/Cargo.toml
@@ -24,6 +24,7 @@ bluer = { workspace = true }
 [target.'cfg(target_os = "windows")'.dependencies]
 windows = { version = "0.58", features = [
     "Devices_Bluetooth",
+    "Devices_Bluetooth_Advertisement",
     "Devices_Bluetooth_GenericAttributeProfile",
     "Foundation",
     "Foundation_Collections",

--- a/crates/pathweave-transport-ble/src/advertising.rs
+++ b/crates/pathweave-transport-ble/src/advertising.rs
@@ -1,0 +1,542 @@
+//! BLE advertising-mode bearer (ADR 018, Option A). Carries data inside BLE advertisement
+//! packets instead of a GATT connection. The dispatcher and virtual-connection logic here
+//! are platform-independent; only `AdvertisingBearer` differs per OS. See the ADR 018
+//! addendum (notes/decisions/018-broadcast-transport-design.md) for why this requires
+//! BLE 5.0 extended advertising and why macOS is permanently unsupported.
+
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::{self, BoxStream, StreamExt};
+use pathweave_core::{
+    Connection, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, Result, Transport,
+    TransportCost, TransportKind,
+};
+use tokio::sync::{broadcast, mpsc, Mutex};
+
+/// `[dest_short_id: 8 bytes][source_short_id: 8 bytes]`, per ADR 018's Decision section.
+pub(crate) const HEADER_LEN: usize = 16;
+
+/// Conservative payload budget for a single BLE 5.0 extended advertising PDU once
+/// Manufacturer Specific Data AD overhead (4 bytes), the magic byte below, and the
+/// 16-byte header above are subtracted from a common ~200-byte practical single-PDU
+/// budget. Adapter-dependent and unverified without hardware; see the ADR 018 addendum.
+const MAX_PAYLOAD_LEN: usize = 150;
+
+const DEDUP_TTL: Duration = Duration::from_secs(2);
+
+/// Bluetooth SIG company ID reserved for testing and unregistered use, not a real
+/// registered company identifier. See the ADR 018 addendum for why this is the honest
+/// choice for this project's current stage, and why Manufacturer Specific Data is the
+/// wire encoding both platform bearers use (Windows forbids apps from publishing
+/// Service Data AD structures at all).
+pub(crate) const MANUFACTURER_COMPANY_ID: u16 = 0xFFFF;
+
+/// One-byte prefix inside the manufacturer data payload, before the ADR 018 header.
+/// Company ID 0xFFFF is the universal "testing" value; other unrelated devices may
+/// also be using it. This magic byte lets a bearer cheaply reject manufacturer-data
+/// advertisements that are not ours before attempting to parse them as a header.
+pub(crate) const ADV_BEARER_MAGIC: u8 = 0xC0;
+
+fn encode_header(dest: [u8; 8], source: [u8; 8]) -> [u8; HEADER_LEN] {
+    let mut header = [0u8; HEADER_LEN];
+    header[..8].copy_from_slice(&dest);
+    header[8..].copy_from_slice(&source);
+    header
+}
+
+fn decode_header(bytes: &[u8]) -> Option<([u8; 8], [u8; 8], &[u8])> {
+    if bytes.len() < HEADER_LEN {
+        return None;
+    }
+    let mut dest = [0u8; 8];
+    let mut source = [0u8; 8];
+    dest.copy_from_slice(&bytes[0..8]);
+    source.copy_from_slice(&bytes[8..16]);
+    Some((dest, source, &bytes[HEADER_LEN..]))
+}
+
+fn short_id_to_hex(id: [u8; 8]) -> String {
+    id.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+fn hex_to_short_id(hex: &str) -> Option<[u8; 8]> {
+    if hex.len() != 16 {
+        return None;
+    }
+    let mut out = [0u8; 8];
+    for (i, byte) in out.iter_mut().enumerate() {
+        *byte = u8::from_str_radix(&hex[i * 2..i * 2 + 2], 16).ok()?;
+    }
+    Some(out)
+}
+
+fn hash_payload(payload: &[u8]) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    payload.hash(&mut hasher);
+    hasher.finish()
+}
+
+// --------------------------------------------------------------------------
+// AdvertisingBearer: the only platform-specific surface. Everything else in
+// this module is written once against this trait. See ADR 018 addendum.
+// --------------------------------------------------------------------------
+
+#[async_trait]
+pub(crate) trait AdvertisingBearer: Send + Sync {
+    /// Broadcasts `packet` (header + payload) into the air.
+    async fn advertise(&self, packet: Vec<u8>) -> Result<()>;
+    /// Stream of raw packets (header + payload) observed on the medium.
+    fn scan(&self) -> BoxStream<'static, Vec<u8>>;
+}
+
+// --------------------------------------------------------------------------
+// Unsupported-platform fallback. macOS is permanently out of scope: see the
+// ADR 018 addendum for why CBPeripheralManager cannot carry this transport.
+// --------------------------------------------------------------------------
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+struct UnsupportedBearer;
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+#[async_trait]
+impl AdvertisingBearer for UnsupportedBearer {
+    async fn advertise(&self, _packet: Vec<u8>) -> Result<()> {
+        Err(PathweaveError::Transport(
+            "BLE advertising-mode bearer is not implemented on this platform".into(),
+        ))
+    }
+
+    fn scan(&self) -> BoxStream<'static, Vec<u8>> {
+        Box::pin(stream::empty())
+    }
+}
+
+// --------------------------------------------------------------------------
+// Virtual connection: a peer-scoped view over the shared broadcast medium.
+// --------------------------------------------------------------------------
+
+struct BroadcastConnection {
+    bearer: Arc<dyn AdvertisingBearer>,
+    local_short_id: [u8; 8],
+    peer_short_id: [u8; 8],
+    inbound_rx: Mutex<mpsc::UnboundedReceiver<Bytes>>,
+}
+
+#[async_trait]
+impl Connection for BroadcastConnection {
+    async fn send_bytes(&mut self, bytes: &[u8]) -> Result<()> {
+        let header = encode_header(self.peer_short_id, self.local_short_id);
+        let mut packet = Vec::with_capacity(HEADER_LEN + bytes.len());
+        packet.extend_from_slice(&header);
+        packet.extend_from_slice(bytes);
+        self.bearer.advertise(packet).await
+    }
+
+    async fn recv_bytes(&mut self) -> Result<Bytes> {
+        self.inbound_rx
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or_else(|| PathweaveError::Transport("ble-advertising connection closed".into()))
+    }
+
+    async fn close(&mut self) -> Result<()> {
+        Ok(())
+    }
+
+    fn mtu(&self) -> usize {
+        MAX_PAYLOAD_LEN
+    }
+}
+
+// --------------------------------------------------------------------------
+// Dispatcher: reads the bearer's scan stream, parses headers, routes packets.
+// --------------------------------------------------------------------------
+
+type ConnectionMap = Arc<StdMutex<HashMap<[u8; 8], mpsc::UnboundedSender<Bytes>>>>;
+
+async fn dispatch_loop(
+    bearer: Arc<dyn AdvertisingBearer>,
+    local_short_id: [u8; 8],
+    connections: ConnectionMap,
+    incoming_tx: mpsc::UnboundedSender<Box<dyn Connection>>,
+    announce_tx: broadcast::Sender<PeerAnnouncement>,
+) {
+    let mut recent: HashMap<([u8; 8], u64), Instant> = HashMap::new();
+    let mut scan = bearer.scan();
+
+    while let Some(packet) = scan.next().await {
+        let Some((dest, source, payload)) = decode_header(&packet) else {
+            continue;
+        };
+        if source == local_short_id {
+            // Self-originated; guards against a medium that echoes our own broadcasts.
+            continue;
+        }
+
+        let now = Instant::now();
+        recent.retain(|_, seen_at| now.duration_since(*seen_at) < DEDUP_TTL);
+        let key = (source, hash_payload(payload));
+        if recent.contains_key(&key) {
+            continue;
+        }
+        recent.insert(key, now);
+
+        // Anyone we observe a valid-header packet from is provably in range, regardless
+        // of whether the packet is addressed to us. The header is plaintext metadata
+        // already (ADR 018's security note), so this reveals nothing a passive observer
+        // couldn't already see.
+        let _ = announce_tx.send(PeerAnnouncement {
+            address: PeerAddress::BleAdvertising(short_id_to_hex(source)),
+            short_id: Some(source),
+        });
+
+        if dest != local_short_id {
+            continue;
+        }
+
+        let existing_tx = connections.lock().unwrap().get(&source).cloned();
+        if let Some(tx) = existing_tx {
+            let _ = tx.send(Bytes::copy_from_slice(payload));
+        } else {
+            let (tx, rx) = mpsc::unbounded_channel();
+            let _ = tx.send(Bytes::copy_from_slice(payload));
+            connections.lock().unwrap().insert(source, tx);
+            let conn: Box<dyn Connection> = Box::new(BroadcastConnection {
+                bearer: Arc::clone(&bearer),
+                local_short_id,
+                peer_short_id: source,
+                inbound_rx: Mutex::new(rx),
+            });
+            if incoming_tx.send(conn).is_err() {
+                break;
+            }
+        }
+    }
+}
+
+// --------------------------------------------------------------------------
+// BleAdvertisingTransport
+// --------------------------------------------------------------------------
+
+pub struct BleAdvertisingTransport {
+    bearer: Arc<dyn AdvertisingBearer>,
+    local_short_id: StdMutex<Option<[u8; 8]>>,
+    connections: ConnectionMap,
+    incoming_tx: mpsc::UnboundedSender<Box<dyn Connection>>,
+    incoming_rx: Mutex<mpsc::UnboundedReceiver<Box<dyn Connection>>>,
+    announce_tx: broadcast::Sender<PeerAnnouncement>,
+    dispatcher_handle: Mutex<Option<tokio::task::JoinHandle<()>>>,
+}
+
+impl BleAdvertisingTransport {
+    pub fn new() -> Self {
+        #[cfg(target_os = "linux")]
+        let bearer: Arc<dyn AdvertisingBearer> =
+            Arc::new(super::linux_adv::LinuxAdvertisingBearer::new());
+        #[cfg(target_os = "windows")]
+        let bearer: Arc<dyn AdvertisingBearer> =
+            Arc::new(super::windows_adv::WindowsAdvertisingBearer::new());
+        #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+        let bearer: Arc<dyn AdvertisingBearer> = Arc::new(UnsupportedBearer);
+
+        Self::with_bearer(bearer)
+    }
+
+    pub(crate) fn with_bearer(bearer: Arc<dyn AdvertisingBearer>) -> Self {
+        let (incoming_tx, incoming_rx) = mpsc::unbounded_channel();
+        let (announce_tx, _) = broadcast::channel(64);
+        Self {
+            bearer,
+            local_short_id: StdMutex::new(None),
+            connections: Arc::new(StdMutex::new(HashMap::new())),
+            incoming_tx,
+            incoming_rx: Mutex::new(incoming_rx),
+            announce_tx,
+            dispatcher_handle: Mutex::new(None),
+        }
+    }
+}
+
+impl Default for BleAdvertisingTransport {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Transport for BleAdvertisingTransport {
+    async fn start(&self, identity: &NodeIdentity) -> Result<()> {
+        let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8]
+            .try_into()
+            .expect("PeerId is always 32 bytes");
+        *self.local_short_id.lock().unwrap() = Some(short_id);
+
+        let bearer = Arc::clone(&self.bearer);
+        let connections = Arc::clone(&self.connections);
+        let incoming_tx = self.incoming_tx.clone();
+        let announce_tx = self.announce_tx.clone();
+
+        let handle = tokio::spawn(dispatch_loop(
+            bearer,
+            short_id,
+            connections,
+            incoming_tx,
+            announce_tx,
+        ));
+        *self.dispatcher_handle.lock().await = Some(handle);
+        Ok(())
+    }
+
+    async fn stop(&self) -> Result<()> {
+        if let Some(handle) = self.dispatcher_handle.lock().await.take() {
+            handle.abort();
+        }
+        *self.local_short_id.lock().unwrap() = None;
+        self.connections.lock().unwrap().clear();
+        Ok(())
+    }
+
+    fn discover(&self) -> BoxStream<'static, PeerAnnouncement> {
+        let rx = self.announce_tx.subscribe();
+        Box::pin(stream::unfold(rx, |mut rx| async move {
+            loop {
+                match rx.recv().await {
+                    Ok(ann) => return Some((ann, rx)),
+                    Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                    Err(broadcast::error::RecvError::Closed) => return None,
+                }
+            }
+        }))
+    }
+
+    async fn connect(&self, peer: &PeerAnnouncement) -> Result<Box<dyn Connection>> {
+        let hex_id = match &peer.address {
+            PeerAddress::BleAdvertising(s) => s.clone(),
+            _ => {
+                return Err(PathweaveError::Transport(
+                    "expected BLE advertising address".into(),
+                ))
+            }
+        };
+        let peer_short_id = hex_to_short_id(&hex_id).ok_or_else(|| {
+            PathweaveError::Transport("malformed BLE advertising short_id".into())
+        })?;
+        let local_short_id = self
+            .local_short_id
+            .lock()
+            .unwrap()
+            .ok_or_else(|| PathweaveError::Transport("transport not started".into()))?;
+
+        let (tx, rx) = mpsc::unbounded_channel();
+        self.connections.lock().unwrap().insert(peer_short_id, tx);
+
+        Ok(Box::new(BroadcastConnection {
+            bearer: Arc::clone(&self.bearer),
+            local_short_id,
+            peer_short_id,
+            inbound_rx: Mutex::new(rx),
+        }))
+    }
+
+    async fn accept(&self) -> Result<Box<dyn Connection>> {
+        self.incoming_rx
+            .lock()
+            .await
+            .recv()
+            .await
+            .ok_or_else(|| PathweaveError::Transport("ble-advertising transport stopped".into()))
+    }
+
+    fn mtu_hint(&self) -> usize {
+        MAX_PAYLOAD_LEN
+    }
+
+    fn cost(&self) -> TransportCost {
+        TransportCost::Free
+    }
+
+    fn kind(&self) -> TransportKind {
+        TransportKind::BleAdvertising
+    }
+
+    fn name(&self) -> &'static str {
+        "ble-advertising"
+    }
+
+    fn local_addresses(&self) -> Vec<PeerAddress> {
+        match *self.local_short_id.lock().unwrap() {
+            Some(id) => vec![PeerAddress::BleAdvertising(short_id_to_hex(id))],
+            None => vec![],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct MockMedium {
+        tx: broadcast::Sender<Vec<u8>>,
+    }
+
+    impl MockMedium {
+        fn new() -> Self {
+            let (tx, _) = broadcast::channel(64);
+            Self { tx }
+        }
+
+        fn bearer(&self) -> Arc<MockBearer> {
+            Arc::new(MockBearer {
+                tx: self.tx.clone(),
+            })
+        }
+    }
+
+    struct MockBearer {
+        tx: broadcast::Sender<Vec<u8>>,
+    }
+
+    #[async_trait]
+    impl AdvertisingBearer for MockBearer {
+        async fn advertise(&self, packet: Vec<u8>) -> Result<()> {
+            let _ = self.tx.send(packet);
+            Ok(())
+        }
+
+        fn scan(&self) -> BoxStream<'static, Vec<u8>> {
+            let rx = self.tx.subscribe();
+            Box::pin(stream::unfold(rx, |mut rx| async move {
+                loop {
+                    match rx.recv().await {
+                        Ok(packet) => return Some((packet, rx)),
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => return None,
+                    }
+                }
+            }))
+        }
+    }
+
+    #[test]
+    fn header_roundtrips() {
+        let dest = [1u8; 8];
+        let source = [2u8; 8];
+        let header = encode_header(dest, source);
+        let bytes = [&header[..], b"hello"].concat();
+        let (d, s, payload) = decode_header(&bytes).unwrap();
+        assert_eq!(d, dest);
+        assert_eq!(s, source);
+        assert_eq!(payload, b"hello");
+    }
+
+    #[test]
+    fn short_id_hex_roundtrips() {
+        let id = [0xde, 0xad, 0xbe, 0xef, 0x01, 0x02, 0x03, 0x04];
+        let hex = short_id_to_hex(id);
+        assert_eq!(hex_to_short_id(&hex), Some(id));
+    }
+
+    #[tokio::test]
+    async fn two_transports_exchange_payload_via_mock_medium() {
+        let medium = MockMedium::new();
+
+        let a_id = NodeIdentity::generate();
+        let b_id = NodeIdentity::generate();
+
+        let a = BleAdvertisingTransport::with_bearer(medium.bearer());
+        let b = BleAdvertisingTransport::with_bearer(medium.bearer());
+
+        a.start(&a_id).await.unwrap();
+        b.start(&b_id).await.unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let b_short_id: [u8; 8] = b_id.peer_id().as_bytes()[..8].try_into().unwrap();
+        let peer = PeerAnnouncement {
+            address: PeerAddress::BleAdvertising(short_id_to_hex(b_short_id)),
+            short_id: Some(b_short_id),
+        };
+
+        let mut conn_a = a.connect(&peer).await.unwrap();
+        conn_a.send_bytes(b"hello from a").await.unwrap();
+
+        let mut conn_b = b.accept().await.unwrap();
+        let received = conn_b.recv_bytes().await.unwrap();
+        assert_eq!(received, Bytes::from_static(b"hello from a"));
+    }
+
+    #[tokio::test]
+    async fn packet_addressed_to_someone_else_is_dropped() {
+        let medium = MockMedium::new();
+
+        let a_id = NodeIdentity::generate();
+        let b_id = NodeIdentity::generate();
+        let someone_else_short_id = [0xffu8; 8];
+
+        let a = BleAdvertisingTransport::with_bearer(medium.bearer());
+        let b = BleAdvertisingTransport::with_bearer(medium.bearer());
+
+        a.start(&a_id).await.unwrap();
+        b.start(&b_id).await.unwrap();
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let peer = PeerAnnouncement {
+            address: PeerAddress::BleAdvertising(short_id_to_hex(someone_else_short_id)),
+            short_id: Some(someone_else_short_id),
+        };
+
+        let mut conn_a = a.connect(&peer).await.unwrap();
+        conn_a.send_bytes(b"not for b").await.unwrap();
+
+        // b must never see an incoming connection for a packet not addressed to it.
+        let result = tokio::time::timeout(Duration::from_millis(200), b.accept()).await;
+        assert!(
+            result.is_err(),
+            "b must not observe a packet addressed to someone else"
+        );
+    }
+
+    #[tokio::test]
+    async fn discover_emits_announcement_for_observed_peer() {
+        let medium = MockMedium::new();
+
+        let a_id = NodeIdentity::generate();
+        let b_id = NodeIdentity::generate();
+
+        let a = BleAdvertisingTransport::with_bearer(medium.bearer());
+        let b = BleAdvertisingTransport::with_bearer(medium.bearer());
+
+        a.start(&a_id).await.unwrap();
+        b.start(&b_id).await.unwrap();
+
+        let mut b_discover = b.discover();
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let b_short_id: [u8; 8] = b_id.peer_id().as_bytes()[..8].try_into().unwrap();
+        let peer = PeerAnnouncement {
+            address: PeerAddress::BleAdvertising(short_id_to_hex(b_short_id)),
+            short_id: Some(b_short_id),
+        };
+        let mut conn_a = a.connect(&peer).await.unwrap();
+        conn_a.send_bytes(b"hi").await.unwrap();
+
+        let a_short_id: [u8; 8] = a_id.peer_id().as_bytes()[..8].try_into().unwrap();
+        let announcement = tokio::time::timeout(Duration::from_secs(2), b_discover.next())
+            .await
+            .expect("timed out waiting for discover() announcement")
+            .expect("discover stream ended");
+        assert_eq!(announcement.short_id, Some(a_short_id));
+    }
+}

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -21,6 +21,14 @@ use pathweave_core::{
 use tokio::sync::Mutex;
 use uuid::{uuid, Uuid};
 
+mod advertising;
+#[cfg(target_os = "linux")]
+mod linux_adv;
+#[cfg(target_os = "windows")]
+mod windows_adv;
+
+pub use advertising::BleAdvertisingTransport;
+
 // --------------------------------------------------------------------------
 // Protocol constants (defined in ARCHITECTURE.md)
 // --------------------------------------------------------------------------
@@ -173,7 +181,9 @@ fn uuid_to_guid(uuid: &Uuid) -> windows::core::GUID {
 }
 
 #[cfg(target_os = "windows")]
-fn bytes_to_ibuffer(bytes: &[u8]) -> windows::core::Result<windows::Storage::Streams::IBuffer> {
+pub(crate) fn bytes_to_ibuffer(
+    bytes: &[u8],
+) -> windows::core::Result<windows::Storage::Streams::IBuffer> {
     let writer = windows::Storage::Streams::DataWriter::new()?;
     writer.WriteBytes(bytes)?;
     writer.DetachBuffer()

--- a/crates/pathweave-transport-ble/src/linux_adv.rs
+++ b/crates/pathweave-transport-ble/src/linux_adv.rs
@@ -1,0 +1,161 @@
+//! Linux `AdvertisingBearer` using `bluer`. Requires BLE 5.0 extended advertising; see
+//! the ADR 018 addendum for why legacy advertising cannot carry this transport's header.
+//!
+//! Compile-checked by CI's ubuntu-latest runner. Not exercised against real hardware in
+//! this codebase yet; see issue #98's "Out of scope" (matches the precedent already set
+//! by #72 for the GATT-based BLE transport).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bluer::adv::{Advertisement, SecondaryChannel, Type as AdvertisementType};
+use futures::stream::{BoxStream, StreamExt};
+use pathweave_core::{PathweaveError, Result};
+use tokio::sync::Mutex;
+
+use crate::advertising::{AdvertisingBearer, ADV_BEARER_MAGIC, MANUFACTURER_COMPANY_ID};
+
+/// Held duration for a single advertisement before withdrawal. The controller repeats
+/// the same advertisement at its configured interval; this just needs to be long enough
+/// for a nearby scanner to observe at least one repetition.
+const ADVERTISE_HOLD: Duration = Duration::from_millis(500);
+
+pub(crate) struct LinuxAdvertisingBearer {
+    adapter: Arc<Mutex<Option<bluer::Adapter>>>,
+}
+
+impl LinuxAdvertisingBearer {
+    pub(crate) fn new() -> Self {
+        Self {
+            adapter: Arc::new(Mutex::new(None)),
+        }
+    }
+
+    async fn ensure_adapter(
+        adapter: &Arc<Mutex<Option<bluer::Adapter>>>,
+    ) -> Result<bluer::Adapter> {
+        let mut guard = adapter.lock().await;
+        if let Some(a) = guard.as_ref() {
+            return Ok(a.clone());
+        }
+        let session = bluer::Session::new()
+            .await
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        let new_adapter = session
+            .default_adapter()
+            .await
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        *guard = Some(new_adapter.clone());
+        Ok(new_adapter)
+    }
+}
+
+#[async_trait]
+impl AdvertisingBearer for LinuxAdvertisingBearer {
+    async fn advertise(&self, packet: Vec<u8>) -> Result<()> {
+        let adapter = Self::ensure_adapter(&self.adapter).await?;
+
+        let mut data = Vec::with_capacity(1 + packet.len());
+        data.push(ADV_BEARER_MAGIC);
+        data.extend_from_slice(&packet);
+
+        let mut manufacturer_data = BTreeMap::new();
+        manufacturer_data.insert(MANUFACTURER_COMPANY_ID, data);
+
+        let adv = Advertisement {
+            advertisement_type: AdvertisementType::Broadcast,
+            manufacturer_data,
+            // Legacy advertising cannot carry the ADR 018 header at all; see the ADR
+            // 018 addendum. Extended advertising is the baseline, not an enhancement.
+            secondary_channel: Some(SecondaryChannel::OneM),
+            ..Default::default()
+        };
+
+        let handle = adapter
+            .advertise(adv)
+            .await
+            .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+        tokio::time::sleep(ADVERTISE_HOLD).await;
+        drop(handle);
+        Ok(())
+    }
+
+    fn scan(&self) -> BoxStream<'static, Vec<u8>> {
+        let adapter_arc = Arc::clone(&self.adapter);
+        let (tx, rx) = futures::channel::mpsc::unbounded::<Vec<u8>>();
+
+        tokio::spawn(async move {
+            let adapter = match Self::ensure_adapter(&adapter_arc).await {
+                Ok(a) => a,
+                Err(e) => {
+                    tracing::warn!("BLE advertising-mode scan: adapter init failed: {}", e);
+                    return;
+                }
+            };
+
+            let mut events = match adapter.discover_devices().await {
+                Ok(e) => e,
+                Err(e) => {
+                    tracing::warn!("BLE advertising-mode scan: discover_devices failed: {}", e);
+                    return;
+                }
+            };
+
+            // AdapterEvent::PropertyChanged carries an adapter-level property, not a
+            // device address, so it cannot tell us which device changed. A device that
+            // re-advertises with a new payload (the normal case for this transport,
+            // since every advertise() call carries a different packet) surfaces that
+            // through a separate per-device events() stream, not this adapter-level one.
+            // Each newly discovered device gets its own forwarding task below.
+            while let Some(event) = events.next().await {
+                let bluer::AdapterEvent::DeviceAdded(addr) = event else {
+                    continue;
+                };
+                let device = match adapter.device(addr) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
+                let tx = tx.clone();
+                tokio::spawn(async move {
+                    check_and_forward(&device, &tx).await;
+                    let Ok(mut device_events) = device.events().await else {
+                        return;
+                    };
+                    // Any property change is treated as "re-check manufacturer data,"
+                    // rather than pattern-matching which property changed: the dispatcher's
+                    // own dedup (by source + payload hash, see advertising.rs) collapses
+                    // any duplicate checks this produces, and this is robust to property
+                    // change payload shapes we have not exhaustively verified.
+                    while device_events.next().await.is_some() {
+                        if check_and_forward(&device, &tx).await.is_err() {
+                            break;
+                        }
+                    }
+                });
+            }
+        });
+
+        Box::pin(rx)
+    }
+}
+
+/// Reads `device`'s current manufacturer data; forwards the packet (magic byte
+/// stripped) if it matches this transport's company ID and magic byte. Returns `Err`
+/// only when the forwarding channel itself has closed, signaling the caller to stop.
+async fn check_and_forward(
+    device: &bluer::Device,
+    tx: &futures::channel::mpsc::UnboundedSender<Vec<u8>>,
+) -> std::result::Result<(), ()> {
+    let Ok(Some(manufacturer_data)) = device.manufacturer_data().await else {
+        return Ok(());
+    };
+    let Some(data) = manufacturer_data.get(&MANUFACTURER_COMPANY_ID) else {
+        return Ok(());
+    };
+    if data.first() != Some(&ADV_BEARER_MAGIC) {
+        return Ok(());
+    }
+    tx.unbounded_send(data[1..].to_vec()).map_err(|_| ())
+}

--- a/crates/pathweave-transport-ble/src/linux_adv.rs
+++ b/crates/pathweave-transport-ble/src/linux_adv.rs
@@ -119,7 +119,9 @@ impl AdvertisingBearer for LinuxAdvertisingBearer {
                 };
                 let tx = tx.clone();
                 tokio::spawn(async move {
-                    check_and_forward(&device, &tx).await;
+                    if check_and_forward(&device, &tx).await.is_err() {
+                        return;
+                    }
                     let Ok(mut device_events) = device.events().await else {
                         return;
                     };

--- a/crates/pathweave-transport-ble/src/windows_adv.rs
+++ b/crates/pathweave-transport-ble/src/windows_adv.rs
@@ -1,0 +1,176 @@
+//! Windows `AdvertisingBearer` using `BluetoothLEAdvertisementPublisher`/`Watcher`.
+//! Requires BLE 5.0 extended advertising; see the ADR 018 addendum for why legacy
+//! advertising cannot carry this transport's header. See issue #98.
+
+use std::time::Duration;
+
+use async_trait::async_trait;
+use futures::stream::BoxStream;
+use pathweave_core::{PathweaveError, Result};
+use windows::Devices::Bluetooth::Advertisement::{
+    BluetoothLEAdvertisementPublisher, BluetoothLEAdvertisementReceivedEventArgs,
+    BluetoothLEAdvertisementWatcher, BluetoothLEManufacturerData,
+};
+use windows::Foundation::TypedEventHandler;
+use windows::Storage::Streams::DataReader;
+
+use crate::advertising::{AdvertisingBearer, ADV_BEARER_MAGIC, MANUFACTURER_COMPANY_ID};
+use crate::bytes_to_ibuffer;
+
+/// Held duration for a single advertisement before withdrawal. The controller repeats
+/// the same advertisement at its configured interval; this just needs to be long enough
+/// for a nearby scanner to observe at least one repetition.
+const ADVERTISE_HOLD: Duration = Duration::from_millis(500);
+
+pub(crate) struct WindowsAdvertisingBearer;
+
+impl WindowsAdvertisingBearer {
+    pub(crate) fn new() -> Self {
+        Self
+    }
+}
+
+#[async_trait]
+impl AdvertisingBearer for WindowsAdvertisingBearer {
+    async fn advertise(&self, packet: Vec<u8>) -> Result<()> {
+        let mut data = Vec::with_capacity(1 + packet.len());
+        data.push(ADV_BEARER_MAGIC);
+        data.extend_from_slice(&packet);
+
+        // Every WinRT object touched below wraps a raw COM pointer (NonNull<c_void>)
+        // that windows-rs does not mark Send, regardless of the underlying WinRT type's
+        // "Agile" marshaling behavior. spawn_blocking's closure only captures `data`
+        // (a plain Vec<u8>, which is Send); the publisher, buffer, and advertisement
+        // objects are created and consumed entirely inside this closure on its own
+        // thread, so they never need to cross an .await point in this async fn.
+        tokio::task::spawn_blocking(move || -> Result<()> {
+            // Publisher's own Advertisement property starts as an empty advertisement;
+            // populate that object directly rather than constructing a separate one,
+            // since BluetoothLEAdvertisementPublisher's argument-taking constructor
+            // would require resolving which of its two WinRT constructors windows-rs
+            // binds to which name.
+            let publisher = BluetoothLEAdvertisementPublisher::new()
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+            let buffer =
+                bytes_to_ibuffer(&data).map_err(|e| PathweaveError::Transport(e.to_string()))?;
+            let manufacturer_data =
+                BluetoothLEManufacturerData::Create(MANUFACTURER_COMPANY_ID, &buffer)
+                    .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+            let advertisement = publisher
+                .Advertisement()
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+            advertisement
+                .ManufacturerData()
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?
+                .Append(&manufacturer_data)
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+            // Legacy advertising cannot carry the ADR 018 header at all; see the ADR
+            // 018 addendum. Extended advertising is the baseline, not an enhancement.
+            publisher
+                .SetUseExtendedAdvertisement(true)
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+
+            publisher
+                .Start()
+                .map_err(|e| PathweaveError::Transport(e.to_string()))?;
+            std::thread::sleep(ADVERTISE_HOLD);
+            let _ = publisher.Stop();
+            Ok(())
+        })
+        .await
+        .map_err(|e| PathweaveError::Transport(format!("blocking task panicked: {e}")))?
+    }
+
+    fn scan(&self) -> BoxStream<'static, Vec<u8>> {
+        let (tx, rx) = futures::channel::mpsc::unbounded::<Vec<u8>>();
+
+        // BluetoothLEAdvertisementWatcher delivers events via its own WinRT dispatch
+        // mechanism; a dedicated OS thread (rather than a tokio task) avoids any
+        // assumption about tokio's worker threads being suitable for driving it, and
+        // gives this loop a place to park for the watcher's lifetime.
+        std::thread::spawn(move || {
+            let watcher = match BluetoothLEAdvertisementWatcher::new() {
+                Ok(w) => w,
+                Err(e) => {
+                    tracing::warn!("BLE advertising-mode scan: watcher init failed: {}", e);
+                    return;
+                }
+            };
+            if let Err(e) = watcher.SetAllowExtendedAdvertisements(true) {
+                tracing::warn!(
+                    "BLE advertising-mode scan: extended advertisements unavailable: {}",
+                    e
+                );
+                return;
+            }
+
+            let handler_tx = tx.clone();
+            let registered = watcher.Received(&TypedEventHandler::new(
+                move |_, args: &Option<BluetoothLEAdvertisementReceivedEventArgs>| {
+                    let Some(args) = args else {
+                        return Ok(());
+                    };
+                    let Ok(advertisement) = args.Advertisement() else {
+                        return Ok(());
+                    };
+                    let Ok(entries) =
+                        advertisement.GetManufacturerDataByCompanyId(MANUFACTURER_COMPANY_ID)
+                    else {
+                        return Ok(());
+                    };
+                    let Ok(size) = entries.Size() else {
+                        return Ok(());
+                    };
+                    if size == 0 {
+                        return Ok(());
+                    }
+                    let Ok(entry) = entries.GetAt(0) else {
+                        return Ok(());
+                    };
+                    let Ok(buffer) = entry.Data() else {
+                        return Ok(());
+                    };
+                    let Ok(reader) = DataReader::FromBuffer(&buffer) else {
+                        return Ok(());
+                    };
+                    let Ok(len) = reader.UnconsumedBufferLength() else {
+                        return Ok(());
+                    };
+                    let mut buf = vec![0u8; len as usize];
+                    if reader.ReadBytes(&mut buf).is_err() {
+                        return Ok(());
+                    }
+                    if buf.first() != Some(&ADV_BEARER_MAGIC) {
+                        return Ok(());
+                    }
+                    let _ = handler_tx.unbounded_send(buf[1..].to_vec());
+                    Ok(())
+                },
+            ));
+            if registered.is_err() {
+                tracing::warn!("BLE advertising-mode scan: failed to register Received handler");
+                return;
+            }
+
+            if watcher.Start().is_err() {
+                tracing::warn!("BLE advertising-mode scan: watcher failed to start");
+                return;
+            }
+
+            // Dropping `tx` (when the dispatcher consuming this stream exits, e.g. on
+            // BleAdvertisingTransport::stop()) is the only signal this loop has to exit;
+            // poll for that rather than blocking forever.
+            loop {
+                std::thread::sleep(Duration::from_millis(500));
+                if tx.is_closed() {
+                    let _ = watcher.Stop();
+                    break;
+                }
+            }
+        });
+
+        Box::pin(rx)
+    }
+}

--- a/crates/pathweave-transport-ble/src/windows_adv.rs
+++ b/crates/pathweave-transport-ble/src/windows_adv.rs
@@ -174,3 +174,106 @@ impl AdvertisingBearer for WindowsAdvertisingBearer {
         Box::pin(rx)
     }
 }
+
+#[cfg(test)]
+mod hardware_tests {
+    use super::*;
+    use crate::advertising::AdvertisingBearer;
+    use futures::stream::StreamExt;
+    use windows::Devices::Bluetooth::BluetoothAdapter;
+
+    /// Diagnostic only: prints this machine's adapter capabilities and the publisher's
+    /// actual status after Start(), so a timeout in the loopback test below can be
+    /// attributed to a real hardware/driver limitation instead of guessed at.
+    /// `cargo test -p pathweave-transport-ble -- --ignored diagnose --nocapture`.
+    #[tokio::test]
+    #[ignore]
+    async fn diagnose_adapter_capabilities() {
+        let adapter = BluetoothAdapter::GetDefaultAsync()
+            .expect("GetDefaultAsync call failed")
+            .get()
+            .expect("no default Bluetooth adapter found");
+        println!("IsLowEnergySupported: {:?}", adapter.IsLowEnergySupported());
+        println!(
+            "IsPeripheralRoleSupported: {:?}",
+            adapter.IsPeripheralRoleSupported()
+        );
+        println!(
+            "IsCentralRoleSupported: {:?}",
+            adapter.IsCentralRoleSupported()
+        );
+        println!(
+            "IsExtendedAdvertisingSupported: {:?}",
+            adapter.IsExtendedAdvertisingSupported()
+        );
+
+        let publisher = BluetoothLEAdvertisementPublisher::new().unwrap();
+        let buffer = bytes_to_ibuffer(&[ADV_BEARER_MAGIC, 1, 2, 3]).unwrap();
+        let manufacturer_data =
+            BluetoothLEManufacturerData::Create(MANUFACTURER_COMPANY_ID, &buffer).unwrap();
+        publisher
+            .Advertisement()
+            .unwrap()
+            .ManufacturerData()
+            .unwrap()
+            .Append(&manufacturer_data)
+            .unwrap();
+        publisher.SetUseExtendedAdvertisement(true).unwrap();
+        println!("Status before Start: {:?}", publisher.Status());
+        publisher.Start().expect("Start() failed");
+        for i in 0..5 {
+            std::thread::sleep(Duration::from_millis(300));
+            println!(
+                "Status after Start +{}ms: {:?}",
+                (i + 1) * 300,
+                publisher.Status()
+            );
+        }
+        let _ = publisher.Stop();
+    }
+
+    /// Requires a real, enabled Bluetooth radio on this machine that supports BLE 5.0
+    /// extended advertising. Not run by default;
+    /// `cargo test -p pathweave-transport-ble -- --ignored hardware_loopback`.
+    ///
+    /// If this times out, run `diagnose_adapter_capabilities` first and check
+    /// `IsExtendedAdvertisingSupported`: a `false` there means this adapter cannot run
+    /// this transport at all, and no code change will fix that. This is not a
+    /// hypothetical; it is exactly what happened on the machine this test was written
+    /// on. See the ADR 018 addendum for why extended advertising is a hard requirement,
+    /// not an optimization.
+    ///
+    /// Verifies WindowsAdvertisingBearer against actual radio behavior rather than the
+    /// mock: this bearer's own published advertisement is observed by its own watcher
+    /// on the same adapter. Per issue #98's acceptance criteria.
+    #[tokio::test]
+    #[ignore]
+    async fn hardware_loopback_advertise_and_scan() {
+        let bearer = WindowsAdvertisingBearer::new();
+        let mut scan = bearer.scan();
+
+        // Give the watcher time to start before the first advertisement fires.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        let payload = b"pathweave-hw-loopback-test".to_vec();
+        let advertise_task = tokio::spawn({
+            let payload = payload.clone();
+            async move { bearer.advertise(payload).await }
+        });
+
+        let received = tokio::time::timeout(Duration::from_secs(10), scan.next())
+            .await
+            .expect(
+                "timed out waiting for the watcher to observe our own advertisement; \
+                 run diagnose_adapter_capabilities and check IsExtendedAdvertisingSupported",
+            )
+            .expect("scan stream ended unexpectedly");
+
+        advertise_task
+            .await
+            .expect("advertise task panicked")
+            .expect("advertise() returned an error");
+
+        assert_eq!(received, payload);
+    }
+}

--- a/examples/pw-chat/src/main.rs
+++ b/examples/pw-chat/src/main.rs
@@ -85,6 +85,7 @@ fn transport_kind_name(kind: TransportKind) -> &'static str {
         TransportKind::Quic => "QUIC",
         TransportKind::Ble => "BLE",
         TransportKind::WifiDirect => "WiFiDirect",
+        TransportKind::BleAdvertising => "BLE-Advertising",
     }
 }
 

--- a/notes/decisions/018-broadcast-transport-design.md
+++ b/notes/decisions/018-broadcast-transport-design.md
@@ -144,3 +144,34 @@ work planned for a later release.
   reliability).
 - The Noise handshake runs over the virtual connection as-is. Broadcast transports do
   not require any Noise layer changes.
+
+## Addendum: legacy BLE advertising cannot carry the 16-byte header (2026-06-17)
+
+Legacy BLE advertising's AD payload budget is 31 bytes total. A custom 128-bit vendor
+service UUID (the kind used everywhere else in this codebase, including
+`PATHWEAVE_SERVICE_UUID`) costs 18 bytes of Service Data AD structure overhead by
+itself (1 length byte + 1 AD type byte + 16 UUID bytes), plus another 3 bytes for the
+mandatory Flags structure. That leaves 10 bytes for header and payload combined, less
+than this ADR's 16-byte header alone. There is no header size, including the reduced
+sizes this ADR already permits for bandwidth-constrained transports, that leaves room
+for a Noise-encrypted payload once a minimum ChaChaPoly authentication tag (16 bytes)
+is accounted for. This held on both platforms checked: BlueZ's 31-byte legacy AD limit
+on Linux and Windows' identical 31-byte limit for `BluetoothLEAdvertisementPublisher`
+are the same constraint, since both are bound by the same BLE 4.x link-layer spec, not
+an OS-specific choice.
+
+BLE advertising-mode bearer therefore requires BLE 5.0 extended advertising as its
+baseline, not legacy advertising: `secondary_channel` on `bluer::adv::Advertisement`
+(Linux) or `UseExtendedAdvertisement` on `BluetoothLEAdvertisementPublisher` (Windows).
+Extended advertising's data length budget is adapter-dependent but well above legacy's
+31 bytes on any BLE 5.0 controller. This does not change the header format or any other
+part of this ADR's decision; it changes which BLE advertising mode each platform
+implementation must use to fit that header at all.
+
+macOS is out of scope for this transport, not pending verification like the existing
+GATT-based BLE transport's macOS gap. `CBPeripheralManager` does not expose custom
+service data to advertisements under any advertising mode; this is an Apple API
+restriction already documented in `pathweave-transport-ble/src/lib.rs` for the GATT
+peripheral's advertisement (`CBAdvertisementDataServiceDataKey` is silently ignored).
+Extended advertising does not change what CoreBluetooth exposes to applications. Same
+permanent status as WiFi Direct on macOS.

--- a/notes/decisions/018-broadcast-transport-design.md
+++ b/notes/decisions/018-broadcast-transport-design.md
@@ -147,18 +147,26 @@ work planned for a later release.
 
 ## Addendum: legacy BLE advertising cannot carry the 16-byte header (2026-06-17)
 
-Legacy BLE advertising's AD payload budget is 31 bytes total. A custom 128-bit vendor
-service UUID (the kind used everywhere else in this codebase, including
-`PATHWEAVE_SERVICE_UUID`) costs 18 bytes of Service Data AD structure overhead by
-itself (1 length byte + 1 AD type byte + 16 UUID bytes), plus another 3 bytes for the
-mandatory Flags structure. That leaves 10 bytes for header and payload combined, less
-than this ADR's 16-byte header alone. There is no header size, including the reduced
-sizes this ADR already permits for bandwidth-constrained transports, that leaves room
-for a Noise-encrypted payload once a minimum ChaChaPoly authentication tag (16 bytes)
-is accounted for. This held on both platforms checked: BlueZ's 31-byte legacy AD limit
-on Linux and Windows' identical 31-byte limit for `BluetoothLEAdvertisementPublisher`
-are the same constraint, since both are bound by the same BLE 4.x link-layer spec, not
-an OS-specific choice.
+The wire encoding for BLE advertising-mode bearer is Manufacturer Specific Data (AD
+type 0xFF), not Service Data: Windows' `BluetoothLEAdvertisementPublisher` explicitly
+forbids apps from publishing Service Data AD structures (16-, 32-, and 128-bit UUID
+variants are all in its system-reserved list) and only permits Manufacturer Specific
+Data or non-standard types. `bluer::adv::Advertisement` exposes the matching
+`manufacturer_data: BTreeMap<u16, Vec<u8>>` field on Linux, so both platforms use the
+same AD type and the same wire format.
+
+Legacy BLE advertising's AD payload budget is 31 bytes total. A Manufacturer Specific
+Data AD structure costs 4 bytes of overhead (1 length byte + 1 AD type byte + 2-byte
+company ID), plus another 3 bytes for the mandatory Flags structure, leaving 24 bytes
+for header and payload combined. This ADR's 16-byte header now fits, with 8 bytes left
+for payload. There is no header size, including the reduced sizes this ADR already
+permits for bandwidth-constrained transports, that leaves room for a Noise-encrypted
+payload once a minimum ChaChaPoly authentication tag (16 bytes, present even for an
+empty plaintext) is accounted for: 8 available bytes is still short of that 16-byte
+floor. This held on both platforms checked: BlueZ's 31-byte legacy AD limit on Linux
+and Windows' identical 31-byte limit for `BluetoothLEAdvertisementPublisher` are the
+same constraint, since both are bound by the same BLE 4.x link-layer spec, not an
+OS-specific choice.
 
 BLE advertising-mode bearer therefore requires BLE 5.0 extended advertising as its
 baseline, not legacy advertising: `secondary_channel` on `bluer::adv::Advertisement`
@@ -167,6 +175,12 @@ Extended advertising's data length budget is adapter-dependent but well above le
 31 bytes on any BLE 5.0 controller. This does not change the header format or any other
 part of this ADR's decision; it changes which BLE advertising mode each platform
 implementation must use to fit that header at all.
+
+The company ID used for the Manufacturer Specific Data field is `0xFFFF`, the value
+the Bluetooth SIG reserves specifically for testing and unregistered use, not a real
+registered company identifier. This is the same spirit as the self-assigned 128-bit
+UUIDs already used elsewhere in this codebase: honest about being unregistered,
+appropriate for a project at this stage.
 
 macOS is out of scope for this transport, not pending verification like the existing
 GATT-based BLE transport's macOS gap. `CBPeripheralManager` does not expose custom


### PR DESCRIPTION
## What changed

A new `Transport` implementation, `BleAdvertisingTransport`, that carries data inside BLE advertisement packets rather than a GATT connection, per ADR 018. The dispatcher and virtual-connection logic (header parsing, `dest_short_id` filtering, dedup, routing inbound packets to `accept()` or an existing connection) are written once against a new `AdvertisingBearer` trait and are entirely platform-independent. `LinuxAdvertisingBearer` (`bluer`) and `WindowsAdvertisingBearer` (`BluetoothLEAdvertisementPublisher`/`Watcher`) are the only platform-specific pieces.

`PeerAddress::BleAdvertising(String)` and `TransportKind::BleAdvertising` are added to `pathweave-core`, with the addr-exchange wire codec, mock transport names, and `pw-chat`'s display function all updated for the new variant.

Both bearers encode packets as Manufacturer Specific Data (AD type 0xFF, company ID `0xFFFF`) over BLE 5.0 extended advertising. Two ADR 018 addenda record why: legacy advertising's 31-byte budget can't fit the 16-byte header plus a minimum Noise ciphertext once AD structure overhead is accounted for, and Windows forbids apps from publishing Service Data AD structures at all (a restriction found while implementing, not assumed up front).

## Why

Closes #98. A connectionless BLE bearer is useful precisely because it doesn't require GATT pairing to succeed first; it's the fallback channel when that fails, and the only one with a chance of reaching every device in range rather than one peer.

## Alternatives considered

**Bearer as a trait vs. calling `bluer`/WinRT directly in the transport.** The dispatcher and connection-routing logic is "take a stream of header+payload bytes, route by short_id," nothing about it is BLE-specific. Writing it against a trait instead of a concrete platform API meant the entire dispatcher could be tested with an in-memory mock on a machine that can't even compile the Linux bearer, rather than waiting for hardware or CI to find logic bugs.

**Service Data vs. Manufacturer Specific Data.** First pass used Service Data (matching the existing GATT transport's `PATHWEAVE_SERVICE_UUID` convention). Checking Microsoft's docs before writing the Windows bearer found Service Data AD structures (16/32/128-bit UUID, all of them) explicitly listed as system-reserved: apps cannot publish them. `bluer` has no such restriction, but using a different AD type per platform would mean two implementations of the same protocol speaking different wire formats. Manufacturer Specific Data is allowed on both and is what both bearers use.

**A custom non-reserved AD type instead of Manufacturer Specific Data.** Windows also permits "any non-standard type not reserved by the system," which would save 2 more bytes (no company ID field). Rejected: `bluer`'s `Advertisement` struct exposes structured fields (`service_uuids`, `service_data`, `manufacturer_data`) rather than an arbitrary type-by-number API, so this was unverified on Linux, and the 2-byte difference doesn't change the legacy-vs-extended-advertising conclusion either way.

**Legacy advertising as the baseline, with extended advertising as a future optimization.** This was the original plan, and the actual AD-structure byte math (see the ADR 018 addendum) ruled it out: there is no header size that leaves room for a Noise-encrypted payload in 31 bytes once overhead is subtracted. Extended advertising became a hard requirement, not an enhancement.

## Security considerations

`dest_short_id`/`source_short_id` are plaintext in every packet, by ADR 018's design. An observer in range learns who is talking to whom, but `short_id` is a one-way hash truncation of a public key, not the key itself, and this is no different from what an observer of a completed Noise handshake would already learn. The Noise session itself runs unmodified over the virtual connection; this transport changes nothing about encryption, only how bytes physically move. The company ID `0xFFFF` and the one-byte magic prefix are not security boundaries; they're filtering conveniences to cheaply ignore unrelated devices' advertisements before attempting to parse them as ours.

## Test plan

- `cargo test --workspace`: all passing (62 + 8 + 3 across the affected crates), including 5 new tests in `advertising.rs` covering header round-tripping, short_id hex round-tripping, the mock-medium end-to-end exchange, dest-mismatch dropping, and `discover()` emitting announcements.
- `cargo clippy --workspace --all-targets`: clean (this crate has `#![deny(clippy::all)]`).
- `cargo fmt --check`: clean.
- `LinuxAdvertisingBearer`: not locally compilable on this Windows machine; will be verified by CI's ubuntu-latest job.
- `WindowsAdvertisingBearer`: compile-checked locally, including fixing a real `Send`-future compile error (every WinRT object wrapper is non-`Send` regardless of its "Agile" marshaling attribute; fixed via `spawn_blocking`).
- Real hardware test attempted: `hardware_loopback_advertise_and_scan` (`#[ignore]`d) on this machine's Bluetooth adapter. Result: the adapter does not support BLE 5.0 extended advertising (confirmed via the included `diagnose_adapter_capabilities` diagnostic: `IsExtendedAdvertisingSupported() == false`, publisher status goes straight to `Aborted`). This is a hardware capability gap, not a code defect; Windows hardware verification is now explicitly listed as deferred in #98's "Out of scope," same status as Linux's.
