### PR TITLE
feat(core): flood key announcements per ADR 020

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -39,10 +39,15 @@ second time, preventing duplicate delivery from the at-least-once retry mechanis
 
 Being clear about this matters.
 
-**No initiator identity hiding.** We use Noise_XX, where both sides reveal their static
-keys during the handshake. A passive observer who can intercept the handshake learns
-both parties' public keys. Noise_XK, which hides the initiator's identity from passive
-observers, is a future milestone.
+**No protection against an anonymous active prober.** We use Noise_XX. Both static keys
+are encrypted in transit, so a purely passive eavesdropper learns neither. But the
+responder's static key is encrypted only with a key derived from the
+ephemeral-ephemeral DH, which protects it from passive eavesdropping but not from
+anyone who actively connects and runs the handshake: a complete stranger with no prior
+relationship can decrypt and learn the responder's identity simply by being the one who
+initiates. Noise_XK, where the responder's static key is a pre-message never
+transmitted on the wire at all, closes this gap for known contacts and is a future
+milestone.
 
 **No group key exchange.** Noise_XX handles 1:1 sessions. There is no MLS or any other
 group key mechanism in v0.2.0.

--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -256,6 +256,14 @@ pub enum TransportEvent {
     StoreFailed {
         peer_id: PeerId,
     },
+    /// Fired whenever a key is learned for the first time (not already in the registry),
+    /// whether via a direct Noise handshake or a received gossip announcement. A
+    /// background task floods this onward per ADR 020; firing this event rather than
+    /// flooding inline keeps the handshake/send path that triggered it non-blocking.
+    KeyLearned {
+        peer_id: PeerId,
+        public_key: [u8; 32],
+    },
 }
 
 pub trait MessageHandler: Send + Sync {

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -13,7 +13,7 @@ use crate::{
     Result, Router, Session, Transport, TransportEvent,
 };
 
-const MAX_TTL: u8 = 7;
+pub(crate) const MAX_TTL: u8 = 7;
 
 const DEDUP_TTL: Duration = Duration::from_secs(60);
 
@@ -151,6 +151,21 @@ impl PathweaveNode {
                             drain_direct_for_peer(&peer_id, &pd, &p, &id, &kr, &r, store_ttl, &etx)
                                 .await;
                             drain_routed_all(&pr, &p, &id, &kr, &r, store_ttl, &etx).await;
+                        }
+                        Ok(TransportEvent::KeyLearned {
+                            peer_id,
+                            public_key,
+                        }) => {
+                            router::flood_key_announcement(
+                                &r,
+                                &id,
+                                &kr,
+                                &p,
+                                id.peer_id(),
+                                &peer_id,
+                                &public_key,
+                            )
+                            .await;
                         }
                         Ok(_) => {}
                         Err(broadcast::error::RecvError::Closed) => break,
@@ -777,10 +792,17 @@ async fn handle_incoming(
         }
     };
     let sender_peer_id = session.peer_id().clone();
-    key_registry
+    let is_new_key = key_registry
         .lock()
         .unwrap()
-        .insert(sender_peer_id.clone(), *session.remote_static_key());
+        .insert(sender_peer_id.clone(), *session.remote_static_key())
+        .is_none();
+    if is_new_key {
+        let _ = router.event_tx().send(TransportEvent::KeyLearned {
+            peer_id: sender_peer_id.clone(),
+            public_key: *session.remote_static_key(),
+        });
+    }
 
     let first = match session.recv().await {
         Ok(p) => p,
@@ -832,6 +854,52 @@ async fn handle_incoming(
             &key_registry,
         )
         .await;
+    }
+}
+
+/// Spawns a background send of `relay_body` (already framed with its own route_flag
+/// byte) to every known neighbor except `sender_peer_id` (so a relayed frame never
+/// bounces straight back to whoever just sent it) and `local_peer_id`. Shared by both
+/// routed-message (0x01) and key-announcement (0x02) relay in `dispatch_payload`, which
+/// differ only in how `relay_body` is framed before reaching this point.
+#[allow(clippy::too_many_arguments)]
+fn spawn_relay_to_neighbors(
+    relay_body: Vec<u8>,
+    msg_id: u64,
+    sender_peer_id: &PeerId,
+    local_peer_id: &PeerId,
+    peers: &PeerTable,
+    router: &Arc<Router>,
+    identity: &NodeIdentity,
+    key_registry: &KeyRegistry,
+) {
+    let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(pid, _)| **pid != *sender_peer_id && **pid != *local_peer_id)
+        .map(|(pid, anns)| (pid.clone(), anns.clone()))
+        .collect();
+
+    for (next_peer_id, announcements) in neighbors {
+        let router = Arc::clone(router);
+        let identity = identity.clone();
+        let relay_body = relay_body.clone();
+        let key_registry = Arc::clone(key_registry);
+        let peers = Arc::clone(peers);
+        tokio::spawn(async move {
+            let _ = router
+                .send(
+                    &announcements,
+                    &identity,
+                    relay_body,
+                    &next_peer_id,
+                    &key_registry,
+                    &peers,
+                    Some(msg_id),
+                )
+                .await;
+        });
     }
 }
 
@@ -906,39 +974,65 @@ async fn dispatch_payload(
                     relay_body.push(new_ttl);
                     relay_body.extend_from_slice(&app_payload);
 
-                    let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
-                        .lock()
-                        .unwrap()
-                        .iter()
-                        .filter(|(pid, _)| **pid != *sender_peer_id && **pid != *local_peer_id)
-                        .map(|(pid, anns)| (pid.clone(), anns.clone()))
-                        .collect();
-
-                    for (next_peer_id, announcements) in neighbors {
-                        let router = Arc::clone(router);
-                        let identity = identity.clone();
-                        let relay_body = relay_body.clone();
-                        let key_registry = Arc::clone(key_registry);
-                        let peers = Arc::clone(peers);
-                        tokio::spawn(async move {
-                            let _ = router
-                                .send(
-                                    &announcements,
-                                    &identity,
-                                    relay_body,
-                                    &next_peer_id,
-                                    &key_registry,
-                                    &peers,
-                                    Some(msg_id),
-                                )
-                                .await;
-                        });
-                    }
+                    spawn_relay_to_neighbors(
+                        relay_body,
+                        msg_id,
+                        sender_peer_id,
+                        local_peer_id,
+                        peers,
+                        router,
+                        identity,
+                        key_registry,
+                    );
                 } else {
                     tracing::debug!(msg_id, "suppressed duplicate routed message at relay");
                 }
             }
         }
+        0x02 => match router::decode_key_announcement(&payload[9..]) {
+            Some((announced_peer_id, public_key, ttl)) => {
+                if !router::validate_key_announcement(&announced_peer_id, &public_key) {
+                    tracing::debug!(
+                        peer = %sender_peer_id,
+                        "key announcement failed hash validation; dropping"
+                    );
+                } else {
+                    let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                    if is_dup {
+                        tracing::debug!(msg_id, "suppressed duplicate key announcement");
+                    } else {
+                        key_registry
+                            .lock()
+                            .unwrap()
+                            .insert(announced_peer_id.clone(), public_key);
+
+                        let ttl = ttl.min(MAX_TTL);
+                        if ttl > 0 {
+                            let new_ttl = ttl - 1;
+                            let relay_body = router::encode_key_announcement(
+                                &announced_peer_id,
+                                &public_key,
+                                new_ttl,
+                            );
+
+                            spawn_relay_to_neighbors(
+                                relay_body,
+                                msg_id,
+                                sender_peer_id,
+                                local_peer_id,
+                                peers,
+                                router,
+                                identity,
+                                key_registry,
+                            );
+                        }
+                    }
+                }
+            }
+            None => {
+                tracing::debug!(peer = %sender_peer_id, "key announcement: parse failed; skipping");
+            }
+        },
         _ => {
             tracing::debug!(peer = %sender_peer_id, route_flag, "unknown route_flag; skipping");
         }
@@ -1753,6 +1847,134 @@ mod tests {
             count_a.load(Ordering::Relaxed),
             0,
             "invariant 5: originator does not receive its own message"
+        );
+    }
+
+    #[tokio::test]
+    async fn key_announcement_propagates_to_indirect_peer() {
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+
+        let pid_a = id_a.peer_id().clone();
+        let key_a: [u8; 32] = id_a.public_key().try_into().unwrap();
+
+        // B is the active connector on both legs, so connection order is deterministic:
+        // B connects to C first, then to A. When B learns A's key (new), C is already
+        // a known neighbor, so B floods A's key to C. See ADR 020.
+        let (t_b_for_bc, t_c) = wire_transports(TransportKind::Quic);
+        let (t_b_for_ab, t_a) = wire_transports(TransportKind::Ble);
+
+        let mut node_a = PathweaveNode::new(NodeConfig::default(), id_a)
+            .await
+            .unwrap();
+        node_a.register_transport(Box::new(t_a));
+
+        let mut node_b = PathweaveNode::new(NodeConfig::default(), id_b)
+            .await
+            .unwrap();
+        node_b.register_transport(Box::new(t_b_for_bc));
+        node_b.register_transport(Box::new(t_b_for_ab));
+
+        let mut node_c = PathweaveNode::new(NodeConfig::default(), id_c)
+            .await
+            .unwrap();
+        node_c.register_transport(Box::new(t_c));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        node_b
+            .connect(PeerAnnouncement {
+                address: PeerAddress::Quic("127.0.0.1:1".parse().unwrap()),
+                short_id: None,
+            })
+            .await
+            .unwrap();
+
+        node_b
+            .connect(PeerAnnouncement {
+                address: PeerAddress::Ble("a".into()),
+                short_id: None,
+            })
+            .await
+            .unwrap();
+
+        // The flood is fired as a TransportEvent and handled by a background task
+        // (not awaited synchronously by connect()), so poll rather than assert
+        // immediately.
+        let stored = tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
+            loop {
+                if let Some(key) = node_c.key_registry.lock().unwrap().get(&pid_a).copied() {
+                    return key;
+                }
+                tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
+            }
+        })
+        .await
+        .expect("timed out waiting for C to learn A's key via gossip");
+        assert_eq!(
+            stored, key_a,
+            "C must learn A's key via gossip without ever connecting to A directly"
+        );
+    }
+
+    #[tokio::test]
+    async fn forged_key_announcement_is_rejected() {
+        let (conn_tx, conn_rx) = tokio::sync::mpsc::unbounded_channel::<Box<dyn Connection>>();
+        let transport = AcceptMockTransport {
+            conn_rx: tokio::sync::Mutex::new(conn_rx),
+        };
+
+        let receiver_id = NodeIdentity::generate();
+        let sender_id = NodeIdentity::generate();
+
+        let victim_identity = NodeIdentity::generate();
+        let victim_peer_id = victim_identity.peer_id().clone();
+        let attacker_identity = NodeIdentity::generate();
+        let attacker_public_key: [u8; 32] = attacker_identity.public_key().try_into().unwrap();
+
+        let mut node = PathweaveNode::new(NodeConfig::default(), receiver_id)
+            .await
+            .unwrap();
+        node.register_transport(Box::new(transport));
+
+        tokio::task::yield_now().await;
+        tokio::task::yield_now().await;
+
+        let (client_conn, server_conn) = conn_pair();
+        conn_tx
+            .send(Box::new(server_conn))
+            .expect("transport still alive");
+
+        let victim_peer_id_for_frame = victim_peer_id.clone();
+        tokio::spawn(async move {
+            let bundled: Box<dyn Connection> = Box::new(BundleLayer::new(Box::new(client_conn)));
+            let mut session = Session::initiate(&sender_id, bundled, None).await.unwrap();
+            let msg_id: u64 = 0xDEAD_BEEF_0001_0002;
+            let mut framed = Vec::with_capacity(9 + 32 + 32 + 1);
+            framed.extend_from_slice(&msg_id.to_be_bytes());
+            framed.push(0x02); // key announcement
+            framed.extend_from_slice(victim_peer_id_for_frame.as_bytes());
+            framed.extend_from_slice(&attacker_public_key); // mismatched: forged
+            framed.push(7);
+            session.send(&framed).await.unwrap();
+            // Wait for the ACK so dispatch_payload has time to process before this exits.
+            let _ = tokio::time::timeout(tokio::time::Duration::from_secs(2), session.recv()).await;
+        });
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+        let stored = node
+            .key_registry
+            .lock()
+            .unwrap()
+            .get(&victim_peer_id)
+            .copied();
+        assert!(
+            stored.is_none(),
+            "forged key announcement must not be stored in the registry"
         );
     }
 

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -9,8 +9,9 @@ use tokio::sync::{broadcast, watch};
 use tokio::task::JoinHandle;
 
 use crate::{
-    BundleLayer, KeyRegistry, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId,
-    PeerTable, Result, Session, Transport, TransportCost, TransportEvent, TransportKind,
+    node::MAX_TTL, peer_id_from_public_key, BundleLayer, KeyRegistry, NodeIdentity, PathweaveError,
+    PeerAddress, PeerAnnouncement, PeerId, PeerTable, Result, Session, Transport, TransportCost,
+    TransportEvent, TransportKind,
 };
 
 const MAX_SEND_ATTEMPTS: usize = 3;
@@ -164,11 +165,17 @@ impl Router {
                 )
                 .await
                 {
-                    Ok(()) => {
+                    Ok(learned_key) => {
                         let _ = self.event_tx.send(TransportEvent::MessageDelivered {
                             peer_id: peer_id.clone(),
                             transport: transport.kind(),
                         });
+                        if let Some(public_key) = learned_key {
+                            let _ = self.event_tx.send(TransportEvent::KeyLearned {
+                                peer_id: peer_id.clone(),
+                                public_key,
+                            });
+                        }
                         return Ok(());
                     }
                     Err(e) => tracing::debug!(
@@ -226,9 +233,15 @@ impl Router {
         });
 
         for (transport, ann) in candidates {
-            if let Ok(peer_id) =
+            if let Ok((peer_id, learned_key)) =
                 try_connect(transport.as_ref(), &ann, identity, key_registry, peer_table).await
             {
+                if let Some(public_key) = learned_key {
+                    let _ = self.event_tx.send(TransportEvent::KeyLearned {
+                        peer_id: peer_id.clone(),
+                        public_key,
+                    });
+                }
                 return Ok(peer_id);
             }
         }
@@ -404,7 +417,9 @@ fn current_ipv4_addrs() -> HashSet<Ipv4Addr> {
         .collect()
 }
 
-/// Dials the transport, completes the Noise_XX handshake, and returns the remote PeerId.
+/// Dials the transport, completes the Noise_XX handshake, and returns the remote PeerId,
+/// plus the learned key if this was newly learned (not already in the registry before
+/// this call), so the caller can fire a TransportEvent::KeyLearned (ADR 020).
 /// Always uses Noise_XX because the target identity is unknown before dialing.
 /// Performs an address exchange after the handshake (ADR 017), then closes the session.
 /// The close is explicit so transports that require active teardown release resources.
@@ -414,15 +429,17 @@ async fn try_connect(
     identity: &NodeIdentity,
     key_registry: &KeyRegistry,
     peers: &PeerTable,
-) -> Result<PeerId> {
+) -> Result<(PeerId, Option<[u8; 32]>)> {
     let raw = transport.connect(peer).await?;
     let bundled = Box::new(BundleLayer::new(raw));
     let mut session = Session::initiate(identity, bundled, None).await?;
     let peer_id = session.peer_id().clone();
-    key_registry
+    let is_new_key = key_registry
         .lock()
         .unwrap()
-        .insert(peer_id.clone(), *session.remote_static_key());
+        .insert(peer_id.clone(), *session.remote_static_key())
+        .is_none();
+    let learned_key = is_new_key.then(|| *session.remote_static_key());
     let local = transport.local_addresses();
     let _ = session.send(&encode_addr_exchange(&local)).await;
     match tokio::time::timeout(ADDR_EXCHANGE_TIMEOUT, session.recv()).await {
@@ -434,7 +451,7 @@ async fn try_connect(
         Err(_) => tracing::debug!(peer = %peer_id, "addr-exchange: timed out"),
     }
     let _ = session.close().await;
-    Ok(peer_id)
+    Ok((peer_id, learned_key))
 }
 
 /// Generates a cryptographically random 64-bit message ID from OS entropy.
@@ -612,12 +629,99 @@ pub(crate) fn upsert_peer_addresses(peers: &PeerTable, peer_id: &PeerId, addrs: 
     }
 }
 
+/// Encodes a route_flag 0x02 key announcement body (ADR 020): the route_flag byte
+/// itself, the identity an announcement is about, that identity's static public key,
+/// and a TTL. Callers pass the result to `Router::send` as `payload`;
+/// `Router::send`/`try_send` prepend the 8-byte message ID on top.
+pub(crate) fn encode_key_announcement(peer_id: &PeerId, public_key: &[u8; 32], ttl: u8) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(1 + 32 + 32 + 1);
+    buf.push(0x02);
+    buf.extend_from_slice(peer_id.as_bytes());
+    buf.extend_from_slice(public_key);
+    buf.push(ttl);
+    buf
+}
+
+/// Decodes a route_flag 0x02 key announcement body. `payload` excludes the 8-byte
+/// message ID and the route_flag byte (the caller has already matched on it).
+/// Returns `None` on malformed length. Does not validate the peer_id/public_key
+/// binding; callers must call `validate_key_announcement` before trusting the result.
+pub(crate) fn decode_key_announcement(payload: &[u8]) -> Option<(PeerId, [u8; 32], u8)> {
+    if payload.len() != 32 + 32 + 1 {
+        return None;
+    }
+    let peer_id_bytes: [u8; 32] = payload[0..32].try_into().ok()?;
+    let public_key: [u8; 32] = payload[32..64].try_into().ok()?;
+    let ttl = payload[64];
+    Some((PeerId::from_bytes(peer_id_bytes), public_key, ttl))
+}
+
+/// Verifies the self-certifying PeerId/public-key binding per ADR 020:
+/// `PeerId = base58(blake3(public_key))`. Mandatory before storing or re-flooding any
+/// received key announcement; a mismatch means the pair was forged or corrupted.
+pub(crate) fn validate_key_announcement(peer_id: &PeerId, public_key: &[u8; 32]) -> bool {
+    peer_id_from_public_key(public_key) == *peer_id
+}
+
+/// Floods a fresh key announcement for `learned_peer_id`/`learned_key` to every known
+/// neighbor except that peer and `local_peer_id`. Called whenever a node directly
+/// learns a key it did not already have via a Noise handshake (not on every handshake,
+/// only the first time, so already-known keys are not re-announced); see ADR 020.
+#[allow(clippy::too_many_arguments)]
+pub(crate) async fn flood_key_announcement(
+    router: &Router,
+    identity: &NodeIdentity,
+    key_registry: &KeyRegistry,
+    peers: &PeerTable,
+    local_peer_id: &PeerId,
+    learned_peer_id: &PeerId,
+    learned_key: &[u8; 32],
+) {
+    let msg_id = new_message_id();
+    let body = encode_key_announcement(learned_peer_id, learned_key, MAX_TTL);
+
+    let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
+        .lock()
+        .unwrap()
+        .iter()
+        .filter(|(pid, _)| *pid != learned_peer_id && *pid != local_peer_id)
+        .map(|(pid, anns)| (pid.clone(), anns.clone()))
+        .collect();
+
+    // Concurrent, not sequential: this runs from a background task (triggered by
+    // TransportEvent::KeyLearned, not awaited from the handshake/send path that
+    // learned the key), so there's no caller-facing latency to protect here, but a
+    // mesh with many neighbors still shouldn't wait on each one in series.
+    let sends = neighbors.into_iter().map(|(next_peer_id, announcements)| {
+        let body = body.clone();
+        async move {
+            let _ = router
+                .send(
+                    &announcements,
+                    identity,
+                    body,
+                    &next_peer_id,
+                    key_registry,
+                    peers,
+                    Some(msg_id),
+                )
+                .await;
+        }
+    });
+    futures::future::join_all(sends).await;
+}
+
 /// Opens a connection through the given transport, wraps it in BundleLayer and
 /// Session, performs an address exchange (ADR 017), prepends the 8-byte message
 /// ID for receiver-side deduplication, sends the framed payload, and waits for
 /// the receiver's delivery ACK. Uses Noise_XK when the key registry has an entry
 /// for peer_id; falls back to Noise_XX on XK failure and evicts the stale entry.
 #[allow(clippy::too_many_arguments)]
+/// Returns the learned key if this call newly populated the registry for `peer_id`
+/// (not already present beforehand), so the caller can fire a TransportEvent::KeyLearned
+/// (ADR 020). Derived directly from this call's own insert, not a snapshot taken before
+/// this function ran: an XK failure can evict and then this same call can repopulate the
+/// entry via an XX fallback, which a before/after snapshot at the caller would miss.
 async fn try_send(
     transport: &dyn Transport,
     peer: &PeerAnnouncement,
@@ -627,7 +731,7 @@ async fn try_send(
     key_registry: &KeyRegistry,
     peer_id: &PeerId,
     peers: &PeerTable,
-) -> Result<()> {
+) -> Result<Option<[u8; 32]>> {
     let remote_key = key_registry.lock().unwrap().get(peer_id).copied();
     let raw = transport.connect(peer).await.map_err(|e| {
         tracing::debug!(addr = ?peer.address, error = %e, "try_send: connect failed");
@@ -645,10 +749,12 @@ async fn try_send(
             return Err(e);
         }
     };
-    key_registry
+    let is_new_key = key_registry
         .lock()
         .unwrap()
-        .insert(session.peer_id().clone(), *session.remote_static_key());
+        .insert(session.peer_id().clone(), *session.remote_static_key())
+        .is_none();
+    let learned_key = is_new_key.then(|| *session.remote_static_key());
 
     let local = transport.local_addresses();
     let _ = session.send(&encode_addr_exchange(&local)).await;
@@ -673,7 +779,7 @@ async fn try_send(
     // connection handle drops, which happens before the buffer is flushed. Waiting
     // for the receiver's ACK keeps the connection alive until the data is delivered.
     match tokio::time::timeout(Duration::from_secs(5), session.recv()).await {
-        Ok(Ok(_)) => Ok(()),
+        Ok(Ok(_)) => Ok(learned_key),
         Ok(Err(e)) => {
             tracing::debug!(addr = ?peer.address, error = %e, "try_send: ACK recv failed");
             Err(e)
@@ -736,11 +842,11 @@ pub(crate) async fn peer_stream(
                     )
                     .await
                     {
-                        Ok(peer_id) if peer_id == local_peer_id => {
+                        Ok((peer_id, _)) if peer_id == local_peer_id => {
                             // Self-discovery: keep addr in known_addrs so we don't retry.
                             tracing::debug!(addr = %addr, "discovered self; skipping");
                         }
-                        Ok(peer_id) => {
+                        Ok((peer_id, learned_key)) => {
                             tracing::debug!(addr = %addr, peer = %peer_id, "peer connected");
                             peers
                                 .lock()
@@ -748,6 +854,12 @@ pub(crate) async fn peer_stream(
                                 .entry(peer_id.clone())
                                 .or_default()
                                 .push(announcement);
+                            if let Some(public_key) = learned_key {
+                                let _ = event_tx.send(TransportEvent::KeyLearned {
+                                    peer_id: peer_id.clone(),
+                                    public_key,
+                                });
+                            }
                             let _ = event_tx.send(TransportEvent::PeerConnected(peer_id));
                         }
                         Err(e) => {
@@ -790,6 +902,53 @@ mod tests {
     use bytes::Bytes;
     use std::sync::atomic::AtomicUsize;
     use tokio::sync::mpsc::{unbounded_channel, UnboundedReceiver, UnboundedSender};
+
+    // --- key announcement codec and validation (ADR 020) -----------------------
+
+    #[test]
+    fn key_announcement_roundtrips() {
+        let identity = NodeIdentity::generate();
+        let peer_id = identity.peer_id().clone();
+        let public_key: [u8; 32] = identity.public_key().try_into().unwrap();
+
+        let encoded = encode_key_announcement(&peer_id, &public_key, 7);
+        // encode_key_announcement includes the route_flag byte; decode_key_announcement
+        // expects the caller to have already matched on and stripped it.
+        let decoded = decode_key_announcement(&encoded[1..]).unwrap();
+
+        assert_eq!(decoded.0, peer_id);
+        assert_eq!(decoded.1, public_key);
+        assert_eq!(decoded.2, 7);
+    }
+
+    #[test]
+    fn key_announcement_decode_rejects_wrong_length() {
+        assert!(decode_key_announcement(&[0u8; 64]).is_none());
+        assert!(decode_key_announcement(&[0u8; 66]).is_none());
+    }
+
+    #[test]
+    fn key_announcement_validates_genuine_pair() {
+        let identity = NodeIdentity::generate();
+        let peer_id = identity.peer_id().clone();
+        let public_key: [u8; 32] = identity.public_key().try_into().unwrap();
+        assert!(validate_key_announcement(&peer_id, &public_key));
+    }
+
+    #[test]
+    fn key_announcement_rejects_forged_pair() {
+        let real_identity = NodeIdentity::generate();
+        let real_peer_id = real_identity.peer_id().clone();
+        let attacker_identity = NodeIdentity::generate();
+        let attacker_public_key: [u8; 32] = attacker_identity.public_key().try_into().unwrap();
+
+        // Claiming the attacker's key belongs to the real identity's PeerId must fail:
+        // blake3(attacker_public_key) != real_peer_id.
+        assert!(!validate_key_announcement(
+            &real_peer_id,
+            &attacker_public_key
+        ));
+    }
 
     // --- in-memory connection --------------------------------------------------
 

--- a/notes/decisions/001-noise-xx-not-xk.md
+++ b/notes/decisions/001-noise-xx-not-xk.md
@@ -23,10 +23,18 @@ Use `Noise_XX_25519_ChaChaPoly_BLAKE2s` for all sessions in v0.1.0.
 
 ## Consequences
 
-Both parties' static public keys are visible to a passive observer who can intercept
-the handshake. This is a known limitation of Noise_XX and is documented in SECURITY.md
-under "What v0.1.0 does not provide."
+Both parties' static public keys are encrypted in transit, not sent in the clear, so a
+purely passive eavesdropper learns neither. The actual exposure is narrower and
+different: the responder's static key (Noise_XX message 2) is encrypted only with a
+key derived from the ephemeral-ephemeral DH, which protects it from passive
+eavesdropping but not from an active, anonymous initiator. Anyone who can connect and
+run the handshake, even a complete stranger with no prior relationship, can decrypt and
+learn the responder's identity simply by being the one who initiates (Noise spec
+identity-hiding property 1). This is a known limitation of Noise_XX and is documented
+in SECURITY.md under "What v0.1.0 does not provide."
 
-Noise_XK, which hides the initiator's identity, becomes the v0.3.0 upgrade once we have
-a contact and key registry. The pattern string changes; the snow crate and everything
-else stays the same.
+Noise_XK, which prevents even an anonymous active initiator from learning the
+responder's identity (the responder's static key is a pre-message, never transmitted on
+the wire at all, so there is nothing to intercept or decrypt), becomes the v0.3.0
+upgrade once we have a contact and key registry. The pattern string changes; the snow
+crate and everything else stays the same.

--- a/notes/decisions/020-key-registry-and-gossip.md
+++ b/notes/decisions/020-key-registry-and-gossip.md
@@ -12,13 +12,19 @@ During a Noise_XX handshake, `session.get_remote_static()` returns the remote pe
 the PeerId and then drops them. Two planned features require those bytes to be retained:
 
 **Noise_XK (known-peer handshake).** In Noise_XK, the initiator supplies the
-responder's static public key before the handshake begins. The responder's first message
-is encrypted with the initiator's ephemeral key and the responder's known static key,
-which means a passive observer cannot link the connection to the responder's identity.
-In Noise_XX, the static keys are exchanged in the clear during the handshake, so a
-passive observer sees both identities. XK is strictly better for privacy with known
-peers, and ADR 001 deferred it to this release on the condition that a key registry
-exists.
+responder's static public key before the handshake begins, as a pre-message the
+initiator already has out-of-band. The responder's static key is therefore never
+transmitted on the wire at all: there is nothing to intercept, encrypted or otherwise.
+In Noise_XX, by contrast, the responder's static key is sent in message 2, encrypted
+with a key derived from the ephemeral-ephemeral DH alone. That protects it from a
+passive eavesdropper, but not from an active, anonymous initiator: anyone who can
+connect and run the handshake, even a complete stranger with no prior relationship, can
+decrypt and learn the responder's identity simply by being the one who initiates
+(Noise spec identity-hiding property 1). XK's real advantage over XX is not passive-
+observer protection, XX already has that for this key; it is that XK refuses to reveal
+the responder's identity to anyone who does not already hold the pre-shared key,
+closing the door XX leaves open to any anonymous prober. ADR 001 deferred XK to this
+release on the condition that a key registry exists.
 
 **E2E hop encryption.** To seal a message to a destination node that may be several
 hops away, the sender encrypts the inner payload to the destination's public key. Only
@@ -46,35 +52,83 @@ let raw: [u8; 32] = remote_static
 // caller stores: key_registry.lock().unwrap().insert(peer_id.clone(), raw);
 ```
 
-The registry is append-only in normal operation. Keys do not expire. A peer's key is
-deterministic from its static keypair (ADR 005 requires the keypair to persist across
-restarts), so overwriting an existing entry with the same key is idempotent.
+The registry is append-only by design: a key is never overwritten with a different
+value for the same PeerId, only re-inserted idempotently or evicted outright. The one
+exception is eviction on XK handshake failure (see "Noise_XK upgrade" below), which
+removes a stale entry rather than replacing it with an unverified one; the next
+handshake falls back to XX and repopulates the registry from scratch.
 
-### Key gossip via address exchange
+### Key gossip via flooded announcement (amended 2026-06-17)
 
-Extend the address exchange protocol (ADR 017, control message type 1) with a new
-control message type:
+**Status: implementation deferred; tracked in issue #100.** The key registry and the
+Noise_XK upgrade below have shipped. This subsection has not: it was corrected to a
+different mechanism (see below) before any code was written against the original
+version, and that corrected mechanism is not yet implemented.
+
+The original version of this section specified piggybacking the sender's own public
+key onto the address exchange (a new control type 2, address list plus a 32-byte key
+field). That mechanism does not actually achieve what this section claims: address
+exchange only ever carries a transport's own `local_addresses()`, never another peer's
+information, so adding the sender's own key to it is redundant with what the Noise
+handshake already provides for that same direct peer. It does not get a destination's
+key to a sender who has never directly connected to that destination, which is exactly
+the case E2E hop encryption needs. This was found before any code was written against
+it and is corrected here rather than left as a known-wrong addendum, since nothing
+downstream depends on the original text.
+
+Key gossip instead reuses the TTL-limited flooding mechanism ADR 019 already built for
+application messages, the same pattern Reticulum uses for its destination announces.
+A new `route_flag` value carries a key announcement:
 
 ```
-type 2 — address + key exchange
-[0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02]   control ID
-[count: u8]                                          number of addresses
-[addresses: N bytes]                                 same format as type 1
-[public_key: 32 bytes]                               sender's static public key
+route_flag 0x02: key announcement
+[peer_id:    32 bytes]   the identity this announcement is about
+[public_key: 32 bytes]   that identity's Curve25519 static public key
+[ttl:         1 byte]    clamped to MAX_TTL (7) on receipt, same as 0x01 routed frames
 ```
 
-Nodes that receive a type 2 exchange store the sender's public key in the registry
-before processing the addresses. Nodes that do not yet implement type 2 ignore it
-(unknown control types are silently dropped per ADR 017).
+A node generates a fresh announcement (new message ID, fresh TTL) only at the moment
+it directly learns a new key via a Noise handshake; it does not periodically
+re-announce keys it already knows, and does not announce its own key before any
+connection exists. This is the minimal mechanism that solves the stated problem:
+genuine multi-hop propagation, without adding a second, independent "broadcast my
+existence on a timer" feature nobody asked for.
 
-This provides one-hop key propagation: when A connects to B, A learns B's key directly
-from the Noise handshake and also receives B's addresses. B likewise learns A's key.
-For multi-hop scenarios, keys reach nodes that have never directly connected through the
-natural flow of address exchanges across the mesh as connections form.
+**Validation is mandatory, not an implementation detail.** `PeerId` is
+`base58(blake3(public_key))` by construction (see "PeerId" in ARCHITECTURE.md), which
+makes every `(peer_id, public_key)` pair self-certifying: a receiver can verify
+`blake3(claimed_public_key) == claimed_peer_id` before storing or re-flooding an
+announcement. Since blake3 is preimage-resistant, no attacker can construct a different
+key that hashes to an existing victim's PeerId, so this check alone prevents the
+substitution attack a flooded gossip mechanism would otherwise be vulnerable to: no
+signature scheme (the kind Reticulum's announce needs on top of its own hash binding)
+is required. Every hop must perform this check independently before storing or
+forwarding; never trust that an upstream relay already validated. A malicious relay
+that tries to inject a forged pair gets it dropped at the very next honest hop.
 
-A separate gossip broadcast mechanism (flooding key announcements to all known peers) is
-not implemented in v0.3.0. The address exchange on each connection provides sufficient
-propagation for expected mesh sizes.
+**Hop radius.** Announcements are clamped to `MAX_TTL` (7), the same cap application
+messages already use, not a larger radius. Propagating a key further than an
+E2E-encrypted message could ever travel to reach that destination would only widen
+exposure for no corresponding benefit.
+
+**What this does not solve.** Key gossip makes a peer's full public key discoverable
+to anyone within the announcement's hop radius, not just direct contacts, a widening
+of disclosure beyond what direct handshakes alone would produce. This is judged
+acceptable because the *pseudonymous identifier* (PeerId, the hash) is already
+disclosed at this same radius today via routed message `dest_peer_id` headers (ADR
+019) and BLE `short_id` (ADR 018); gossip adds "and here is the actual key, not just
+its hash" to information that already traveled that far, and a public key is not
+independently exploitable without the corresponding private key. Sybil identities
+(an attacker generating many free `NodeIdentity` keypairs and announcing all of them)
+are a pre-existing property of the identity model this ADR does not change or worsen;
+no sybil-resistance mechanism exists at this layer in Reticulum or libp2p either. Two
+related concerns are deliberately deferred rather than solved here: per-source
+announcement rate-limiting (the existing application-message flood has the same gap),
+and a growth bound on the key registry itself now that it can grow from gossip, not
+just from peers directly met, tracked as a separate follow-up issue.
+
+No further broadcast mechanism beyond this flooded announcement is needed; the
+existing TTL-flood reuse provides sufficient propagation for expected mesh sizes.
 
 ### Noise_XK upgrade
 
@@ -90,7 +144,7 @@ it and builds a responder for the matching pattern.
 
 **When to use XK:** `Session::initiate()` checks the key registry for the destination
 PeerId. If a key is found, it sends prefix `0x01` and calls
-`snow::Builder::with_remote_public_key(stored_key).build_initiator()` with the XK
+`snow::Builder::new(...).local_private_key(...).remote_public_key(stored_key).build_initiator()` with the XK
 pattern. If no key is found, it sends prefix `0x00` and uses XX.
 
 **When to use XX:** always on first contact. Also as a fallback if the stored key is
@@ -103,10 +157,14 @@ No other changes to the `snow` crate usage. The `Session` struct is unchanged;
 `Session::initiate()` and `Session::respond()` gain the protocol version logic.
 
 XX and XK coexist permanently. XX is always used for first contact. XK is used once the
-key is known. The privacy improvement is asymmetric: XK hides the responder's identity
-from a passive observer during the handshake; the initiator's identity is still visible
-in the first XK message. Full mutual anonymity requires Sphinx routing (planned for a
-later release).
+key is known. XK's improvement over XX is specifically that the responder's static key
+is never transmitted at all, closing the anonymous-prober gap XX leaves open (see the
+Noise_XK paragraph in Context above). The initiator's static key is still transmitted,
+in message 3, with the same forward-secret protection XX's message 3 already has:
+decryptable only by an already-authenticated party, not by a passive eavesdropper or an
+anonymous prober. It is not visible in the first XK message, which carries only the
+initiator's ephemeral key and no static-identity material. Full mutual anonymity
+requires Sphinx routing (planned for a later release).
 
 ## Rationale
 
@@ -118,12 +176,28 @@ stale if the peer violates ADR 005 (regenerates its keypair). Expiry would requi
 re-running XX handshakes with known peers unnecessarily. The registry is a cache of
 immutable facts, not session state.
 
-**Why type 2 address exchange instead of a dedicated gossip message?**
+**Why a flooded announcement instead of piggybacking on address exchange?**
 
-Every connection already does an address exchange. Piggybacking the public key on that
-exchange adds 32 bytes to a message that already travels and costs no additional
-round-trip. A dedicated gossip flood would require new message types, scheduling logic,
-and flood control. The address exchange is sufficient for the expected mesh size.
+The original version of this ADR proposed piggybacking the sender's own key onto the
+address exchange, reasoning that every connection already does one and a dedicated
+flood would need new message types and flood control. That reasoning held for cost
+but missed correctness: address exchange only ever carries a transport's own
+`local_addresses()`, so piggybacking a sender's own key onto it can never deliver a
+*third party's* key to someone who has never connected to that third party, which is
+the actual requirement. A flooded announcement is the mechanism that genuinely
+achieves multi-hop propagation, and it costs less new code than it first appears to:
+the flood control, dedup, and TTL machinery already exist for application messages
+(ADR 019); a key announcement is one more `route_flag` value reusing all of it.
+
+**Why no signature on the announcement, unlike Reticulum's announce?**
+
+Reticulum's announce needs an Ed25519 signature because its destination hash and
+routing metadata are not, on their own, sufficient to prevent forgery. Pathweave's
+PeerId is `base58(blake3(public_key))`: the identity and the key are bound by
+construction, not by a separate signature. A receiver re-derives `blake3(public_key)`
+and compares it to the claimed `peer_id`; any mismatch means the pair was forged or
+corrupted, and is rejected. This is cheaper than a signature scheme and exists because
+of a property Pathweave's identity model already has, not something added for gossip.
 
 **Why a protocol version byte instead of attempting XK and falling back?**
 
@@ -151,11 +225,12 @@ a pure cryptographic layer with no knowledge of the routing or storage layer abo
 - `try_connect()` and `try_send()` in `router.rs` write to the key registry after a
   successful handshake. Both pass a reference to the shared registry.
 - `handle_incoming()` in `node.rs` writes to the key registry after a successful
-  `Session::respond()`. It already receives a reference to `PathweaveNode` (added in
-  ADR 019 to support forwarding); the key registry is accessed through that reference.
-- The address exchange (ADR 017) moves from control type 1 to type 2 when the sender
-  has a public key to share (always, once key storage is implemented). Type 1 remains
-  valid for nodes running older versions.
+  `Session::respond()`. It is a free function taking `key_registry`, `peers`, and
+  `router` as separate explicit parameters (added in ADR 019 to support forwarding),
+  not a method accessed through a `PathweaveNode` reference.
+- `route_flag` (ADR 019) gains value `0x02` for key announcements, alongside the
+  existing `0x00` (direct) and `0x01` (routed). The address exchange (ADR 017) is
+  unaffected; key propagation is a routing-layer concern, not a connection-time one.
 - ADR 001's deferred Noise_XK work is resolved by this ADR. The implementation
   conditions stated there (key registry must exist) are satisfied.
 - E2E hop encryption uses the key registry to look up the destination's public key


### PR DESCRIPTION
## What changed

Key gossip via flooded announcement, per a corrected ADR 020. The key registry (populated only from direct Noise handshakes until now) gains a second source: a `route_flag 0x02` announcement, flooded with ADR 019's existing TTL/dedup machinery, lets a node learn a peer's public key without ever connecting to that peer directly. This is the missing piece for E2E hop encryption, which needs a destination's key before sealing a payload to a node it may never have a direct connection to.

Also includes a correction to ADR 001, ADR 020, and SECURITY.md: all three claimed Noise_XX exchanges static keys "in the clear" and that a passive observer learns both identities. Per the Noise spec's identity-hiding properties, neither key is sent in the clear; the actual exposure is that any active initiator, including a complete stranger, can decrypt the responder's key just by being the one who connects. This was found and fixed while verifying the gossip design's own cryptographic claims, before any of it was committed.

## Why

Closes #100. ADR 020's original gossip design (piggybacking the sender's own key onto the address exchange) could not work: address exchange only ever carries a transport's own `local_addresses()`, never a third party's information, so it could never deliver a destination's key to a sender who has never connected to that destination. That's exactly the case E2E hop encryption needs handled. The ADR is corrected in this PR before any code was written against the original version.

## Alternatives considered

**Address-exchange piggyback (the original ADR 020 design) vs. a flooded announcement.** The piggyback approach looked cheaper since every connection already does an address exchange. It doesn't actually achieve multi-hop propagation, only confirms a direct peer's own key, which the Noise handshake already provides. A flooded announcement, the same pattern Reticulum uses for its destination announces, is the mechanism that actually gets a key to a node that never connects to its owner. It also costs less new code than expected: ADR 019's flood control, dedup, and TTL machinery already exist; this is one more `route_flag` value reusing all of it.

**A signature on the announcement, matching Reticulum's approach.** Reticulum signs its announce because its destination hash and routing metadata aren't otherwise sufficient to prevent forgery. Pathweave's PeerId is `base58(blake3(public_key))`, binding identity to key by construction. A receiver re-derives `blake3(public_key)` and compares it to the claimed PeerId; a mismatch is forgery, full stop. No signature scheme needed on top of a property the identity model already has.

**Flooding inline from the handshake/send path vs. firing an event.** The first version of this called the flood directly from `Router::send`, `Router::connect`, `peer_stream`, and `handle_incoming`, awaited before returning. `Router::send`/`Router::connect` only have `&self`, not `Arc<Self>`, so they couldn't spawn the per-neighbor sends the way the existing 0x01 relay code does from `dispatch_payload` (which has `Arc<Router>`). The result was a brand-new peer's first `send()` blocking for seconds per neighbor, scaling with mesh size, before returning. Fixed by adding `TransportEvent::KeyLearned`: learning a key fires the event instead of flooding inline, and the existing background task in `PathweaveNode::new()` (already subscribed to handle `PeerConnected` for store-and-forward draining) handles it with `Arc<Router>` it already owns. Neighbor sends inside the flood run concurrently via `join_all` rather than in series.

## Security considerations

The validation step (`blake3(public_key) == peer_id`) is mandatory at every hop, not just at the point of storage: a malicious relay that tries to inject a forged pair gets it dropped at the very next honest hop, regardless of how far it already traveled. This is tested directly (`forged_key_announcement_is_rejected`).

Gossip does widen disclosure: a peer's full public key becomes discoverable to anyone within the announcement's hop radius (`MAX_TTL`, the same cap application messages use), not just direct contacts. This is judged acceptable because the pseudonymous identifier (PeerId, the hash) is already disclosed at this same radius via routed message `dest_peer_id` headers (ADR 019) and BLE `short_id` (ADR 018); gossip adds the actual key to information that already traveled that far, and a public key is not independently exploitable without the corresponding private key. Sybil identities (an attacker generating many free `NodeIdentity` keypairs and announcing all of them) are a pre-existing property of the identity model, not changed or worsened here. Per-source rate-limiting and a growth bound on the key registry are explicitly deferred (the existing application-message flood has the same rate-limiting gap; the registry bound is tracked as #101, matching the precedent set by #94/#97 for the store-and-forward queue).

## Test plan

- `cargo test --workspace`: all passing (68 in pathweave-core, up from 62), including 6 new tests: `key_announcement_roundtrips`, `key_announcement_decode_rejects_wrong_length`, `key_announcement_validates_genuine_pair`, `key_announcement_rejects_forged_pair`, `key_announcement_propagates_to_indirect_peer` (a 3-node test confirming C learns A's key via B's gossip without C ever connecting to A directly), and `forged_key_announcement_is_rejected` (confirms a mismatched public-key/PeerId pair is dropped, not stored).
- `cargo clippy --workspace --all-targets`: clean.
- `cargo fmt --check`: clean.
