### PR TITLE
feat(core): bound key registry growth from gossip

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use bytes::Bytes;
 use futures::stream::{self, BoxStream};
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -305,11 +305,177 @@ pub trait Connection: Send + Sync {
 
 // -- key registry --------------------------------------------------------
 
-/// Key store for the Noise_XK upgrade path; populated after every handshake. See ADR 020.
-pub(crate) type KeyRegistry = Arc<Mutex<HashMap<PeerId, [u8; 32]>>>;
+/// Maps PeerId to Curve25519 static public key for the Noise_XK upgrade path and E2E
+/// hop encryption. Populated after every handshake and, since #100, by gossip
+/// announcements. `gossip_order` is the sole record of which entries were learned via
+/// gossip rather than a direct handshake (oldest first): a peer_id's presence there,
+/// not a separate field on the entry, is what makes it eligible for eviction when the
+/// registry is bounded (#101). A direct handshake removes a peer_id from this tracking
+/// even if it was originally learned via gossip, since the handshake confirms it
+/// deserves the same protection direct entries always have. See ADR 020.
+pub struct KeyRegistryState {
+    entries: HashMap<PeerId, [u8; 32]>,
+    gossip_order: VecDeque<PeerId>,
+    max_size: Option<usize>,
+}
 
+impl KeyRegistryState {
+    fn new(max_size: Option<usize>) -> Self {
+        Self {
+            entries: HashMap::new(),
+            gossip_order: VecDeque::new(),
+            max_size,
+        }
+    }
+
+    pub(crate) fn get(&self, peer_id: &PeerId) -> Option<[u8; 32]> {
+        self.entries.get(peer_id).copied()
+    }
+
+    pub(crate) fn remove(&mut self, peer_id: &PeerId) -> Option<[u8; 32]> {
+        self.gossip_order.retain(|p| p != peer_id);
+        self.entries.remove(peer_id)
+    }
+
+    /// Inserts a key learned via a direct Noise handshake. Never evicted by the size
+    /// bound. Promotes the entry out of gossip-eviction tracking if it was previously
+    /// gossip-learned. Returns true if this peer_id had no entry before this call, so
+    /// callers can decide whether to fire TransportEvent::KeyLearned.
+    pub(crate) fn insert_direct(&mut self, peer_id: PeerId, public_key: [u8; 32]) -> bool {
+        self.gossip_order.retain(|p| p != &peer_id);
+        self.entries.insert(peer_id, public_key).is_none()
+    }
+
+    /// Inserts a key learned via a gossip announcement (#100). If at capacity, evicts
+    /// the oldest gossip-learned entry first; if every entry is directly handshaked,
+    /// drops the new key instead of evicting one. See #101.
+    pub(crate) fn insert_gossip(&mut self, peer_id: PeerId, public_key: [u8; 32]) {
+        if let Some(existing) = self.entries.get_mut(&peer_id) {
+            // Already known (direct handshake or earlier gossip): idempotent refresh,
+            // no capacity check needed since this does not grow the registry.
+            *existing = public_key;
+            return;
+        }
+
+        if let Some(max) = self.max_size {
+            if self.entries.len() >= max {
+                match self.gossip_order.pop_front() {
+                    Some(oldest) => {
+                        self.entries.remove(&oldest);
+                    }
+                    None => return, // every slot is directly handshaked; drop the new key
+                }
+            }
+        }
+
+        self.entries.insert(peer_id.clone(), public_key);
+        self.gossip_order.push_back(peer_id);
+    }
+}
+
+pub(crate) type KeyRegistry = Arc<Mutex<KeyRegistryState>>;
+
+#[cfg(test)]
 pub(crate) fn new_key_registry() -> KeyRegistry {
-    Arc::new(Mutex::new(HashMap::new()))
+    new_key_registry_with_bound(None)
+}
+
+pub(crate) fn new_key_registry_with_bound(max_size: Option<usize>) -> KeyRegistry {
+    Arc::new(Mutex::new(KeyRegistryState::new(max_size)))
+}
+
+#[cfg(test)]
+mod key_registry_tests {
+    use super::KeyRegistryState;
+    use crate::{NodeIdentity, PeerId};
+
+    fn dummy_key(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    fn dummy_peer_id() -> PeerId {
+        NodeIdentity::generate().peer_id().clone()
+    }
+
+    #[test]
+    fn gossip_entries_evict_oldest_first_without_bound_overflow() {
+        let mut registry = KeyRegistryState::new(Some(2));
+        let p1 = dummy_peer_id();
+        let p2 = dummy_peer_id();
+        let p3 = dummy_peer_id();
+
+        registry.insert_gossip(p1.clone(), dummy_key(1));
+        registry.insert_gossip(p2.clone(), dummy_key(2));
+        // At capacity (2). p1 is the oldest gossip entry and must be evicted to make
+        // room for p3.
+        registry.insert_gossip(p3.clone(), dummy_key(3));
+
+        assert_eq!(
+            registry.get(&p1),
+            None,
+            "oldest gossip entry must be evicted"
+        );
+        assert_eq!(registry.get(&p2), Some(dummy_key(2)));
+        assert_eq!(registry.get(&p3), Some(dummy_key(3)));
+    }
+
+    #[test]
+    fn direct_handshake_entry_is_never_evicted_by_gossip() {
+        let mut registry = KeyRegistryState::new(Some(1));
+        let direct_peer = dummy_peer_id();
+        let gossip_peer = dummy_peer_id();
+
+        registry.insert_direct(direct_peer.clone(), dummy_key(1));
+        // At capacity (1), and the only entry is direct, not gossip-learned: the new
+        // gossip key must be dropped, not evict the direct entry.
+        registry.insert_gossip(gossip_peer.clone(), dummy_key(2));
+
+        assert_eq!(registry.get(&direct_peer), Some(dummy_key(1)));
+        assert_eq!(
+            registry.get(&gossip_peer),
+            None,
+            "gossip-learned key must be dropped when only directly-handshaked entries exist to evict"
+        );
+    }
+
+    #[test]
+    fn direct_handshake_promotes_a_previously_gossip_learned_entry() {
+        let mut registry = KeyRegistryState::new(Some(1));
+        let peer = dummy_peer_id();
+        let other = dummy_peer_id();
+
+        registry.insert_gossip(peer.clone(), dummy_key(1));
+        // A real handshake with the same peer now confirms the key directly; it must
+        // no longer be eligible for gossip eviction.
+        registry.insert_direct(peer.clone(), dummy_key(1));
+
+        // At capacity (1) with the only entry now direct: a new gossip key must be
+        // dropped rather than evicting the promoted entry.
+        registry.insert_gossip(other.clone(), dummy_key(2));
+
+        assert_eq!(registry.get(&peer), Some(dummy_key(1)));
+        assert_eq!(registry.get(&other), None);
+    }
+
+    #[test]
+    fn unbounded_registry_never_evicts() {
+        let mut registry = KeyRegistryState::new(None);
+        let peers: Vec<PeerId> = (0..50u8)
+            .map(|i| {
+                let peer_id = dummy_peer_id();
+                registry.insert_gossip(peer_id.clone(), dummy_key(i));
+                peer_id
+            })
+            .collect();
+
+        for (i, peer_id) in peers.iter().enumerate() {
+            assert_eq!(
+                registry.get(peer_id),
+                Some(dummy_key(i as u8)),
+                "no entry should be evicted when max_size is None"
+            );
+        }
+    }
 }
 
 // -- peer table ----------------------------------------------------------
@@ -333,4 +499,9 @@ pub struct NodeConfig {
     /// When a destination's queue is full, the incoming payload is dropped and
     /// `TransportEvent::StoreFailed` is fired immediately. `None` means no bound.
     pub max_queue_depth: Option<usize>,
+    /// Maximum number of entries in the key registry. When at capacity, the oldest
+    /// gossip-learned entry (#100) is evicted first; if every entry was learned via a
+    /// direct handshake, a new gossip-learned key is dropped instead of evicting one.
+    /// `None` means no bound. See #101.
+    pub max_key_registry_size: Option<usize>,
 }

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -8,9 +8,9 @@ use futures::stream::BoxStream;
 use tokio::sync::{broadcast, watch};
 
 use crate::{
-    new_key_registry, new_peer_table, router, BundleLayer, Connection, KeyRegistry, MessageHandler,
-    NodeConfig, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement, PeerId, PeerTable,
-    Result, Router, Session, Transport, TransportEvent,
+    new_key_registry_with_bound, new_peer_table, router, BundleLayer, Connection, KeyRegistry,
+    MessageHandler, NodeConfig, NodeIdentity, PathweaveError, PeerAddress, PeerAnnouncement,
+    PeerId, PeerTable, Result, Router, Session, Transport, TransportEvent,
 };
 
 pub(crate) const MAX_TTL: u8 = 7;
@@ -128,7 +128,7 @@ impl PathweaveNode {
         let max_queue_depth = config.max_queue_depth;
         let router = Arc::new(Router::new());
         let peers = new_peer_table();
-        let key_registry = new_key_registry();
+        let key_registry = new_key_registry_with_bound(config.max_key_registry_size);
         let pending_direct: PendingStore = Arc::new(Mutex::new(HashMap::new()));
         let pending_routed: PendingStore = Arc::new(Mutex::new(HashMap::new()));
 
@@ -557,7 +557,7 @@ impl PathweaveNode {
     /// Populated after every successful handshake. Used by the Noise_XK upgrade path
     /// and future E2E hop encryption. See ADR 020.
     pub fn lookup_key(&self, peer_id: &PeerId) -> Option<[u8; 32]> {
-        self.key_registry.lock().unwrap().get(peer_id).copied()
+        self.key_registry.lock().unwrap().get(peer_id)
     }
 }
 
@@ -795,8 +795,7 @@ async fn handle_incoming(
     let is_new_key = key_registry
         .lock()
         .unwrap()
-        .insert(sender_peer_id.clone(), *session.remote_static_key())
-        .is_none();
+        .insert_direct(sender_peer_id.clone(), *session.remote_static_key());
     if is_new_key {
         let _ = router.event_tx().send(TransportEvent::KeyLearned {
             peer_id: sender_peer_id.clone(),
@@ -1004,7 +1003,7 @@ async fn dispatch_payload(
                         key_registry
                             .lock()
                             .unwrap()
-                            .insert(announced_peer_id.clone(), public_key);
+                            .insert_gossip(announced_peer_id.clone(), public_key);
 
                         let ttl = ttl.min(MAX_TTL);
                         if ttl > 0 {
@@ -1481,7 +1480,7 @@ mod tests {
         let stored = registry
             .get(&peer_id)
             .expect("key must be in registry after connect");
-        assert_eq!(stored, &expected_key);
+        assert_eq!(stored, expected_key);
     }
 
     #[tokio::test]
@@ -1906,7 +1905,7 @@ mod tests {
         // immediately.
         let stored = tokio::time::timeout(tokio::time::Duration::from_secs(5), async {
             loop {
-                if let Some(key) = node_c.key_registry.lock().unwrap().get(&pid_a).copied() {
+                if let Some(key) = node_c.key_registry.lock().unwrap().get(&pid_a) {
                     return key;
                 }
                 tokio::time::sleep(tokio::time::Duration::from_millis(20)).await;
@@ -1966,12 +1965,7 @@ mod tests {
 
         tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
 
-        let stored = node
-            .key_registry
-            .lock()
-            .unwrap()
-            .get(&victim_peer_id)
-            .copied();
+        let stored = node.key_registry.lock().unwrap().get(&victim_peer_id);
         assert!(
             stored.is_none(),
             "forged key announcement must not be stored in the registry"

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -437,8 +437,7 @@ async fn try_connect(
     let is_new_key = key_registry
         .lock()
         .unwrap()
-        .insert(peer_id.clone(), *session.remote_static_key())
-        .is_none();
+        .insert_direct(peer_id.clone(), *session.remote_static_key());
     let learned_key = is_new_key.then(|| *session.remote_static_key());
     let local = transport.local_addresses();
     let _ = session.send(&encode_addr_exchange(&local)).await;
@@ -732,7 +731,7 @@ async fn try_send(
     peer_id: &PeerId,
     peers: &PeerTable,
 ) -> Result<Option<[u8; 32]>> {
-    let remote_key = key_registry.lock().unwrap().get(peer_id).copied();
+    let remote_key = key_registry.lock().unwrap().get(peer_id);
     let raw = transport.connect(peer).await.map_err(|e| {
         tracing::debug!(addr = ?peer.address, error = %e, "try_send: connect failed");
         e
@@ -752,8 +751,7 @@ async fn try_send(
     let is_new_key = key_registry
         .lock()
         .unwrap()
-        .insert(session.peer_id().clone(), *session.remote_static_key())
-        .is_none();
+        .insert_direct(session.peer_id().clone(), *session.remote_static_key());
     let learned_key = is_new_key.then(|| *session.remote_static_key());
 
     let local = transport.local_addresses();


### PR DESCRIPTION
## What changed

`NodeConfig::max_key_registry_size: Option<usize>` bounds the key registry, mirroring the existing `max_queue_depth` pattern from #94/#97. `None` preserves today's unbounded behavior. When bounded and full, the oldest gossip-learned entry is evicted first; if every entry was learned via a direct handshake, a new gossip-learned key is dropped instead of evicting one. A direct handshake promotes a previously gossip-learned entry out of eviction eligibility, since the handshake confirms it deserves the same protection a direct entry always has, regardless of how it originally arrived.

Tracking which entries are gossip-learned is done via insertion order in a separate `VecDeque<PeerId>`, not a label on each entry. A peer_id's presence in that queue, not a stored field, is what makes it eligible for eviction, since eviction only ever needs "what's the oldest gossip entry," never "what is this specific entry's source."

## Why

Closes #101. The key registry was populated only from direct Noise handshakes, naturally bounded by however many peers a node has actually met. Gossip (#100) can now also populate it from identities a node has never met and may never connect to, the same shape of problem already fixed for the store-and-forward queue.

## Alternatives considered

**A `source: KeySource` field on each entry vs. a separate ordering queue.** The first version of this PR stored `{ public_key, source: DirectHandshake | Gossip }` per entry. It turned out redundant: eviction only ever needs "what's the oldest gossip entry," answered entirely by the queue's front, and nothing ever read the per-entry `source` field directly. Removed it once `cargo clippy` flagged it as dead code, rather than keeping an unused field for documentation value alone.

**LRU over a single combined structure.** The issue itself names this as the wrong naive approach, and it's worth restating why: a peer you are actively talking to and a stranger several hops away whose key arrived via gossip are not equally valuable. A pure recency-based LRU would evict a real, present contact to make room for gossip noise if the contact simply hadn't been touched recently. Treating "learned via gossip" as a separate eligibility dimension, not just another point on a recency axis, is what the issue's constraint section actually requires.

## Security considerations

This closes a real, if narrow, amplification gossip introduced: before gossip, a fake identity's key only ever reached the one node it directly connected to. After gossip, that single connection can propagate the fake key up to `MAX_TTL` (7) hops without further effort from whoever generated it (identity creation in this system is free, `NodeIdentity::generate()` has no cost, no proof-of-work, matching Reticulum and libp2p, this is not something this PR changes). The fake key itself still isn't independently exploitable (a public key alone can't be used to decrypt or impersonate), but an unbounded registry meant that amplification had no ceiling on how much memory it could consume. This bound caps it, and ensures the cap is paid for by gossip-learned entries first, never by displacing a peer the node actually talks to.

## Test plan

- `cargo test --workspace`: all passing (72 in pathweave-core, up from 68), including 4 new unit tests against `KeyRegistryState` directly: `gossip_entries_evict_oldest_first_without_bound_overflow`, `direct_handshake_entry_is_never_evicted_by_gossip`, `direct_handshake_promotes_a_previously_gossip_learned_entry`, `unbounded_registry_never_evicts`.
- `cargo clippy --workspace --all-targets`: clean (`#![deny(clippy::all)]` caught a `map_entry` lint during development, fixed with `get_mut` instead of `contains_key` + `insert`).
- `cargo fmt --check`: clean.
