### PR TITLE
feat(core): seal routed messages to the destination with Noise_K

### DIFF
--- a/crates/pathweave-core/src/lib.rs
+++ b/crates/pathweave-core/src/lib.rs
@@ -38,6 +38,8 @@ pub enum PathweaveError {
     Bundle(String),
     #[error("invalid key material")]
     InvalidKey,
+    #[error("no known key for destination {0}")]
+    KeyUnknown(PeerId),
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }
@@ -46,6 +48,7 @@ pub enum PathweaveError {
 
 pub(crate) const NOISE_PARAMS: &str = "Noise_XX_25519_ChaChaPoly_BLAKE2s";
 pub(crate) const NOISE_XK_PARAMS: &str = "Noise_XK_25519_ChaChaPoly_BLAKE2s";
+pub(crate) const NOISE_K_PARAMS: &str = "Noise_K_25519_ChaChaPoly_BLAKE2s";
 
 pub(crate) fn peer_id_from_public_key(public_key: &[u8]) -> PeerId {
     PeerId(*blake3::hash(public_key).as_bytes())

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -422,6 +422,73 @@ impl PathweaveNode {
         }
     }
 
+    /// Sends `payload` to `dest_peer_id` via mesh routing, sealed end-to-end with
+    /// Noise_K so only `dest_peer_id` can read it (ADR 023).
+    ///
+    /// Relays along the path see `dest_peer_id` and `ttl` (needed to route) but never
+    /// the plaintext. Requires `dest_peer_id`'s static key already in the key registry
+    /// (from a direct handshake or gossip); returns `PathweaveError::KeyUnknown` if it
+    /// is not there yet rather than silently falling back to an unsealed send.
+    pub async fn send_routed_sealed(&self, dest_peer_id: PeerId, payload: Vec<u8>) -> Result<()> {
+        let dest_public_key = self
+            .key_registry
+            .lock()
+            .unwrap()
+            .get(&dest_peer_id)
+            .ok_or_else(|| PathweaveError::KeyUnknown(dest_peer_id.clone()))?;
+
+        let sealed = crate::session::seal(&self.identity, &dest_public_key, &payload)?;
+        let mut envelope = Vec::with_capacity(32 + sealed.len());
+        envelope.extend_from_slice(self.identity.peer_id().as_bytes());
+        envelope.extend_from_slice(&sealed);
+
+        let msg_id = router::new_message_id();
+        let mut frame_body = Vec::with_capacity(1 + 32 + 1 + envelope.len());
+        frame_body.push(0x03); // E2E-sealed routed route_flag (ADR 023)
+        frame_body.extend_from_slice(dest_peer_id.as_bytes());
+        frame_body.push(MAX_TTL);
+        frame_body.extend_from_slice(&envelope);
+
+        let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = self
+            .peers
+            .lock()
+            .unwrap()
+            .iter()
+            .filter(|(pid, _)| **pid != *self.identity.peer_id())
+            .map(|(pid, anns)| (pid.clone(), anns.clone()))
+            .collect();
+
+        if neighbors.is_empty() {
+            return Err(PathweaveError::NoTransportAvailable);
+        }
+
+        let mut any_ok = false;
+        for (peer_id, announcements) in neighbors {
+            if self
+                .router
+                .send(
+                    &announcements,
+                    &self.identity,
+                    frame_body.clone(),
+                    &peer_id,
+                    &self.key_registry,
+                    &self.peers,
+                    Some(msg_id),
+                )
+                .await
+                .is_ok()
+            {
+                any_ok = true;
+            }
+        }
+
+        if any_ok {
+            Ok(())
+        } else {
+            Err(PathweaveError::DeliveryFailed)
+        }
+    }
+
     /// Accepts `payload` for deferred delivery to `peer_id` and returns immediately.
     ///
     /// If the peer is already reachable, delivery is attempted right away using the same
@@ -1032,6 +1099,81 @@ async fn dispatch_payload(
                 tracing::debug!(peer = %sender_peer_id, "key announcement: parse failed; skipping");
             }
         },
+        0x03 => {
+            // [dest_peer_id: 32][ttl: 1][envelope: sender_peer_id(32) + noise_k_message] (ADR 023)
+            if payload.len() < 9 + 32 + 1 + 32 {
+                tracing::debug!(peer = %sender_peer_id, "sealed routed frame too short; skipping");
+                let _ = session.send(b"").await;
+                return;
+            }
+            let dest_bytes: [u8; 32] = payload[9..41].try_into().unwrap();
+            let dest = PeerId::from_bytes(dest_bytes);
+            let ttl = payload[41].min(MAX_TTL);
+            let envelope = &payload[42..];
+            let sealed_sender_bytes: [u8; 32] = envelope[..32].try_into().unwrap();
+            let sealed_sender = PeerId::from_bytes(sealed_sender_bytes);
+            let noise_k_message = &envelope[32..];
+
+            if &dest == local_peer_id {
+                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                if is_dup {
+                    tracing::debug!(
+                        msg_id,
+                        "suppressed duplicate sealed routed message at destination"
+                    );
+                } else {
+                    let sender_key = key_registry.lock().unwrap().get(&sealed_sender);
+                    match sender_key {
+                        Some(sender_key) => match crate::session::unseal(
+                            identity,
+                            &sealed_sender,
+                            &sender_key,
+                            noise_k_message,
+                        ) {
+                            Ok(plaintext) => {
+                                if let Some(h) = handler.lock().unwrap().as_ref() {
+                                    h.on_message(sealed_sender, plaintext);
+                                }
+                            }
+                            Err(e) => {
+                                tracing::debug!(peer = %sealed_sender, error = %e, "unseal failed; dropping");
+                            }
+                        },
+                        None => {
+                            tracing::debug!(peer = %sealed_sender, "sealed routed message: sender key unknown; dropping");
+                        }
+                    }
+                }
+            } else if ttl == 0 {
+                tracing::debug!(msg_id, "TTL=0: silently dropping sealed routed message");
+            } else {
+                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                if !is_dup {
+                    let new_ttl = ttl - 1;
+                    let mut relay_body = Vec::with_capacity(1 + 32 + 1 + envelope.len());
+                    relay_body.push(0x03);
+                    relay_body.extend_from_slice(dest.as_bytes());
+                    relay_body.push(new_ttl);
+                    relay_body.extend_from_slice(envelope);
+
+                    spawn_relay_to_neighbors(
+                        relay_body,
+                        msg_id,
+                        sender_peer_id,
+                        local_peer_id,
+                        peers,
+                        router,
+                        identity,
+                        key_registry,
+                    );
+                } else {
+                    tracing::debug!(
+                        msg_id,
+                        "suppressed duplicate sealed routed message at relay"
+                    );
+                }
+            }
+        }
         _ => {
             tracing::debug!(peer = %sender_peer_id, route_flag, "unknown route_flag; skipping");
         }
@@ -1729,6 +1871,26 @@ mod tests {
         }
     }
 
+    type IdentifiedSender = tokio::sync::oneshot::Sender<(PeerId, Vec<u8>)>;
+
+    // Captures both the reported sender PeerId and the payload, unlike
+    // CountingHandler which discards the sender. Used to assert E2E-sealed
+    // delivery reports the cryptographically authenticated sender (ADR 023),
+    // not just the immediate transport-level relay.
+    struct IdentifyingHandler {
+        count: Arc<std::sync::atomic::AtomicUsize>,
+        tx: Arc<Mutex<Option<IdentifiedSender>>>,
+    }
+
+    impl MessageHandler for IdentifyingHandler {
+        fn on_message(&self, peer_id: PeerId, payload: Vec<u8>) {
+            self.count.fetch_add(1, Ordering::Relaxed);
+            if let Some(tx) = self.tx.lock().unwrap().take() {
+                let _ = tx.send((peer_id, payload));
+            }
+        }
+    }
+
     // --- mesh routing integration tests --------------------------------------
 
     // Topology: A --[Ble]--> B --[Quic]--> C
@@ -2180,6 +2342,216 @@ mod tests {
             count_c.load(Ordering::Relaxed),
             1,
             "invariant 4: routed message delivered exactly once despite two distinct sender paths"
+        );
+    }
+
+    // --- E2E hop encryption tests (ADR 023) -----------------------------------
+
+    // Topology: A --[Ble]--> B --[Quic]--> C, same as routed_message_delivered_via_relay,
+    // but A seals the payload to C's key. B relays the opaque envelope without ever
+    // calling on_message; only C, holding the matching private key, can open it.
+    #[tokio::test]
+    async fn sealed_routed_message_relay_cannot_read_payload() {
+        let id_a = NodeIdentity::generate();
+        let id_b = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+
+        let pid_a = id_a.peer_id().clone();
+        let pid_b = id_b.peer_id().clone();
+        let pid_c = id_c.peer_id().clone();
+        let key_a: [u8; 32] = id_a.public_key().try_into().unwrap();
+        let key_c: [u8; 32] = id_c.public_key().try_into().unwrap();
+
+        let (t_a, t_b_inbound) = wire_transports(TransportKind::Ble);
+        let (t_b_outbound, t_c) = wire_transports(TransportKind::Quic);
+
+        let mut node_a = PathweaveNode::new(NodeConfig::default(), id_a)
+            .await
+            .unwrap();
+        node_a.register_transport(Box::new(t_a));
+        node_a.add_peer(pid_b.clone(), ble_ann("node-b"));
+        // A must already have C's key to seal to it (from a prior handshake or gossip;
+        // ADR 023 never falls back to sending unsealed).
+        node_a
+            .key_registry
+            .lock()
+            .unwrap()
+            .insert_direct(pid_c.clone(), key_c);
+
+        let mut node_b = PathweaveNode::new(NodeConfig::default(), id_b)
+            .await
+            .unwrap();
+        node_b.register_transport(Box::new(t_b_inbound));
+        node_b.register_transport(Box::new(t_b_outbound));
+        node_b.add_peer(pid_a.clone(), ble_ann("node-a"));
+        node_b.add_peer(
+            pid_c.clone(),
+            PeerAnnouncement {
+                address: PeerAddress::Quic("127.0.0.1:30".parse().unwrap()),
+                short_id: None,
+            },
+        );
+
+        let mut node_c = PathweaveNode::new(NodeConfig::default(), id_c)
+            .await
+            .unwrap();
+        node_c.register_transport(Box::new(t_c));
+        node_c.add_peer(
+            pid_b.clone(),
+            PeerAnnouncement {
+                address: PeerAddress::Quic("127.0.0.1:31".parse().unwrap()),
+                short_id: None,
+            },
+        );
+        // C must already have A's key to verify and open the seal.
+        node_c
+            .key_registry
+            .lock()
+            .unwrap()
+            .insert_direct(pid_a.clone(), key_a);
+
+        let count_a = Arc::new(AtomicUsize::new(0));
+        let count_b = Arc::new(AtomicUsize::new(0));
+        let count_c = Arc::new(AtomicUsize::new(0));
+        let (c_tx, c_rx) = tokio::sync::oneshot::channel::<(PeerId, Vec<u8>)>();
+        let c_tx = Arc::new(Mutex::new(Some(c_tx)));
+
+        node_a.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_a),
+            payload_tx: Arc::new(Mutex::new(None)),
+        }));
+        node_b.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_b),
+            payload_tx: Arc::new(Mutex::new(None)),
+        }));
+        node_c.on_message(Box::new(IdentifyingHandler {
+            count: Arc::clone(&count_c),
+            tx: c_tx,
+        }));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        node_a
+            .send_routed_sealed(pid_c.clone(), b"e2e sealed payload".to_vec())
+            .await
+            .unwrap();
+
+        let (reported_sender, delivered) =
+            tokio::time::timeout(tokio::time::Duration::from_secs(5), c_rx)
+                .await
+                .expect("timed out waiting for sealed delivery")
+                .unwrap();
+
+        assert_eq!(delivered, b"e2e sealed payload");
+        assert_eq!(
+            reported_sender, pid_a,
+            "destination must see the cryptographically authenticated sender, not the relay"
+        );
+        assert_eq!(
+            count_c.load(Ordering::Relaxed),
+            1,
+            "delivered exactly once at C"
+        );
+        assert_eq!(
+            count_b.load(Ordering::Relaxed),
+            0,
+            "relay never decrypts or delivers a sealed message"
+        );
+        assert_eq!(count_a.load(Ordering::Relaxed), 0);
+    }
+
+    #[tokio::test]
+    async fn send_routed_sealed_returns_key_unknown_without_destination_key() {
+        let id_a = NodeIdentity::generate();
+        let node_a = PathweaveNode::new(NodeConfig::default(), id_a)
+            .await
+            .unwrap();
+
+        let unknown_dest = NodeIdentity::generate().peer_id().clone();
+        let result = node_a
+            .send_routed_sealed(unknown_dest.clone(), b"payload".to_vec())
+            .await;
+
+        match result {
+            Err(PathweaveError::KeyUnknown(p)) => assert_eq!(p, unknown_dest),
+            other => panic!("expected KeyUnknown, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn replayed_sealed_message_is_dropped_at_dedup() {
+        // Build one route_flag 0x03 frame by hand with a fixed message_id and send it
+        // twice over the same path. dispatch_payload's 0x03 branch checks
+        // check_and_insert_routed before calling unseal (ADR 023), so the second
+        // delivery must be suppressed without needing to involve unseal at all.
+        let id_s = NodeIdentity::generate();
+        let id_c = NodeIdentity::generate();
+        let pid_c = id_c.peer_id().clone();
+        let key_c: [u8; 32] = id_c.public_key().try_into().unwrap();
+
+        let (t_s, t_c) = wire_transports(TransportKind::Ble);
+
+        let mut node_s = PathweaveNode::new(NodeConfig::default(), id_s.clone())
+            .await
+            .unwrap();
+        node_s.register_transport(Box::new(t_s));
+
+        let mut node_c = PathweaveNode::new(NodeConfig::default(), id_c)
+            .await
+            .unwrap();
+        node_c.register_transport(Box::new(t_c));
+
+        let count_c = Arc::new(AtomicUsize::new(0));
+        let (c_tx, c_rx) = tokio::sync::oneshot::channel::<Vec<u8>>();
+        let c_tx_arc = Arc::new(Mutex::new(Some(c_tx)));
+        node_c.on_message(Box::new(CountingHandler {
+            count: Arc::clone(&count_c),
+            payload_tx: Arc::clone(&c_tx_arc),
+        }));
+
+        for _ in 0..6 {
+            tokio::task::yield_now().await;
+        }
+
+        let sealed = crate::session::seal(&id_s, &key_c, b"replay me").unwrap();
+        let mut envelope = Vec::with_capacity(32 + sealed.len());
+        envelope.extend_from_slice(id_s.peer_id().as_bytes());
+        envelope.extend_from_slice(&sealed);
+
+        let msg_id = crate::router::new_message_id();
+        let mut frame_body = Vec::new();
+        frame_body.push(0x03);
+        frame_body.extend_from_slice(pid_c.as_bytes());
+        frame_body.push(MAX_TTL);
+        frame_body.extend_from_slice(&envelope);
+
+        for _ in 0..2 {
+            node_s
+                .router
+                .send(
+                    &[ble_ann("c")],
+                    &id_s,
+                    frame_body.clone(),
+                    &pid_c,
+                    &node_s.key_registry,
+                    &node_s.peers,
+                    Some(msg_id),
+                )
+                .await
+                .unwrap();
+        }
+
+        let _ = tokio::time::timeout(tokio::time::Duration::from_secs(5), c_rx)
+            .await
+            .expect("timed out waiting for sealed delivery");
+
+        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+        assert_eq!(
+            count_c.load(Ordering::Relaxed),
+            1,
+            "replayed sealed frame must not be delivered twice"
         );
     }
 

--- a/crates/pathweave-core/src/session.rs
+++ b/crates/pathweave-core/src/session.rs
@@ -2,7 +2,7 @@ use bytes::Bytes;
 
 use crate::{
     peer_id_from_public_key, Connection, NodeIdentity, PathweaveError, PeerId, Result,
-    NOISE_PARAMS, NOISE_XK_PARAMS,
+    NOISE_K_PARAMS, NOISE_PARAMS, NOISE_XK_PARAMS,
 };
 
 // Maximum Noise protocol message size (spec limit).
@@ -197,6 +197,70 @@ impl Session {
     }
 }
 
+/// Seals `payload` to `dest_public_key` using a one-shot Noise_K message (ADR 023).
+///
+/// Noise_K's pre-message tokens require both parties' static keys before the single
+/// message is written; `identity` proves the sender, `dest_public_key` is the
+/// destination's key from the key registry. The resulting bytes are the complete
+/// sealed message (ephemeral public key, ciphertext, and AEAD tag); the handshake
+/// state is discarded immediately after, there is no transport phase to convert into.
+pub(crate) fn seal(
+    identity: &NodeIdentity,
+    dest_public_key: &[u8; 32],
+    payload: &[u8],
+) -> Result<Vec<u8>> {
+    let mut state = snow::Builder::new(
+        NOISE_K_PARAMS
+            .parse()
+            .expect("hardcoded noise params are valid"),
+    )
+    .local_private_key(identity.private_key_bytes())
+    .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
+    .remote_public_key(dest_public_key)
+    .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
+    .build_initiator()
+    .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
+
+    let mut buf = vec![0u8; NOISE_MSG_MAX];
+    let n = state
+        .write_message(payload, &mut buf)
+        .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
+    Ok(buf[..n].to_vec())
+}
+
+/// Opens a message produced by `seal` (ADR 023).
+///
+/// `sender_public_key` is the claimed sender's key, looked up by the caller from the
+/// key registry using `sender_peer_id` (carried in the envelope alongside `sealed`).
+/// Noise_K verifies the sender via static-static DH during `read_message`; a key
+/// mismatch or corrupted message fails here rather than producing wrong plaintext.
+pub(crate) fn unseal(
+    identity: &NodeIdentity,
+    sender_peer_id: &PeerId,
+    sender_public_key: &[u8; 32],
+    sealed: &[u8],
+) -> Result<Vec<u8>> {
+    let mut state = snow::Builder::new(
+        NOISE_K_PARAMS
+            .parse()
+            .expect("hardcoded noise params are valid"),
+    )
+    .local_private_key(identity.private_key_bytes())
+    .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
+    .remote_public_key(sender_public_key)
+    .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?
+    .build_responder()
+    .map_err(|e: snow::Error| PathweaveError::Session(e.to_string()))?;
+
+    let mut buf = vec![0u8; sealed.len()];
+    let n = state
+        .read_message(sealed, &mut buf)
+        .map_err(|e: snow::Error| {
+            PathweaveError::Session(format!("unseal failed for sender {sender_peer_id}: {e}"))
+        })?;
+    Ok(buf[..n].to_vec())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -389,6 +453,50 @@ mod tests {
         assert!(
             matches!(result, Err(PathweaveError::Session(_))),
             "expected session error on tampered ciphertext, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn seal_unseal_roundtrips() {
+        let sender = NodeIdentity::generate();
+        let dest = NodeIdentity::generate();
+        let dest_public_key: [u8; 32] = dest.public_key().try_into().unwrap();
+        let sender_public_key: [u8; 32] = sender.public_key().try_into().unwrap();
+
+        let sealed = seal(&sender, &dest_public_key, b"hop encrypted payload").unwrap();
+        let opened = unseal(&dest, sender.peer_id(), &sender_public_key, &sealed).unwrap();
+        assert_eq!(&opened[..], b"hop encrypted payload");
+    }
+
+    #[test]
+    fn unseal_with_wrong_sender_key_fails() {
+        let sender = NodeIdentity::generate();
+        let dest = NodeIdentity::generate();
+        let wrong_sender = NodeIdentity::generate();
+        let dest_public_key: [u8; 32] = dest.public_key().try_into().unwrap();
+        let wrong_sender_key: [u8; 32] = wrong_sender.public_key().try_into().unwrap();
+
+        let sealed = seal(&sender, &dest_public_key, b"payload").unwrap();
+        let result = unseal(&dest, sender.peer_id(), &wrong_sender_key, &sealed);
+        assert!(
+            matches!(result, Err(PathweaveError::Session(_))),
+            "unseal with the wrong sender key must fail, got: {result:?}"
+        );
+    }
+
+    #[test]
+    fn unseal_with_wrong_dest_identity_fails() {
+        let sender = NodeIdentity::generate();
+        let dest = NodeIdentity::generate();
+        let wrong_dest = NodeIdentity::generate();
+        let dest_public_key: [u8; 32] = dest.public_key().try_into().unwrap();
+        let sender_public_key: [u8; 32] = sender.public_key().try_into().unwrap();
+
+        let sealed = seal(&sender, &dest_public_key, b"payload").unwrap();
+        let result = unseal(&wrong_dest, sender.peer_id(), &sender_public_key, &sealed);
+        assert!(
+            matches!(result, Err(PathweaveError::Session(_))),
+            "unseal from the wrong destination identity must fail, got: {result:?}"
         );
     }
 }

--- a/notes/decisions/023-e2e-hop-encryption.md
+++ b/notes/decisions/023-e2e-hop-encryption.md
@@ -142,8 +142,14 @@ decrypt successfully every time, since decryption only depends on the fixed send
 destination static keys plus the ephemeral key embedded in the captured message itself.
 This does not need new protection in Pathweave: every routed frame, `0x01`, `0x02`, or
 `0x03`, already carries a `message_id` deduplicated at every hop (ADR 019,
-`check_and_insert_routed`), before any attempt to interpret the payload. A replayed
-`0x03` frame is dropped at the dedup check, never reaching `unseal`.
+`check_and_insert_routed`), before any attempt to interpret the payload. A `0x03` frame
+replayed within the same 60-second dedup TTL used everywhere else in this codebase
+(ADR 011, SECURITY.md's Replay suppression section) is dropped at the dedup check,
+never reaching `unseal`. A frame replayed after that window expires is no longer
+recognized as a duplicate and will successfully unseal and deliver again, the same
+time-bounded property `0x01` and `0x02` already have. This is not a new gap introduced
+here; closing it for good would mean adding a freshness mechanism Noise_K does not
+provide on its own, which is out of scope for this ADR.
 
 ### Missing key: fail loudly, never silently downgrade
 

--- a/notes/decisions/023-e2e-hop-encryption.md
+++ b/notes/decisions/023-e2e-hop-encryption.md
@@ -1,0 +1,213 @@
+# ADR 023: E2E hop encryption via Noise_K
+
+**Status:** Accepted
+
+## Context
+
+A routed message (ADR 019, `route_flag 0x01`) travels hop by hop. Each link between two
+nodes is encrypted with Noise (XX or XK), but every relay along the path decrypts its
+Noise session with its immediate neighbor and sees the plaintext payload before
+re-encrypting for the next hop. A relay forwarding a message is fully able to read it.
+
+E2E hop encryption means sealing the payload to the destination's actual identity key,
+so a relay can still read what it needs to route (`dest_peer_id`, `ttl`) but cannot read
+the content. Only the destination, holding the matching private key, can open it. This
+requires the sender to already have the destination's public key before sending, which
+the key registry and gossip (ADR 020, #100, #101) now provide, including for
+destinations the sender has never directly connected to.
+
+## Decision
+
+### Sealing mechanism: Noise_K, not a custom construction
+
+The first draft of this ADR proposed a hand-rolled construction: an X25519
+Diffie-Hellman between the sender's static key and the destination's static key, used
+directly as a ChaCha20-Poly1305 key. That was wrong before any code was written against
+it: a raw DH output is not safe to use directly as a symmetric key without a key
+derivation step first (Noise itself never does this; every `MixKey` operation in the
+protocol runs DH output through HKDF before deriving a cipher key). Rolling that by hand
+risks getting the derivation subtly wrong, and would have required a new direct
+dependency on `chacha20poly1305` for a construction with no formal analysis behind it.
+
+The Noise Protocol Framework already defines this exact case. Section 7.4 specifies
+**one-way handshake patterns** (`N`, `X`, `K`) for "a one-way stream of data from a
+sender to a recipient... to encrypt files, database records, or other non-interactive
+data streams." `Noise_K` fits: both parties' static keys are known in advance, it is a
+single message with no response possible, and that single message carries the
+application payload directly, no separate handshake-then-transport phase.
+
+`snow` (already a direct dependency, used for XX and XK) supports one-way patterns
+natively:
+
+```rust
+pattern_enum! {
+    HandshakePattern {
+        // 7.4. One-way handshake patterns
+        N, X, K,
+        ...
+```
+
+with a dedicated `is_oneway()` method (confirmed against `snow`'s actual source, not
+assumed from the spec alone). `Noise_K_25519_ChaChaPoly_BLAKE2s` parses through the
+exact same pattern-string mechanism already proven for `Noise_XX_25519_ChaChaPoly_BLAKE2s`
+and `Noise_XK_25519_ChaChaPoly_BLAKE2s`. No new dependency.
+
+Noise_K's token sequence:
+
+```
+K:
+  -> s
+  <- s
+  ...
+  -> e, es, ss
+```
+
+The pre-message tokens (`-> s`, `<- s`) mean both parties' static keys must be supplied
+to `snow::Builder` before the single message is written or read; neither key is
+transmitted as part of the Noise_K message itself. The sender already has the
+destination's key from the registry. The destination needs to know which key to supply
+as the sender's, which the envelope format below provides.
+
+### seal/unseal: stateless functions, not an extension of Session
+
+`Session` models an ongoing, multi-message, bidirectional connection (`initiate`/
+`respond` followed by repeated `send`/`recv`). Noise_K is the opposite: exactly one
+message, never followed by anything else over that handshake state. Forcing it through
+`Session`'s shape would mean adding states to an abstraction built for a fundamentally
+different lifecycle. Instead, two new stateless functions, alongside `Session` in
+`session.rs` but not part of it:
+
+```rust
+pub(crate) fn seal(
+    identity: &NodeIdentity,
+    dest_public_key: &[u8; 32],
+    payload: &[u8],
+) -> Result<Vec<u8>>;
+
+pub(crate) fn unseal(
+    identity: &NodeIdentity,
+    sender_peer_id: &PeerId,
+    sender_public_key: &[u8; 32],
+    sealed: &[u8],
+) -> Result<Vec<u8>>;
+```
+
+`seal` builds a fresh `snow::Builder` with `Noise_K_25519_ChaChaPoly_BLAKE2s`, supplies
+`identity`'s private key and `dest_public_key` as the pre-shared remote key, calls
+`build_initiator()`, and calls `write_message(payload, &mut buf)` exactly once. The
+resulting bytes are the sealed message; the `HandshakeState` is discarded immediately
+after, there is no transport phase to convert into. `unseal` does the same as responder,
+supplying `sender_public_key` as the pre-shared remote key (the caller looks this up
+from the key registry using `sender_peer_id`, see the envelope format below), and calls
+`read_message` exactly once.
+
+### Envelope format
+
+```
+[sender_peer_id:    32 bytes]   so the recipient knows which registry key to supply
+[noise_k_message:    N bytes]   output of seal(): ephemeral pubkey + ciphertext + tag
+```
+
+`sender_peer_id` travels in the clear inside the envelope (still inside the outer Noise
+hop-to-hop encryption, so relays decrypting their own link still see it, but it is not
+visible to a passive observer outside any hop). This is necessary, not optional: Noise_K
+never transmits the sender's static key as part of the message, by design (it is a
+pre-message token, assumed already known), so without `sender_peer_id` the destination
+has no way to know which key to configure before attempting `read_message`.
+
+### Wire format: a new route_flag, not a redefinition of an existing one
+
+A new `route_flag` value, alongside the existing `0x00` (direct), `0x01` (routed,
+unsealed), and `0x02` (key announcement, ADR 020):
+
+```
+route_flag 0x03: E2E-sealed routed message
+[dest_peer_id: 32 bytes]   same as 0x01, relays read this to forward
+[ttl:           1 byte]    same as 0x01, clamped to MAX_TTL (7) on receipt
+[envelope:      N bytes]   sender_peer_id + noise_k_message, see above
+```
+
+`0x01` keeps its current meaning (unsealed routed messages continue to work exactly as
+they do today). `0x03` is the sealed variant, sharing the same TTL clamp, dedup, and
+relay-spawn logic already built for `0x01` and `0x02` (`spawn_relay_to_neighbors` in
+`node.rs`, added in the gossip work): a relay forwarding a `0x03` frame never inspects
+or modifies the `envelope` field, exactly as it already does not have a way to read into
+an opaque payload it cannot decrypt.
+
+### Replay: covered by existing dedup, not solved here
+
+The Noise spec notes one-way patterns have no built-in replay protection: there is no
+`ee` (ephemeral-ephemeral) component, so a captured message can be replayed and will
+decrypt successfully every time, since decryption only depends on the fixed sender and
+destination static keys plus the ephemeral key embedded in the captured message itself.
+This does not need new protection in Pathweave: every routed frame, `0x01`, `0x02`, or
+`0x03`, already carries a `message_id` deduplicated at every hop (ADR 019,
+`check_and_insert_routed`), before any attempt to interpret the payload. A replayed
+`0x03` frame is dropped at the dedup check, never reaching `unseal`.
+
+### Missing key: fail loudly, never silently downgrade
+
+`PathweaveNode::send_routed_sealed` (or equivalent) returns a new error,
+`PathweaveError::KeyUnknown(PeerId)`, when the destination's key is not in the registry.
+It never falls back to sending unsealed. A security feature that can silently downgrade
+is worse than not having it: a caller who believes a message was E2E-protected, when it
+silently was not, is a worse failure mode than an explicit error the caller must handle
+(retry later once gossip propagates the key, surface the failure, or choose to send
+unsealed via the existing `0x01` path explicitly if that is genuinely acceptable for
+that call site).
+
+## Rationale
+
+**Why Noise_K over a custom construction, restated plainly.** Noise_K is formally
+analyzed, already implemented by a crate this project already trusts for its entire
+existing security model, and requires no new dependency. The alternative would have
+required this project to get a KDF step right by hand, for a construction with none of
+that history behind it. There is no advantage to rolling a custom scheme here that
+offsets the risk.
+
+**Why not Noise_X or Noise_N?** `Noise_N` provides no sender authentication (the
+recipient's key is known, but the sender's identity is never verified): anyone could
+seal a message claiming to be from anyone, since there is no static-static DH binding
+the message to a specific sender key at all. `Noise_X` transmits the sender's static key
+as part of the message (encrypted, but the recipient does not need to already know it),
+which is the right choice when the recipient has no prior way to learn the sender's
+identity. Pathweave's destinations can always look up a claimed sender's key from their
+own registry (populated by gossip), so `Noise_K`'s pre-shared assumption already holds in
+practice, and `Noise_K` is simpler: no key transmission step, no need to additionally
+verify that a transmitted key matches what the registry already has.
+
+**The KCI caveat, stated honestly.** Noise_K's sender authentication is vulnerable to
+key-compromise impersonation: if an attacker obtains the *destination's* private key,
+they can forge a message appearing to come from any sender to that destination, without
+needing that sender's actual private key, because the `ss` (static-static) DH only
+requires one party's private key and the other's public key to compute. This is narrow:
+it requires the destination's key specifically to be compromised, and does not affect
+confidentiality or authentication between other, uncompromised parties. It is the same
+class of property already accepted for Noise_XK in this codebase (ADR 020 documents
+XK's own limitations honestly rather than overselling it); E2E hop encryption inherits
+a comparable, named, and disclosed tradeoff rather than an undisclosed one.
+
+**Why a new route_flag instead of changing what 0x01 means.** Changing `0x01`'s meaning
+would mean every existing routed message becomes implicitly sealed, which is not always
+possible (the sender may not have the destination's key yet) and is a behavior change
+to an already-shipped wire format. A new value costs one byte of design space and
+nothing else.
+
+## Implications
+
+- `session.rs` gains `seal`/`unseal` as free functions, not methods on `Session`.
+- `PathweaveError` gains `KeyUnknown(PeerId)`.
+- `node.rs`'s `dispatch_payload` gains a `route_flag 0x03` branch: decode the envelope,
+  look up `sender_peer_id`'s key in the registry (if absent, drop silently, the same as
+  an unverifiable `0x02` announcement; the sender's key should already be in the
+  registry via gossip if any honest path exists), call `unseal`, deliver to `on_message`
+  if addressed locally, otherwise relay via `spawn_relay_to_neighbors` exactly as `0x01`
+  and `0x02` already do.
+- `PathweaveNode` gains a public sealed-send method. The exact name and whether it
+  replaces or sits alongside `send_routed` is an implementation detail for the tracking
+  issue, not fixed by this ADR.
+- Noise_K's pre-shared key requirement means a destination can only verify a sender's
+  claimed identity if that sender's key is already in the destination's registry. For a
+  sender whose key has not yet propagated via gossip to wherever the destination is,
+  `unseal` fails and the frame is dropped; this is a delivery gap inherent to gossip's
+  own propagation time, not a defect introduced by this ADR.


### PR DESCRIPTION
## What changed

Implements ADR 023. `session.rs` gains `seal`/`unseal` as free functions (not `Session` methods): each builds a fresh `snow::Builder` with `Noise_K_25519_ChaChaPoly_BLAKE2s`, calls `write_message`/`read_message` exactly once, and discards the handshake state immediately, there is no transport phase. `node.rs`'s `dispatch_payload` gains a `route_flag 0x03` branch: `[dest_peer_id:32][ttl:1][sender_peer_id:32][noise_k_message:N]`, reusing ADR 019's TTL clamp and `check_and_insert_routed` dedup exactly as the existing `0x01`/`0x02` branches do. `PathweaveNode::send_routed_sealed` is the new public entry point, and `PathweaveError::KeyUnknown(PeerId)` is the new error returned when the destination's key is not yet in the registry.

## Why

Closes #104. A relay forwarding a `route_flag 0x01` frame decrypts its own hop-to-hop Noise session and sees the plaintext before re-encrypting for the next hop. E2E hop encryption seals the payload to the destination's actual static key so a relay can still route on `dest_peer_id`/`ttl` but never reads the content.

## Alternatives considered

Considered extending `Session` with seal/unseal methods, since that's where the existing Noise handshakes live. Rejected: `Session` models a multi-message bidirectional connection (`initiate`/`respond` then repeated `send`/`recv`); Noise_K is exactly one message, never followed by anything else over that handshake state. Forcing it through `Session`'s shape would add states to an abstraction built for a different lifecycle.

Considered redefining what `0x01` means instead of adding a new route_flag. Rejected: every existing routed message would become implicitly sealed, which isn't always possible (the sender may not have the destination's key yet) and is a behavior change to an already-shipped wire format.

Considered reporting the immediate transport-level `sender_peer_id` to `on_message` at the destination, matching what `0x01` already does. Went the other way: the envelope carries the original sealer's `PeerId`, and Noise_K's `ss` DH already cryptographically authenticates it, so reporting it instead of the last relay hop is strictly more accurate and costs nothing extra. Covered by `sealed_routed_message_relay_cannot_read_payload`, which asserts the destination sees the originator, not the relay.

Considered falling back to an unsealed `0x01` send when the destination's key is unknown. Rejected per ADR 023: a caller who believes a message was E2E-protected when it silently wasn't is a worse failure mode than an explicit error. `send_routed_sealed` returns `KeyUnknown` and never downgrades.

## Security considerations

Noise_K's `ss` (static-static) DH authenticates the sender: a forged sender claim fails the AEAD tag check inside `unseal`'s `read_message`, not a policy check (verified directly via `unseal_with_wrong_sender_key_fails`). The known caveat, stated in ADR 023, is key-compromise impersonation: if the destination's private key is stolen, an attacker can forge a message appearing to come from any sender to that destination, since `ss` only requires one party's private key and the other's public key. This is narrow (it requires that specific compromise) and is the same class of disclosed tradeoff already accepted for Noise_XK in this codebase.

Noise_K has no built-in replay protection (no `ee` component). Replay is bounded by the existing `message_id` dedup, which has the same 60-second TTL already used everywhere else (ADR 011, SECURITY.md's Replay suppression section): a `0x03` frame replayed within that window is dropped before reaching `unseal` (verified via `replayed_sealed_message_is_dropped_at_dedup`); a frame replayed after the window expires is not caught, the same time-bounded property `0x01`/`0x02` already have, not a new gap.

## Test plan

- `cargo test -p pathweave-core --lib`: 78 passed, including 3 new tests for this feature: `sealed_routed_message_relay_cannot_read_payload` (relay never calls `on_message`, destination decrypts and reports the cryptographically authenticated sender), `send_routed_sealed_returns_key_unknown_without_destination_key`, `replayed_sealed_message_is_dropped_at_dedup`. Also added `seal_unseal_roundtrips`, `unseal_with_wrong_sender_key_fails`, `unseal_with_wrong_dest_identity_fails` in `session.rs`.
- `cargo test --workspace`: full suite green, no regressions in other crates.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets`: clean (`#![deny(clippy::all)]` in `pathweave-core`).