### PR TITLE
fix(core): replace production unwrap() with expect("invariant")

### DIFF
--- a/crates/pathweave-core/src/bundle.rs
+++ b/crates/pathweave-core/src/bundle.rs
@@ -205,7 +205,10 @@ impl Connection for BundleLayer {
             pending.fragments.insert(offset, chunk);
 
             if pending.is_complete() {
-                let complete = self.pending.remove(&seq).unwrap();
+                let complete = self
+                    .pending
+                    .remove(&seq)
+                    .expect("entry was inserted above and is_complete() confirmed it");
                 return Ok(Bytes::from(complete.reassemble()));
             }
         }

--- a/crates/pathweave-core/src/node.rs
+++ b/crates/pathweave-core/src/node.rs
@@ -248,10 +248,10 @@ impl PathweaveNode {
             .await?;
         self.known_addrs
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .insert(announcement.address.clone());
         {
-            let mut peers = self.peers.lock().unwrap();
+            let mut peers = self.peers.lock().expect("mutex not poisoned");
             let addrs = peers.entry(peer_id.clone()).or_default();
             if !addrs.iter().any(|a| a.address == announcement.address) {
                 addrs.push(announcement);
@@ -291,10 +291,10 @@ impl PathweaveNode {
     pub fn add_peer(&mut self, peer_id: PeerId, announcement: PeerAnnouncement) {
         self.known_addrs
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .insert(announcement.address.clone());
         {
-            let mut peers = self.peers.lock().unwrap();
+            let mut peers = self.peers.lock().expect("mutex not poisoned");
             let addrs = peers.entry(peer_id.clone()).or_default();
             if !addrs.iter().any(|a| a.address == announcement.address) {
                 addrs.push(announcement);
@@ -346,7 +346,7 @@ impl PathweaveNode {
         let announcements = self
             .peers
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .get(&peer_id)
             .cloned()
             .ok_or(PathweaveError::NoTransportAvailable)?;
@@ -385,7 +385,7 @@ impl PathweaveNode {
         let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = self
             .peers
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .iter()
             .filter(|(pid, _)| **pid != *self.identity.peer_id())
             .map(|(pid, anns)| (pid.clone(), anns.clone()))
@@ -433,7 +433,7 @@ impl PathweaveNode {
         let dest_public_key = self
             .key_registry
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .get(&dest_peer_id)
             .ok_or_else(|| PathweaveError::KeyUnknown(dest_peer_id.clone()))?;
 
@@ -452,7 +452,7 @@ impl PathweaveNode {
         let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = self
             .peers
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .iter()
             .filter(|(pid, _)| **pid != *self.identity.peer_id())
             .map(|(pid, anns)| (pid.clone(), anns.clone()))
@@ -502,7 +502,12 @@ impl PathweaveNode {
         let msg_id = router::new_message_id();
         let queued_at = Instant::now();
 
-        let announcements = self.peers.lock().unwrap().get(&peer_id).cloned();
+        let announcements = self
+            .peers
+            .lock()
+            .expect("mutex not poisoned")
+            .get(&peer_id)
+            .cloned();
         if let Some(anns) = announcements {
             if !anns.is_empty() {
                 let mut framed = Vec::with_capacity(1 + payload.len());
@@ -527,7 +532,7 @@ impl PathweaveNode {
             }
         }
 
-        let mut queue = self.pending_direct.lock().unwrap();
+        let mut queue = self.pending_direct.lock().expect("mutex not poisoned");
         let deque = queue.entry(peer_id.clone()).or_default();
         if let Some(max) = self.max_queue_depth {
             if deque.len() >= max {
@@ -555,7 +560,7 @@ impl PathweaveNode {
         let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = self
             .peers
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .iter()
             .filter(|(pid, _)| **pid != *self.identity.peer_id())
             .map(|(pid, anns)| (pid.clone(), anns.clone()))
@@ -592,7 +597,7 @@ impl PathweaveNode {
             }
         }
 
-        let mut queue = self.pending_routed.lock().unwrap();
+        let mut queue = self.pending_routed.lock().expect("mutex not poisoned");
         let deque = queue.entry(dest_peer_id.clone()).or_default();
         if let Some(max) = self.max_queue_depth {
             if deque.len() >= max {
@@ -611,7 +616,7 @@ impl PathweaveNode {
     /// that do not support incoming connections (e.g. BLE central mode) return an
     /// error from accept(), which the loop handles with a backoff.
     pub fn on_message(&self, handler: Box<dyn MessageHandler>) {
-        *self.handler.lock().unwrap() = Some(handler);
+        *self.handler.lock().expect("mutex not poisoned") = Some(handler);
     }
 
     /// Returns a stream of transport lifecycle events from the Router.
@@ -624,7 +629,10 @@ impl PathweaveNode {
     /// Populated after every successful handshake. Used by the Noise_XK upgrade path
     /// and future E2E hop encryption. See ADR 020.
     pub fn lookup_key(&self, peer_id: &PeerId) -> Option<[u8; 32]> {
-        self.key_registry.lock().unwrap().get(peer_id)
+        self.key_registry
+            .lock()
+            .expect("mutex not poisoned")
+            .get(peer_id)
     }
 }
 
@@ -645,7 +653,7 @@ async fn drain_direct_for_peer(
     event_tx: &broadcast::Sender<TransportEvent>,
 ) {
     let entries: Vec<(u64, Vec<u8>, Instant)> = {
-        let mut store = pending_direct.lock().unwrap();
+        let mut store = pending_direct.lock().expect("mutex not poisoned");
         match store.remove(peer_id) {
             Some(q) => q.into_iter().collect(),
             None => return,
@@ -655,7 +663,7 @@ async fn drain_direct_for_peer(
     let now = Instant::now();
     let announcements = peers
         .lock()
-        .unwrap()
+        .expect("mutex not poisoned")
         .get(peer_id)
         .cloned()
         .unwrap_or_default();
@@ -693,7 +701,7 @@ async fn drain_direct_for_peer(
     }
 
     if !failures.is_empty() {
-        let mut store = pending_direct.lock().unwrap();
+        let mut store = pending_direct.lock().expect("mutex not poisoned");
         let queue = store.entry(peer_id.clone()).or_default();
         for entry in failures.into_iter().rev() {
             queue.push_front(entry);
@@ -716,11 +724,16 @@ async fn drain_routed_all(
     store_ttl: Duration,
     event_tx: &broadcast::Sender<TransportEvent>,
 ) {
-    let dest_ids: Vec<PeerId> = pending_routed.lock().unwrap().keys().cloned().collect();
+    let dest_ids: Vec<PeerId> = pending_routed
+        .lock()
+        .expect("mutex not poisoned")
+        .keys()
+        .cloned()
+        .collect();
 
     for dest_peer_id in dest_ids {
         let entries: Vec<(u64, Vec<u8>, Instant)> = {
-            let mut store = pending_routed.lock().unwrap();
+            let mut store = pending_routed.lock().expect("mutex not poisoned");
             match store.remove(&dest_peer_id) {
                 Some(q) => q.into_iter().collect(),
                 None => continue,
@@ -730,7 +743,7 @@ async fn drain_routed_all(
         let now = Instant::now();
         let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .iter()
             .filter(|(pid, _)| **pid != *identity.peer_id())
             .map(|(pid, anns)| (pid.clone(), anns.clone()))
@@ -778,7 +791,7 @@ async fn drain_routed_all(
         }
 
         if !failures.is_empty() {
-            let mut store = pending_routed.lock().unwrap();
+            let mut store = pending_routed.lock().expect("mutex not poisoned");
             let queue = store.entry(dest_peer_id.clone()).or_default();
             for entry in failures.into_iter().rev() {
                 queue.push_front(entry);
@@ -861,7 +874,7 @@ async fn handle_incoming(
     let sender_peer_id = session.peer_id().clone();
     let is_new_key = key_registry
         .lock()
-        .unwrap()
+        .expect("mutex not poisoned")
         .insert_direct(sender_peer_id.clone(), *session.remote_static_key());
     if is_new_key {
         let _ = router.event_tx().send(TransportEvent::KeyLearned {
@@ -941,7 +954,7 @@ fn spawn_relay_to_neighbors(
 ) {
     let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
         .lock()
-        .unwrap()
+        .expect("mutex not poisoned")
         .iter()
         .filter(|(pid, _)| **pid != *sender_peer_id && **pid != *local_peer_id)
         .map(|(pid, anns)| (pid.clone(), anns.clone()))
@@ -998,10 +1011,10 @@ async fn dispatch_payload(
             let data = payload[9..].to_vec();
             let is_dup = dedup
                 .lock()
-                .unwrap()
+                .expect("mutex not poisoned")
                 .check_and_insert(sender_peer_id, msg_id);
             if !is_dup {
-                if let Some(h) = handler.lock().unwrap().as_ref() {
+                if let Some(h) = handler.lock().expect("mutex not poisoned").as_ref() {
                     h.on_message(sender_peer_id.clone(), data);
                 }
             } else {
@@ -1014,15 +1027,20 @@ async fn dispatch_payload(
                 let _ = session.send(b"").await;
                 return;
             }
-            let dest_bytes: [u8; 32] = payload[9..41].try_into().unwrap();
+            let dest_bytes: [u8; 32] = payload[9..41]
+                .try_into()
+                .expect("length checked above: payload[9..41] is exactly 32 bytes");
             let dest = PeerId::from_bytes(dest_bytes);
             let ttl = payload[41].min(MAX_TTL);
             let app_payload = payload[42..].to_vec();
 
             if &dest == local_peer_id {
-                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                let is_dup = dedup
+                    .lock()
+                    .expect("mutex not poisoned")
+                    .check_and_insert_routed(msg_id);
                 if !is_dup {
-                    if let Some(h) = handler.lock().unwrap().as_ref() {
+                    if let Some(h) = handler.lock().expect("mutex not poisoned").as_ref() {
                         h.on_message(sender_peer_id.clone(), app_payload);
                     }
                 } else {
@@ -1031,7 +1049,10 @@ async fn dispatch_payload(
             } else if ttl == 0 {
                 tracing::debug!(msg_id, "TTL=0: silently dropping routed message");
             } else {
-                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                let is_dup = dedup
+                    .lock()
+                    .expect("mutex not poisoned")
+                    .check_and_insert_routed(msg_id);
                 if !is_dup {
                     let new_ttl = ttl - 1;
                     let mut relay_body = Vec::with_capacity(1 + 32 + 1 + app_payload.len());
@@ -1063,13 +1084,16 @@ async fn dispatch_payload(
                         "key announcement failed hash validation; dropping"
                     );
                 } else {
-                    let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                    let is_dup = dedup
+                        .lock()
+                        .expect("mutex not poisoned")
+                        .check_and_insert_routed(msg_id);
                     if is_dup {
                         tracing::debug!(msg_id, "suppressed duplicate key announcement");
                     } else {
                         key_registry
                             .lock()
-                            .unwrap()
+                            .expect("mutex not poisoned")
                             .insert_gossip(announced_peer_id.clone(), public_key);
 
                         let ttl = ttl.min(MAX_TTL);
@@ -1106,23 +1130,33 @@ async fn dispatch_payload(
                 let _ = session.send(b"").await;
                 return;
             }
-            let dest_bytes: [u8; 32] = payload[9..41].try_into().unwrap();
+            let dest_bytes: [u8; 32] = payload[9..41]
+                .try_into()
+                .expect("length checked above: payload[9..41] is exactly 32 bytes");
             let dest = PeerId::from_bytes(dest_bytes);
             let ttl = payload[41].min(MAX_TTL);
             let envelope = &payload[42..];
-            let sealed_sender_bytes: [u8; 32] = envelope[..32].try_into().unwrap();
+            let sealed_sender_bytes: [u8; 32] = envelope[..32]
+                .try_into()
+                .expect("length checked above: envelope[..32] is exactly 32 bytes");
             let sealed_sender = PeerId::from_bytes(sealed_sender_bytes);
             let noise_k_message = &envelope[32..];
 
             if &dest == local_peer_id {
-                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                let is_dup = dedup
+                    .lock()
+                    .expect("mutex not poisoned")
+                    .check_and_insert_routed(msg_id);
                 if is_dup {
                     tracing::debug!(
                         msg_id,
                         "suppressed duplicate sealed routed message at destination"
                     );
                 } else {
-                    let sender_key = key_registry.lock().unwrap().get(&sealed_sender);
+                    let sender_key = key_registry
+                        .lock()
+                        .expect("mutex not poisoned")
+                        .get(&sealed_sender);
                     match sender_key {
                         Some(sender_key) => match crate::session::unseal(
                             identity,
@@ -1131,7 +1165,9 @@ async fn dispatch_payload(
                             noise_k_message,
                         ) {
                             Ok(plaintext) => {
-                                if let Some(h) = handler.lock().unwrap().as_ref() {
+                                if let Some(h) =
+                                    handler.lock().expect("mutex not poisoned").as_ref()
+                                {
                                     h.on_message(sealed_sender, plaintext);
                                 }
                             }
@@ -1147,7 +1183,10 @@ async fn dispatch_payload(
             } else if ttl == 0 {
                 tracing::debug!(msg_id, "TTL=0: silently dropping sealed routed message");
             } else {
-                let is_dup = dedup.lock().unwrap().check_and_insert_routed(msg_id);
+                let is_dup = dedup
+                    .lock()
+                    .expect("mutex not poisoned")
+                    .check_and_insert_routed(msg_id);
                 if !is_dup {
                     let new_ttl = ttl - 1;
                     let mut relay_body = Vec::with_capacity(1 + 32 + 1 + envelope.len());

--- a/crates/pathweave-core/src/router.rs
+++ b/crates/pathweave-core/src/router.rs
@@ -73,11 +73,14 @@ impl Router {
             Arc::clone(&self.transports),
         ));
 
-        self.transports.lock().unwrap().push(TransportEntry {
-            transport,
-            available,
-            task,
-        });
+        self.transports
+            .lock()
+            .expect("mutex not poisoned")
+            .push(TransportEntry {
+                transport,
+                available,
+                task,
+            });
 
         started_rx
     }
@@ -109,7 +112,7 @@ impl Router {
         let any_available = self
             .transports
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .iter()
             .any(|t| t.available.load(Ordering::Acquire));
         if !any_available {
@@ -120,7 +123,7 @@ impl Router {
 
         for attempt in 0..MAX_SEND_ATTEMPTS {
             let mut candidates: Vec<(Arc<dyn Transport>, PeerAnnouncement)> = {
-                let guard = self.transports.lock().unwrap();
+                let guard = self.transports.lock().expect("mutex not poisoned");
                 guard
                     .iter()
                     .filter(|t| t.available.load(Ordering::Acquire))
@@ -210,7 +213,7 @@ impl Router {
         peer_table: &PeerTable,
     ) -> Result<PeerId> {
         let mut candidates: Vec<(Arc<dyn Transport>, PeerAnnouncement)> = {
-            let guard = self.transports.lock().unwrap();
+            let guard = self.transports.lock().expect("mutex not poisoned");
             guard
                 .iter()
                 .filter(|t| t.available.load(Ordering::Acquire))
@@ -258,7 +261,7 @@ impl Router {
     pub fn local_addresses(&self) -> Vec<PeerAddress> {
         self.transports
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .iter()
             .flat_map(|e| e.transport.local_addresses())
             .collect()
@@ -287,7 +290,7 @@ impl Default for Router {
 
 impl Drop for Router {
     fn drop(&mut self) {
-        for entry in self.transports.lock().unwrap().iter() {
+        for entry in self.transports.lock().expect("mutex not poisoned").iter() {
             entry.task.abort();
         }
     }
@@ -392,7 +395,7 @@ fn next_best_transport(
 ) -> Option<TransportKind> {
     transports
         .lock()
-        .unwrap()
+        .expect("mutex not poisoned")
         .iter()
         .filter(|e| {
             !Arc::ptr_eq(&e.available, own_available) && e.available.load(Ordering::Acquire)
@@ -436,7 +439,7 @@ async fn try_connect(
     let peer_id = session.peer_id().clone();
     let is_new_key = key_registry
         .lock()
-        .unwrap()
+        .expect("mutex not poisoned")
         .insert_direct(peer_id.clone(), *session.remote_static_key());
     let learned_key = is_new_key.then(|| *session.remote_static_key());
     let local = transport.local_addresses();
@@ -615,7 +618,7 @@ pub(crate) fn decode_addr_exchange(bytes: &[u8]) -> Option<Vec<PeerAddress>> {
 
 /// Upserts `addrs` into the peer table entry for `peer_id`, deduplicating by address.
 pub(crate) fn upsert_peer_addresses(peers: &PeerTable, peer_id: &PeerId, addrs: Vec<PeerAddress>) {
-    let mut guard = peers.lock().unwrap();
+    let mut guard = peers.lock().expect("mutex not poisoned");
     let entry = guard.entry(peer_id.clone()).or_default();
     for addr in addrs {
         let ann = PeerAnnouncement {
@@ -681,7 +684,7 @@ pub(crate) async fn flood_key_announcement(
 
     let neighbors: Vec<(PeerId, Vec<PeerAnnouncement>)> = peers
         .lock()
-        .unwrap()
+        .expect("mutex not poisoned")
         .iter()
         .filter(|(pid, _)| *pid != learned_peer_id && *pid != local_peer_id)
         .map(|(pid, anns)| (pid.clone(), anns.clone()))
@@ -731,7 +734,10 @@ async fn try_send(
     peer_id: &PeerId,
     peers: &PeerTable,
 ) -> Result<Option<[u8; 32]>> {
-    let remote_key = key_registry.lock().unwrap().get(peer_id);
+    let remote_key = key_registry
+        .lock()
+        .expect("mutex not poisoned")
+        .get(peer_id);
     let raw = transport.connect(peer).await.map_err(|e| {
         tracing::debug!(addr = ?peer.address, error = %e, "try_send: connect failed");
         e
@@ -742,7 +748,10 @@ async fn try_send(
         Err(e) => {
             if remote_key.is_some() {
                 // XK failed; evict the stale key so the next retry uses XX.
-                key_registry.lock().unwrap().remove(peer_id);
+                key_registry
+                    .lock()
+                    .expect("mutex not poisoned")
+                    .remove(peer_id);
             }
             tracing::debug!(addr = ?peer.address, error = %e, "try_send: handshake failed");
             return Err(e);
@@ -750,7 +759,7 @@ async fn try_send(
     };
     let is_new_key = key_registry
         .lock()
-        .unwrap()
+        .expect("mutex not poisoned")
         .insert_direct(session.peer_id().clone(), *session.remote_static_key());
     let learned_key = is_new_key.then(|| *session.remote_static_key());
 
@@ -827,7 +836,11 @@ pub(crate) async fn peer_stream(
                     let addr = announcement.address.clone();
 
                     // Skip re-announcements from already-connected addresses (O(1) check).
-                    if !known_addrs.lock().unwrap().insert(addr.clone()) {
+                    if !known_addrs
+                        .lock()
+                        .expect("mutex not poisoned")
+                        .insert(addr.clone())
+                    {
                         continue;
                     }
 
@@ -848,7 +861,7 @@ pub(crate) async fn peer_stream(
                             tracing::debug!(addr = %addr, peer = %peer_id, "peer connected");
                             peers
                                 .lock()
-                                .unwrap()
+                                .expect("mutex not poisoned")
                                 .entry(peer_id.clone())
                                 .or_default()
                                 .push(announcement);
@@ -863,20 +876,31 @@ pub(crate) async fn peer_stream(
                         Err(e) => {
                             tracing::debug!(addr = %addr, "handshake failed: {}", e);
                             // Remove so we retry on the next re-announcement.
-                            known_addrs.lock().unwrap().remove(&addr);
+                            known_addrs
+                                .lock()
+                                .expect("mutex not poisoned")
+                                .remove(&addr);
                         }
                     }
                 }
                 PeerEvent::Departure(addr) => {
-                    let peer_id = peers.lock().unwrap().iter().find_map(|(pid, anns)| {
-                        if anns.iter().any(|a| a.address == addr) {
-                            Some(pid.clone())
-                        } else {
-                            None
-                        }
-                    });
+                    let peer_id =
+                        peers
+                            .lock()
+                            .expect("mutex not poisoned")
+                            .iter()
+                            .find_map(|(pid, anns)| {
+                                if anns.iter().any(|a| a.address == addr) {
+                                    Some(pid.clone())
+                                } else {
+                                    None
+                                }
+                            });
                     if let Some(peer_id) = peer_id {
-                        known_addrs.lock().unwrap().remove(&addr);
+                        known_addrs
+                            .lock()
+                            .expect("mutex not poisoned")
+                            .remove(&addr);
                         tracing::debug!(addr = %addr, peer = %peer_id, "peer departed");
                         let _ = event_tx.send(TransportEvent::PeerDisconnected(peer_id));
                     }

--- a/crates/pathweave-transport-ble/src/advertising.rs
+++ b/crates/pathweave-transport-ble/src/advertising.rs
@@ -201,13 +201,20 @@ async fn dispatch_loop(
             continue;
         }
 
-        let existing_tx = connections.lock().unwrap().get(&source).cloned();
+        let existing_tx = connections
+            .lock()
+            .expect("mutex not poisoned")
+            .get(&source)
+            .cloned();
         if let Some(tx) = existing_tx {
             let _ = tx.send(Bytes::copy_from_slice(payload));
         } else {
             let (tx, rx) = mpsc::unbounded_channel();
             let _ = tx.send(Bytes::copy_from_slice(payload));
-            connections.lock().unwrap().insert(source, tx);
+            connections
+                .lock()
+                .expect("mutex not poisoned")
+                .insert(source, tx);
             let conn: Box<dyn Connection> = Box::new(BroadcastConnection {
                 bearer: Arc::clone(&bearer),
                 local_short_id,
@@ -276,7 +283,7 @@ impl Transport for BleAdvertisingTransport {
         let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8]
             .try_into()
             .expect("PeerId is always 32 bytes");
-        *self.local_short_id.lock().unwrap() = Some(short_id);
+        *self.local_short_id.lock().expect("mutex not poisoned") = Some(short_id);
 
         let bearer = Arc::clone(&self.bearer);
         let connections = Arc::clone(&self.connections);
@@ -298,8 +305,8 @@ impl Transport for BleAdvertisingTransport {
         if let Some(handle) = self.dispatcher_handle.lock().await.take() {
             handle.abort();
         }
-        *self.local_short_id.lock().unwrap() = None;
-        self.connections.lock().unwrap().clear();
+        *self.local_short_id.lock().expect("mutex not poisoned") = None;
+        self.connections.lock().expect("mutex not poisoned").clear();
         Ok(())
     }
 
@@ -331,11 +338,14 @@ impl Transport for BleAdvertisingTransport {
         let local_short_id = self
             .local_short_id
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .ok_or_else(|| PathweaveError::Transport("transport not started".into()))?;
 
         let (tx, rx) = mpsc::unbounded_channel();
-        self.connections.lock().unwrap().insert(peer_short_id, tx);
+        self.connections
+            .lock()
+            .expect("mutex not poisoned")
+            .insert(peer_short_id, tx);
 
         Ok(Box::new(BroadcastConnection {
             bearer: Arc::clone(&self.bearer),
@@ -371,7 +381,7 @@ impl Transport for BleAdvertisingTransport {
     }
 
     fn local_addresses(&self) -> Vec<PeerAddress> {
-        match *self.local_short_id.lock().unwrap() {
+        match *self.local_short_id.lock().expect("mutex not poisoned") {
             Some(id) => vec![PeerAddress::BleAdvertising(short_id_to_hex(id))],
             None => vec![],
         }

--- a/crates/pathweave-transport-ble/src/lib.rs
+++ b/crates/pathweave-transport-ble/src/lib.rs
@@ -621,7 +621,9 @@ impl Transport for BleTransport {
                             if data.len() < 9 || data[0] != ADVERTISEMENT_VERSION {
                                 continue;
                             }
-                            let short_id: [u8; 8] = data[1..9].try_into().unwrap();
+                            let short_id: [u8; 8] = data[1..9]
+                                .try_into()
+                                .expect("length checked above: data[1..9] is exactly 8 bytes");
                             let announcement = PeerAnnouncement {
                                 address: PeerAddress::Ble(id.to_string()),
                                 short_id: Some(short_id),
@@ -647,7 +649,9 @@ impl Transport for BleTransport {
                         if data.len() < 9 || data[0] != ADVERTISEMENT_VERSION {
                             continue;
                         }
-                        let short_id: [u8; 8] = data[1..9].try_into().unwrap();
+                        let short_id: [u8; 8] = data[1..9]
+                            .try_into()
+                            .expect("length checked above: data[1..9] is exactly 8 bytes");
                         let announcement = PeerAnnouncement {
                             address: PeerAddress::Ble(id.to_string()),
                             short_id: Some(short_id),
@@ -833,7 +837,9 @@ impl BleTransport {
         };
         use std::collections::BTreeMap;
 
-        let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8].try_into().unwrap();
+        let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8]
+            .try_into()
+            .expect("PeerId is always 32 bytes");
 
         let session = bluer::Session::new()
             .await
@@ -933,7 +939,9 @@ impl BleTransport {
         use windows::Foundation::TypedEventHandler;
         use windows::Storage::Streams::DataReader;
 
-        let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8].try_into().unwrap();
+        let short_id: [u8; 8] = identity.peer_id().as_bytes()[..8]
+            .try_into()
+            .expect("PeerId is always 32 bytes");
 
         let write_forward: Arc<
             std::sync::Mutex<Option<tokio::sync::mpsc::UnboundedSender<Bytes>>>,

--- a/crates/pathweave-transport-quic/src/lib.rs
+++ b/crates/pathweave-transport-quic/src/lib.rs
@@ -307,7 +307,7 @@ impl Transport for QuicTransport {
             Endpoint::server(server_config, self.listen_addr).map_err(PathweaveError::Io)?;
         let local_addr = endpoint.local_addr().map_err(PathweaveError::Io)?;
         *self.endpoint.lock().await = Some(endpoint);
-        *self.started_addr.lock().unwrap() = Some(local_addr);
+        *self.started_addr.lock().expect("mutex not poisoned") = Some(local_addr);
 
         let daemon = ServiceDaemon::new().map_err(|e| PathweaveError::Transport(e.to_string()))?;
 
@@ -377,7 +377,7 @@ impl Transport for QuicTransport {
             }
         });
 
-        *self.mdns.lock().unwrap() = Some(MdnsState {
+        *self.mdns.lock().expect("mutex not poisoned") = Some(MdnsState {
             daemon,
             service_fullname,
             announce_rx: Some(announce_rx),
@@ -400,11 +400,11 @@ impl Transport for QuicTransport {
     }
 
     async fn stop(&self) -> Result<()> {
-        *self.started_addr.lock().unwrap() = None;
+        *self.started_addr.lock().expect("mutex not poisoned") = None;
         if let Some(ep) = self.endpoint.lock().await.take() {
             ep.close(0u32.into(), b"shutdown");
         }
-        if let Some(state) = self.mdns.lock().unwrap().take() {
+        if let Some(state) = self.mdns.lock().expect("mutex not poisoned").take() {
             let _ = state.daemon.unregister(&state.service_fullname);
             let _ = state.daemon.stop_browse(SERVICE_TYPE);
             state.bridge.abort();
@@ -417,7 +417,7 @@ impl Transport for QuicTransport {
         let rx = self
             .mdns
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .as_mut()
             .and_then(|state| state.announce_rx.take());
 
@@ -436,8 +436,12 @@ impl Transport for QuicTransport {
         };
 
         let client_config = make_client_config()?;
-        let mut endpoint =
-            Endpoint::client("0.0.0.0:0".parse().unwrap()).map_err(PathweaveError::Io)?;
+        let mut endpoint = Endpoint::client(
+            "0.0.0.0:0"
+                .parse()
+                .expect("hardcoded address is always valid"),
+        )
+        .map_err(PathweaveError::Io)?;
         endpoint.set_default_client_config(client_config);
 
         let connection = endpoint
@@ -503,7 +507,7 @@ impl Transport for QuicTransport {
     fn local_addresses(&self) -> Vec<PeerAddress> {
         self.started_addr
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .map(|addr| vec![PeerAddress::Quic(addr)])
             .unwrap_or_default()
     }
@@ -512,7 +516,7 @@ impl Transport for QuicTransport {
         let rx = self
             .mdns
             .lock()
-            .unwrap()
+            .expect("mutex not poisoned")
             .as_mut()
             .and_then(|state| state.departure_rx.take());
 


### PR DESCRIPTION
## What changed

Replaces every `.unwrap()` in non-test production code across `pathweave-core`, `pathweave-transport-quic`, and `pathweave-transport-ble` with `.expect("specific invariant")`. Three shapes: mutex poison guards (`node.rs`, `router.rs`, `transport-quic/src/lib.rs`, `transport-ble/src/advertising.rs`), fixed-size slice conversions where the length was already checked a few lines above (BLE `short_id` parsing, the `route_flag` 0x01/0x03 `dest_peer_id`/`sealed_sender_bytes` reads in `dispatch_payload`), and two one-offs: a hardcoded address literal that always parses, and a bundle reassembly removal where `is_complete()` just confirmed the entry exists. Test code and `pw-chat` are unchanged.

## Why

Closes #76. A bare `.unwrap()` panics with a message that carries no context. When Pathweave panics inside a downstream application, that message is the first thing a developer sees; "PeerId is always 32 bytes" orients them, "called `unwrap()` on a `None` value" does not.

The issue's original file list undercounted current scope: it was filed 2026-06-12, and the BLE advertising bearer (#98), key gossip (#100), key registry bound (#101), and E2E hop encryption (#104) all merged after that and added their own production `.unwrap()` calls (`advertising.rs` didn't exist yet; the `route_flag 0x03` slice conversions in `node.rs` didn't exist yet). Re-verified the actual file/line list against current `main` before implementing and updated #76's body to match before starting.

## Alternatives considered

Considered also switching poisoned-mutex handling from panic to recovery (`lock().unwrap_or_else(|e| e.into_inner())`) in the same change, since `.expect()` only improves the panic message without changing whether the panic happens. Rejected for this PR specifically: #76 explicitly scopes out "changing error handling strategy beyond the mechanical unwrap-to-expect substitution," and recovering from poison is a real behavior change that deserves its own deliberate issue rather than riding in silently alongside a message-only cleanup. Filing that as a separate follow-up (see Security considerations).

## Security considerations

This PR does not change failure behavior, only panic messages, so it introduces no new risk. But tracing through the mutex guards surfaced a real one worth naming rather than burying: in `dispatch_payload`, `handler.lock().expect(...).as_ref()` followed by `h.on_message(...)` holds the `MutexGuard` for the duration of the call (Rust's temporary-lifetime-extension rule for `if let` keeps it alive across the block), meaning the lock is held while the application's own callback runs. If that callback ever panics, the `handler` mutex poisons, and every subsequent `.lock()` on it panics too, permanently, for the life of the node, since a single mishandled message from one peer can wedge message delivery for every peer thereafter. Filing a follow-up issue to track recovering or isolating this (`catch_unwind` around the callback, or poison recovery on the locks that don't hold semantically-corruptible state) as its own deliberate fix.

## Test plan

- `cargo build --workspace`: clean.
- `cargo test --workspace`: 78 + 8 + 3 passed (pathweave-core, pathweave-transport-ble, pathweave-transport-quic), no regressions.
- `cargo fmt --all -- --check`: clean.
- `cargo clippy --workspace --all-targets`: clean.
- Verified by direct grep against the test-module boundary in every touched file that no production `.unwrap()` remains in the three named crates, and that no edit landed inside a `#[cfg(test)]` region.